### PR TITLE
feat: Add deprecation warnings to the allocation group resource schem…

### DIFF
--- a/internal/provider/allocation_group_resource.go
+++ b/internal/provider/allocation_group_resource.go
@@ -6,6 +6,7 @@ import (
 
 	"terraform-provider-doit/internal/provider/resource_allocation_group"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -50,6 +51,9 @@ func (r *allocationGroupResource) Schema(ctx context.Context, _ resource.SchemaR
 }
 
 func (r *allocationGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(
+		diag.NewWarningDiagnostic("doit_allocation_group resource is deprecated", "use doit_allocation instead"),
+	)
 	plan := new(allocationGroupResourceModel)
 	diags := req.Plan.Get(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -85,6 +89,9 @@ func (r *allocationGroupResource) Create(ctx context.Context, req resource.Creat
 }
 
 func (r *allocationGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	resp.Diagnostics.Append(
+		diag.NewWarningDiagnostic("doit_allocation_group resource is deprecated", "use doit_allocation instead"),
+	)
 	state := new(allocationGroupResourceModel)
 	diags := req.State.Get(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -108,6 +115,9 @@ func (r *allocationGroupResource) Read(ctx context.Context, req resource.ReadReq
 }
 
 func (r *allocationGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(
+		diag.NewWarningDiagnostic("doit_allocation_group resource is deprecated", "use doit_allocation instead"),
+	)
 	plan := new(allocationGroupResourceModel)
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -150,6 +160,9 @@ func (r *allocationGroupResource) Update(ctx context.Context, req resource.Updat
 }
 
 func (r *allocationGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.Append(
+		diag.NewWarningDiagnostic("doit_allocation_group resource is deprecated", "use doit_allocation instead"),
+	)
 	// Retrieve values from state
 	state := new(allocationGroupResourceModel)
 	diags := req.State.Get(ctx, state)

--- a/internal/provider/resource_allocation_group/allocation_group_resource_gen.go
+++ b/internal/provider/resource_allocation_group/allocation_group_resource_gen.go
@@ -5,6 +5,8 @@ package resource_allocation_group
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -13,13 +15,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 func AllocationGroupResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		DeprecationMessage: `Allocation groups are deprecated.
+All of the features of the allocation group will be moved to the allocation resource in the next major version of the provider.
+The allocation group resource will be removed in the next major version of the provider.`,
 		Attributes: map[string]schema.Attribute{
 			"allocation_type": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
This pull request introduces deprecation warnings for the `doit_allocation_group` resource to guide users toward using the newer `doit_allocation` resource instead. The changes ensure users are informed at both runtime and schema level that the allocation group resource will be removed in the next major version.

Deprecation notices and user guidance:

* Added runtime warnings in all CRUD operations (`Create`, `Read`, `Update`, `Delete`) of the `allocationGroupResource` to notify users that `doit_allocation_group` is deprecated and to use `doit_allocation` instead (`internal/provider/allocation_group_resource.go`). [[1]](diffhunk://#diff-75615113afb6e0f9a5abef89fcd2275cc8083856619f563802e0b358cea345f1R54-R56) [[2]](diffhunk://#diff-75615113afb6e0f9a5abef89fcd2275cc8083856619f563802e0b358cea345f1R92-R94) [[3]](diffhunk://#diff-75615113afb6e0f9a5abef89fcd2275cc8083856619f563802e0b358cea345f1R118-R120) [[4]](diffhunk://#diff-75615113afb6e0f9a5abef89fcd2275cc8083856619f563802e0b358cea345f1R163-R165)
* Set a `DeprecationMessage` in the schema definition for the allocation group resource, making the deprecation visible in Terraform plan and documentation output (`internal/provider/resource_allocation_group/allocation_group_resource_gen.go`).

Dependency and import updates:

* Added necessary imports for diagnostics and string handling to support the new warnings and schema messages (`internal/provider/allocation_group_resource.go`, `internal/provider/resource_allocation_group/allocation_group_resource_gen.go`). [[1]](diffhunk://#diff-75615113afb6e0f9a5abef89fcd2275cc8083856619f563802e0b358cea345f1R9) [[2]](diffhunk://#diff-069235bd71adffe162df4c454dd948b6ca1ee15c37201b3a17d5db6b38a610a4R8-R9)

Closes https://github.com/doitintl/terraform-provider-doit/issues/36