### PR TITLE
chore: add backstage catalog info and readme symlink for mkdocs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,34 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: terraform-provider-doit
+  description: A proof-of-concept infrastructure-as-code plugin that allows users to manage DoiT cloud resources through Terraform.
+spec:
+  owner: group:cre
+  domain: doit
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terraform-provider-doit
+  description: A proof-of-concept infrastructure-as-code plugin that allows users to manage DoiT cloud resources through Terraform.
+  annotations:
+    github.com/project-slug: doitintl/terraform-provider-doit
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - terraform-provider-doit
+    - terraform-plugin
+    - terraform
+    - iac
+  links:
+    - url: https://doitintl.slack.com/archives/C03T35W9361
+      title: Support Slack Channel (#terraform-and-iac)
+      icon: help
+      type: support-slack
+spec:
+  type: plugin
+  owner: group:cre
+  lifecycle: production
+  system: terraform-provider-doit

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: Terraform Provider DoiT
+
+nav:
+  - Home: home.md
+  - Provider Resource: index.md
+  - Allocation Resource: resources/allocation.md
+  - Allocation Group Resource: resources/allocation_group.md
+  - Attribution Resource: resources/attribution.md
+  - Attribution Group Resource: resources/attribution_group.md
+  - Budget Resource: resources/budget.md
+  - Report Resource: resources/report.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary

This PR will add catalog-info and mkdocs config to be registered in backstage as our internal developer platform (IDP)

## Related Issues

<!-- Link to any related Jira ticket or GitHub issue -->
Closes [FUSE-216](https://doitintl.atlassian.net/browse/FUSE-216)

## Type of Change

<!-- Select one or more by marking with an 'x' -->
- [ ] New feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Refactor
- [ ] Test coverage
- [x] Chore

## Steps to Reproduce Bug and Validate Solution
<!-- Remove this section if the work is for a feature or story -->

<!-- Steps to recreate the bug. -->
This should be detailed enough to confirm that the bug no longer occurs

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] CI pipeline passed

## Checklist

- [x] I have verified that my changes DOES NOT break existing functionality
- [ ] I have updated the documentation accordingly.
- [ ] I have linted and produced no new errors/warnings.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Does This Introduce a Breaking Change?
- [ ] Yes
- [x] No


[FUSE-216]: https://doitintl.atlassian.net/browse/FUSE-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ