### PR TITLE
Update doit provider version to 0.26.0 in documentation and examples.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     doit = {
       source  = "doitintl/doit"
-      version = "0.25.0"
+      version = "0.26.0"
     }
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     doit = {
       source  = "doitintl/doit"
-      version = "0.25.0"
+      version = "0.26.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     doit = {
       source  = "doitintl/doit"
-      version = "0.25.0"
+      version = "0.26.0"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the required version of the `doitintl/doit` Terraform provider from `0.25.0` to `0.26.0` across documentation and example configuration files. This ensures consistency and compatibility with the latest provider features.

Version update across files:

* Updated the provider version in `docs/index.md` to `0.26.0`.
* Updated the provider version in `examples/main.tf` to `0.26.0`.
* Updated the provider version in `examples/provider/provider.tf` to `0.26.0`.