### PR TITLE
fix: add explicit status code check in Read operations

### DIFF
--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -3,6 +3,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -198,6 +199,16 @@ func (r *allocationResource) populateState(ctx context.Context, state *allocatio
 				"This may indicate a transient API issue. Please retry the operation. "+
 				"If the problem persists, the resource may need to be imported manually. "+
 				"Allocation ID: "+state.Id.ValueString(),
+		)
+		return
+	}
+
+	// Check for successful response
+	if httpResp.StatusCode() != 200 {
+		diags.AddError(
+			"Error Reading Allocation",
+			fmt.Sprintf("Unexpected status code %d for allocation ID %s: %s",
+				httpResp.StatusCode(), state.Id.ValueString(), string(httpResp.Body)),
 		)
 		return
 	}

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_budget"
@@ -177,6 +178,16 @@ func (r *budgetResource) populateState(ctx context.Context, state *budgetResourc
 	// Handle externally deleted resource - remove from state
 	if budgetResp.StatusCode() == 404 {
 		state.Id = types.StringNull()
+		return
+	}
+
+	// Check for successful response
+	if budgetResp.StatusCode() != 200 {
+		diags.AddError(
+			"Error Reading Budget",
+			fmt.Sprintf("Unexpected status code %d for budget ID %s: %s",
+				budgetResp.StatusCode(), state.Id.ValueString(), string(budgetResp.Body)),
+		)
 		return
 	}
 


### PR DESCRIPTION
Improves error messages for non-200/404 status codes (e.g., 500, 403). Previously, these would result in misleading 'empty response body' errors.

- Add status code check to budget.go populateState
- Add status code check to allocation.go populateState

Note: report.go already had this check in place.