### PR TITLE
fix: improve allocation import test reliability

### DIFF
--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -224,11 +224,7 @@ func (r *allocationResource) populateState(ctx context.Context, state *allocatio
 
 	state.Id = types.StringPointerValue(resp.Id)
 	state.Type = types.StringPointerValue(resp.Type)
-	// This is due to a bug in the API where the description is not returned for group allocations
-	// Will be removed once the API is fixed
-	if resp.Description != nil && *resp.Description != "" {
-		state.Description = types.StringPointerValue(resp.Description)
-	}
+	state.Description = types.StringPointerValue(resp.Description)
 	state.AnomalyDetection = types.BoolPointerValue(resp.AnomalyDetection)
 	state.CreateTime = types.Int64PointerValue(resp.CreateTime)
 	state.UpdateTime = types.Int64PointerValue(resp.UpdateTime)

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -61,6 +61,9 @@ func TestAccAllocation(t *testing.T) {
 				ResourceName:      "doit_allocation.this",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"update_time", // Computed field that changes on each modification
+				},
 			},
 		},
 	})
@@ -97,8 +100,8 @@ func TestAccAllocation_Group(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"description",
-					"rules",
+					"update_time", // Computed field that changes on each modification
+					"rules",       // API doesn't return the 'action' field for rules
 				},
 			},
 		},
@@ -152,8 +155,8 @@ func TestAccAllocation_Group_Select(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"description",
-					"rules",
+					"update_time", // Computed field that changes on each modification
+					"rules",       // API doesn't return the 'action' field for rules
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

This PR fixes a flaky test in `TestAccAllocation` and cleans up an API workaround that is no longer needed.

## Problem

`TestAccAllocation` was occasionally failing during CI with:
```
ImportStateVerify attributes not equivalent:
  map[string]string{
  -  "update_time": "1769434887779",
  +  "update_time": "1769434890076",
  }
```

This is a race condition where `update_time` changes between the Update step and the Import verification step.

## Solution

1. **Add `update_time` to `ImportStateVerifyIgnore`** for all allocation import tests - it's a computed field that changes on each API modification

2. **Remove `description` from `ImportStateVerifyIgnore`** - the API bug that prevented description from being returned for group allocations has been fixed

3. **Remove workaround code** in `allocation.go` that conditionally set description only if non-empty

## Changes

- `internal/provider/allocation_resource_test.go` - Updated ImportStateVerifyIgnore for 3 tests
- `internal/provider/allocation.go` - Removed conditional description workaround

## Testing

All allocation tests pass locally:
- `TestAccAllocation` ✅
- `TestAccAllocation_Group` ✅
- `TestAccAllocation_Group_Select` ✅