### PR TITLE
fix(ci): pre-install Terraform CLI to prevent 502 download flakes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ on:
     # Run daily at 5am UTC
     - cron: '0 5 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   validate-examples:
     name: Validate Examples
@@ -41,6 +44,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
+      - run: go mod download
 
       - name: Run Tests
         env:


### PR DESCRIPTION
## Problem

Tests were intermittently failing with:
```
cannot run Terraform provider tests: failed to find or install Terraform CLI from [...]: Unknown status: 502
```

**Root cause:** The `test` job did not use `hashicorp/setup-terraform`, so `terraform-plugin-testing` auto-downloaded Terraform from `releases.hashicorp.com` **for every individual test case**. A single 502 from HashiCorp's endpoint would fail whichever test happened to be downloading at that moment.

## Fix

- Add `hashicorp/setup-terraform` with `terraform_wrapper: false` to the test job (matches [HashiCorp's official scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/test.yml))
- Add `permissions: contents: read` (principle of least privilege)
- Add `go mod download` step (clearer CI logs)

## Notes

- `terraform_wrapper: false` is required because the wrapper intercepts stdout/stderr, breaking `os/exec` calls from the Go test framework
- v3.1.2 is the latest `setup-terraform` release (same SHA already used in `validate-examples` job)