### PR TITLE
chore: sync upstream rename DimensionsExternalAPIList to DimensionsExternalAPIListResponse

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -1443,7 +1443,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DimensionsExternalAPIList"
+                $ref: "#/components/schemas/DimensionsExternalAPIListResponse"
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -4556,7 +4556,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ExternalAPIGetValue"
-    DimensionsExternalAPIList:
+    DimensionsExternalAPIListResponse:
       type: object
       description: Paged list of available dimensions.
       properties:

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -1621,8 +1621,8 @@ type DimensionsExternalAPIGetResponse struct {
 	Values *[]ExternalAPIGetValue `json:"values,omitempty"`
 }
 
-// DimensionsExternalAPIList Paged list of available dimensions.
-type DimensionsExternalAPIList struct {
+// DimensionsExternalAPIListResponse Paged list of available dimensions.
+type DimensionsExternalAPIListResponse struct {
 	// Dimensions Array of dimensions.
 	Dimensions *[]DimensionExternalAPIListItem `json:"dimensions,omitempty"`
 	PageToken  *string                         `json:"pageToken,omitempty"`
@@ -9811,7 +9811,7 @@ func (r GetDimensionsResp) StatusCode() int {
 type ListDimensionsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *DimensionsExternalAPIList
+	JSON200      *DimensionsExternalAPIListResponse
 	JSON400      *N400
 	JSON401      *N401
 	JSON403      *N403
@@ -13622,7 +13622,7 @@ func ParseListDimensionsResp(rsp *http.Response) (*ListDimensionsResp, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest DimensionsExternalAPIList
+		var dest DimensionsExternalAPIListResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Syncs the upstream rename of `DimensionsExternalAPIList` to `DimensionsExternalAPIListResponse` in the OpenAPI spec and regenerates the Go models.

## Changes

- **OpenAPI spec**: Updated `$ref` from `DimensionsExternalAPIList` to `DimensionsExternalAPIListResponse`
- **models_gen.go**: Regenerated via `make generate` to reflect the new type name

## Impact

No functional changes. The dimensions data source code uses the generated client methods (`ListDimensionsWithResponse`) and accesses response fields via `apiResp.JSON200`, so the type rename is fully transparent — no code references the old type name directly.