### PR TITLE
test: skip support requests pagination test (CMP-38591)

### DIFF
--- a/internal/provider/support_requests_data_source_test.go
+++ b/internal/provider/support_requests_data_source_test.go
@@ -13,6 +13,11 @@ import (
 
 // TestAccSupportRequestsDataSource_MaxResultsOnly tests that setting max_results limits results.
 func TestAccSupportRequestsDataSource_MaxResultsOnly(t *testing.T) {
+	// TODO(CMP-38591): The support requests API ignores maxResults entirely, returning all results
+	// regardless of the value. This is different from other APIs which honor maxResults but ignore
+	// pageToken without it. Remove this skip once the API supports maxResults.
+	t.Skip("Skipped: support requests API ignores maxResults entirely (CMP-38591)")
+
 	ticketCount := getSupportRequestCount(t)
 	if ticketCount < 3 {
 		t.Skipf("Need at least 3 support requests to test pagination, got %d", ticketCount)


### PR DESCRIPTION
## Summary

Skip `TestAccSupportRequestsDataSource_MaxResultsOnly` because the support requests API (`/support/v1/tickets`) ignores `maxResults` entirely, returning all results regardless.

## Context

This is related to [CMP-38591](https://doitintl.atlassian.net/browse/CMP-38591) which tracks pagination inconsistencies across the DCI API. However, the support requests API has a **worse** behavior than the other affected endpoints:

| API | `maxResults` honored? | `pageToken` without `maxResults`? |
|-----|----------------------|----------------------------------|
| Alerts, Annotations, etc. | ✅ Yes | ❌ Ignored |
| **Support Requests** | **❌ No** | **❌ Ignored** |

The test was previously passing because there were fewer than 3 support tickets in the test account (the skip guard at line 17 would trigger). After creating additional tickets to test pagination, the underlying API bug was exposed.

The Jira ticket has been updated with reproduction steps and the corrected status for Support Requests.

[CMP-38591]: https://doitintl.atlassian.net/browse/CMP-38591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ