### PR TITLE
chore: update report field descriptions from upstream API spec

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -3702,7 +3702,7 @@
 																"name": "type",
 																"string": {
 																	"computed_optional_required": "computed",
-																	"description": "Type of the origin.\nThe only supported values at the moment: \"attribution\", \"unallocated\""
+																	"description": "Type of the origin."
 																}
 															}
 														],
@@ -3726,7 +3726,7 @@
 																	"name": "type",
 																	"string": {
 																		"computed_optional_required": "computed",
-																		"description": "Type of the target.\nThe only supported value at the moment: \"attribution\""
+																		"description": "Type of the target.\nIf split type is \"attribution_group\", then target type must be \"attribution\".\nOtherwise split types and target types must be the same."
 																	}
 																},
 																{
@@ -3745,7 +3745,7 @@
 													"name": "type",
 													"string": {
 														"computed_optional_required": "computed",
-														"description": "Type of the split.\nThe only supported value at the moment: \"attribution_group\""
+														"description": "Type of the split."
 													}
 												}
 											]

--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -1790,7 +1790,7 @@
 																"name": "type",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "Type of the origin.\nThe only supported values at the moment: \"attribution\", \"unallocated\"",
+																	"description": "Type of the origin.",
 																	"validators": [
 																		{
 																			"custom": {
@@ -1826,7 +1826,7 @@
 																	"name": "type",
 																	"string": {
 																		"computed_optional_required": "computed_optional",
-																		"description": "Type of the target.\nThe only supported value at the moment: \"attribution\"",
+																		"description": "Type of the target.\nIf split type is \"attribution_group\", then target type must be \"attribution\".\nOtherwise split types and target types must be the same.",
 																		"validators": [
 																			{
 																				"custom": {
@@ -1857,7 +1857,7 @@
 													"name": "type",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "Type of the split.\nThe only supported value at the moment: \"attribution_group\"",
+														"description": "Type of the split.",
 														"validators": [
 															{
 																"custom": {

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -5025,7 +5025,6 @@ components:
           type: string
           description: |-
             Type of the origin.
-            The only supported values at the moment: "attribution", "unallocated"
           example: "attribution"
           enum:
             - datetime
@@ -5111,7 +5110,6 @@ components:
           type: string
           description: |-
             Type of the split.
-            The only supported value at the moment: "attribution_group"
           example: "attribution_group"
           enum:
             - datetime
@@ -5136,7 +5134,8 @@ components:
           type: string
           description: |-
             Type of the target.
-            The only supported value at the moment: "attribution"
+            If split type is "attribution_group", then target type must be "attribution".
+            Otherwise split types and target types must be the same.
           example: "attribution"
           enum:
             - datetime

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -4,7 +4,7 @@ info:
   description: Programmatic access to DoiT Platform
   version: v1
 servers:
-  - url: https://api-dev.doit.com
+  - url: ${API_BASE_URL}
 security:
   - api_key: []
   - customerContext: []
@@ -2468,7 +2468,7 @@ paths:
       description: Returns diagram URLs matching the provided resource IDs.
       operationId: findCloudDiagrams
       servers:
-        - url: https://api-dev.doit.com
+        - url: ${API_BASE_URL}
       requestBody:
         required: true
         content:
@@ -4711,7 +4711,6 @@ components:
           type: string
           description: |-
             Type of the origin.
-            The only supported values at the moment: "attribution", "unallocated"
           example: "attribution"
           enum:
             - datetime
@@ -4797,7 +4796,6 @@ components:
           type: string
           description: |-
             Type of the split.
-            The only supported value at the moment: "attribution_group"
           example: "attribution_group"
           enum:
             - datetime
@@ -4822,7 +4820,8 @@ components:
           type: string
           description: |-
             Type of the target.
-            The only supported value at the moment: "attribution"
+            If split type is "attribution_group", then target type must be "attribution".
+            Otherwise split types and target types must be the same.
           example: "attribution"
           enum:
             - datetime

--- a/docs/data-sources/report.md
+++ b/docs/data-sources/report.md
@@ -225,7 +225,6 @@ Read-Only:
 - `origin` (Attributes) Origin info for cost splitting. (see [below for nested schema](#nestedatt--config--splits--origin))
 - `targets` (Attributes List) Targets for the split. (see [below for nested schema](#nestedatt--config--splits--targets))
 - `type` (String) Type of the split.
-The only supported value at the moment: "attribution_group"
 
 <a id="nestedatt--config--splits--origin"></a>
 ### Nested Schema for `config.splits.origin`
@@ -234,7 +233,6 @@ Read-Only:
 
 - `id` (String) ID of the origin.
 - `type` (String) Type of the origin.
-The only supported values at the moment: "attribution", "unallocated"
 
 
 <a id="nestedatt--config--splits--targets"></a>
@@ -244,7 +242,8 @@ Read-Only:
 
 - `id` (String) ID of the target.
 - `type` (String) Type of the target.
-The only supported value at the moment: "attribution"
+If split type is "attribution_group", then target type must be "attribution".
+Otherwise split types and target types must be the same.
 - `value` (Number) Percent of the target, represented in float format. E.g. 30% is 0.3. Required only if the Split Mode is custom.
 
 

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -405,7 +405,6 @@ Optional:
 - `origin` (Attributes) Origin info for cost splitting. (see [below for nested schema](#nestedatt--config--splits--origin))
 - `targets` (Attributes List) Targets for the split. (see [below for nested schema](#nestedatt--config--splits--targets))
 - `type` (String) Type of the split.
-The only supported value at the moment: "attribution_group"
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`
 
 <a id="nestedatt--config--splits--origin"></a>
@@ -415,7 +414,6 @@ Optional:
 
 - `id` (String) ID of the origin.
 - `type` (String) Type of the origin.
-The only supported values at the moment: "attribution", "unallocated"
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`, `unallocated`
 
 
@@ -426,7 +424,8 @@ Optional:
 
 - `id` (String) ID of the target.
 - `type` (String) Type of the target.
-The only supported value at the moment: "attribution"
+If split type is "attribution_group", then target type must be "attribution".
+Otherwise split types and target types must be the same.
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`
 - `value` (Number) Percent of the target, represented in float format. E.g. 30% is 0.3. Required only if the Split Mode is custom.
 

--- a/internal/provider/datasource_report/report_data_source_gen.go
+++ b/internal/provider/datasource_report/report_data_source_gen.go
@@ -406,8 +406,8 @@ func ReportDataSourceSchema(ctx context.Context) schema.Schema {
 										},
 										"type": schema.StringAttribute{
 											Computed:            true,
-											Description:         "Type of the origin.\nThe only supported values at the moment: \"attribution\", \"unallocated\"",
-											MarkdownDescription: "Type of the origin.\nThe only supported values at the moment: \"attribution\", \"unallocated\"",
+											Description:         "Type of the origin.",
+											MarkdownDescription: "Type of the origin.",
 										},
 									},
 									CustomType: OriginType{
@@ -429,8 +429,8 @@ func ReportDataSourceSchema(ctx context.Context) schema.Schema {
 											},
 											"type": schema.StringAttribute{
 												Computed:            true,
-												Description:         "Type of the target.\nThe only supported value at the moment: \"attribution\"",
-												MarkdownDescription: "Type of the target.\nThe only supported value at the moment: \"attribution\"",
+												Description:         "Type of the target.\nIf split type is \"attribution_group\", then target type must be \"attribution\".\nOtherwise split types and target types must be the same.",
+												MarkdownDescription: "Type of the target.\nIf split type is \"attribution_group\", then target type must be \"attribution\".\nOtherwise split types and target types must be the same.",
 											},
 											"value": schema.Float64Attribute{
 												Computed:            true,
@@ -450,8 +450,8 @@ func ReportDataSourceSchema(ctx context.Context) schema.Schema {
 								},
 								"type": schema.StringAttribute{
 									Computed:            true,
-									Description:         "Type of the split.\nThe only supported value at the moment: \"attribution_group\"",
-									MarkdownDescription: "Type of the split.\nThe only supported value at the moment: \"attribution_group\"",
+									Description:         "Type of the split.",
+									MarkdownDescription: "Type of the split.",
 								},
 							},
 							CustomType: SplitsType{

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -2127,12 +2127,10 @@ type ExternalOrigin struct {
 	Id *string `json:"id,omitempty"`
 
 	// Type Type of the origin.
-	// The only supported values at the moment: "attribution", "unallocated"
 	Type *ExternalOriginType `json:"type,omitempty"`
 }
 
 // ExternalOriginType Type of the origin.
-// The only supported values at the moment: "attribution", "unallocated"
 type ExternalOriginType string
 
 // ExternalRenderer Type of visualization or output format.
@@ -2175,7 +2173,6 @@ type ExternalSplit struct {
 	Targets *[]ExternalSplitTarget `json:"targets,omitempty"`
 
 	// Type Type of the split.
-	// The only supported value at the moment: "attribution_group"
 	Type *ExternalSplitType `json:"type,omitempty"`
 }
 
@@ -2183,7 +2180,6 @@ type ExternalSplit struct {
 type ExternalSplitMode string
 
 // ExternalSplitType Type of the split.
-// The only supported value at the moment: "attribution_group"
 type ExternalSplitType string
 
 // ExternalSplitTarget Target and value of a split definition.
@@ -2192,7 +2188,8 @@ type ExternalSplitTarget struct {
 	Id *string `json:"id,omitempty"`
 
 	// Type Type of the target.
-	// The only supported value at the moment: "attribution"
+	// If split type is "attribution_group", then target type must be "attribution".
+	// Otherwise split types and target types must be the same.
 	Type *ExternalSplitTargetType `json:"type,omitempty"`
 
 	// Value Percent of the target, represented in float format. E.g. 30% is 0.3. Required only if the Split Mode is custom.
@@ -2200,7 +2197,8 @@ type ExternalSplitTarget struct {
 }
 
 // ExternalSplitTargetType Type of the target.
-// The only supported value at the moment: "attribution"
+// If split type is "attribution_group", then target type must be "attribution".
+// Otherwise split types and target types must be the same.
 type ExternalSplitTargetType string
 
 // ExternalUpdateReport Partial report object used for updates.

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -672,8 +672,8 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 										"type": schema.StringAttribute{
 											Optional:            true,
 											Computed:            true,
-											Description:         "Type of the origin.\nThe only supported values at the moment: \"attribution\", \"unallocated\"\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`, `unallocated`",
-											MarkdownDescription: "Type of the origin.\nThe only supported values at the moment: \"attribution\", \"unallocated\"\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`, `unallocated`",
+											Description:         "Type of the origin.\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`, `unallocated`",
+											MarkdownDescription: "Type of the origin.\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`, `unallocated`",
 											Validators: []validator.String{
 												stringvalidator.OneOf(
 													"datetime",
@@ -714,8 +714,8 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 											"type": schema.StringAttribute{
 												Optional:            true,
 												Computed:            true,
-												Description:         "Type of the target.\nThe only supported value at the moment: \"attribution\"\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
-												MarkdownDescription: "Type of the target.\nThe only supported value at the moment: \"attribution\"\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
+												Description:         "Type of the target.\nIf split type is \"attribution_group\", then target type must be \"attribution\".\nOtherwise split types and target types must be the same.\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
+												MarkdownDescription: "Type of the target.\nIf split type is \"attribution_group\", then target type must be \"attribution\".\nOtherwise split types and target types must be the same.\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
 												Validators: []validator.String{
 													stringvalidator.OneOf(
 														"datetime",
@@ -753,8 +753,8 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 								"type": schema.StringAttribute{
 									Optional:            true,
 									Computed:            true,
-									Description:         "Type of the split.\nThe only supported value at the moment: \"attribution_group\"\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
-									MarkdownDescription: "Type of the split.\nThe only supported value at the moment: \"attribution_group\"\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
+									Description:         "Type of the split.\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
+									MarkdownDescription: "Type of the split.\nPossible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `gke`, `gke_label`",
 									Validators: []validator.String{
 										stringvalidator.OneOf(
 											"datetime",


### PR DESCRIPTION
## Summary

Update report-related field descriptions to match the latest upstream API specification.

### Changes

- **Origin type**: Removed outdated "only supported values" note (the enum already covers the allowed values)
- **Split type**: Removed outdated "only supported value" note
- **Target type**: Replaced with clarified description explaining the relationship between split type and target type

### Files changed

- OpenAPI spec files (`openapi_spec_full.yml`, `openapi_spec_processed.yml`)
- Code generator output (`output_datasources.json`, `output_resources.json`)
- Generated Go code (`models_gen.go`, `report_data_source_gen.go`, `report_resource_gen.go`)
- Documentation (`docs/data-sources/report.md`, `docs/resources/report.md`)

All changes are auto-generated from the updated spec — no manual code modifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated-only description text changes (plus a server URL placeholder tweak in the processed spec) with no behavior or validation logic modifications.
> 
> **Overview**
> Updates the OpenAPI spec and all generated artifacts (Terraform provider schemas, Go models, and docs) to reflect revised **report cost-splitting field descriptions**.
> 
> Specifically removes outdated “only supported value(s)” notes from `config.splits.origin.type` and `config.splits.type`, and clarifies `config.splits.targets.type` by documenting how it must relate to the split type (special-casing `attribution_group`). This is a documentation/schema-metadata-only regeneration; validators/enums remain the source of truth for allowed values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f56250611055d5abbe5777425bcd63f73f39fc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->