### PR TITLE
fix: deterministic row count fallback for list data sources

### DIFF
--- a/internal/provider/users_data_source.go
+++ b/internal/provider/users_data_source.go
@@ -78,11 +78,16 @@ func (d *usersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	result := apiResp.JSON200
 
+	userCount := int64(0)
+	if result.Users != nil {
+		userCount = int64(len(*result.Users))
+	}
+
 	// Map row count
 	if result.RowCount != nil {
 		data.RowCount = types.Int64Value(*result.RowCount)
 	} else {
-		data.RowCount = types.Int64Null()
+		data.RowCount = types.Int64Value(userCount)
 	}
 
 	// Map users list

--- a/internal/provider/users_data_source_test.go
+++ b/internal/provider/users_data_source_test.go
@@ -18,6 +18,8 @@ func TestAccUsersDataSource_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.doit_users.test", "users.#"),
 					resource.TestCheckResourceAttrSet("data.doit_users.test", "row_count"),
+					resource.TestCheckResourceAttrSet("data.doit_users.test", "users.0.id"),
+					resource.TestCheckResourceAttrSet("data.doit_users.test", "users.0.email"),
 				),
 			},
 			// Drift verification: re-apply the same config should produce an empty plan


### PR DESCRIPTION
Implements a deterministic fallback for `rowCount` when omitted by the API by checking the slice length. Ensures non-paginated endpoints like organizations and users are consistent. Closes Copilot PR comments from #97

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change limited to how `row_count` is computed when the API field is missing, plus minor test assertions; no auth or write-path changes.
> 
> **Overview**
> Makes the `doit_users` data source return a deterministic `row_count` when the API omits `rowCount`, by falling back to the length of the returned `users` list instead of setting it to null.
> 
> Tightens the acceptance test to assert `users.0.id` and `users.0.email` are populated, improving drift/shape validation for list results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd903cdd3617a6b4be606817c719be78b0c9a506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->