### PR TITLE
fix: clean up CMP-38157 report targets tests

### DIFF
--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -657,8 +657,10 @@ func TestAccReport_WithSplitTargets(t *testing.T) {
 						"doit_report.split_targets",
 						tfjsonpath.New("config").AtMapKey("splits").AtSliceIndex(0).AtMapKey("targets"),
 						knownvalue.ListExact([]knownvalue.Check{
-							knownvalue.ObjectPartial(map[string]knownvalue.Check{
-								"type": knownvalue.StringExact("fixed"),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"id":    knownvalue.StringExact("amazon-web-services"),
+								"type":  knownvalue.StringExact("fixed"),
+								"value": knownvalue.Float64Exact(1.0),
 							}),
 						})),
 				},


### PR DESCRIPTION
## Summary

Removes the broken `TestAccReport_WithTargets` test that tested a non-existent config-level `targets` field and replaces it with proper test coverage.

### Investigation (CMP-38157)

The original ticket reported that the `targets` field was not returned by the API GET endpoint, causing Terraform drift. Investigation revealed:
- The `ExternalConfig` API model has **no top-level `targets` field** — targets only exist inside `splits[].targets`
- The test was placing `targets` at the config level, which was silently ignored
- The API correctly returns `splits[].targets` on GET — there is no bug

### Changes

- **Renamed** `TestAccReport_WithTargets` → `TestAccReport_WithSplits` — now tests a proper splits configuration with `targets = []` using attribution groups
- **Renamed** `TestAccReport_WithSplits` → `TestAccReport_WithSplitTargets` — now tests populated `splits[].targets` using a `cloud_provider` fixed-dimension split with `mode=custom`
- **Strengthened** `TestAccReport_WithSplitTargets` state checks to use `ObjectExact` verifying all 3 target fields (`id`, `type`, `value`) instead of `ObjectPartial` with only `type`
- **Enabled** drift verification (`ExpectEmptyPlan`) on both tests

### Test Results

All tests pass locally:
- `TestAccReport_WithSplitTargets` ✅ (including drift check + full ObjectExact assertion)