### PR TITLE
ci: add validate-docs step to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,25 @@ jobs:
       - name: Validate Examples
         run: make validate-examples
 
+  validate-docs:
+    name: Validate Docs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
+      - name: Validate Docs
+        run: make validate-docs
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,6 +21,10 @@ generate:
 docs:
 	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate
 
+# Validate provider documentation against the provider schema
+validate-docs:
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs validate
+
 fmt:
 	gofmt -s -w -e .
 
@@ -40,4 +44,4 @@ testacc-run:
 validate-examples:
 	./scripts/validate_examples.sh
 
-.PHONY: fmt lint test testacc testacc-run build install generate docs validate-examples
+.PHONY: fmt lint test testacc testacc-run build install generate docs validate-docs validate-examples


### PR DESCRIPTION
## Summary

Adds a `validate-docs` Makefile target and corresponding CI job that runs `tfplugindocs validate` on every PR and push to main.

## What it does

- **`make validate-docs`**: Runs `tfplugindocs validate` to check that the documentation structure in `docs/` matches the provider schema (all resources and data sources have corresponding doc files, frontmatter is valid, etc.)
- **CI job**: Runs as a separate job alongside `validate-examples` and `test`

## Why

While docs are generated via `make docs`, this catches cases where someone forgets to regenerate after adding/removing resources or data sources.