### PR TITLE
fix: set computed attributes to unknown when inputs are unknown in data sources

### DIFF
--- a/internal/provider/alert_data_source.go
+++ b/internal/provider/alert_data_source.go
@@ -53,8 +53,15 @@ func (ds *alertDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if state.Id.IsUnknown() {
+		state.Name = types.StringUnknown()
+		state.CreateTime = types.Int64Unknown()
+		state.UpdateTime = types.Int64Unknown()
+		state.LastAlerted = types.Int64Unknown()
+		state.Recipients = types.ListUnknown(types.StringType)
+		state.Config = datasource_alert.NewConfigValueUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/allocation_data_source.go
+++ b/internal/provider/allocation_data_source.go
@@ -62,8 +62,19 @@ func (ds *allocationDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if data.Id.IsUnknown() {
+		data.Name = types.StringUnknown()
+		data.Description = types.StringUnknown()
+		data.Type = types.StringUnknown()
+		data.AllocationType = types.StringUnknown()
+		data.AnomalyDetection = types.BoolUnknown()
+		data.CreateTime = types.Int64Unknown()
+		data.UpdateTime = types.Int64Unknown()
+		data.UnallocatedCosts = types.StringUnknown()
+		data.Rule = datasource_allocation.NewRuleValueUnknown()
+		data.Rules = types.ListUnknown(datasource_allocation.RulesValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}

--- a/internal/provider/annotation_data_source.go
+++ b/internal/provider/annotation_data_source.go
@@ -62,8 +62,15 @@ func (d *annotationDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if data.Id.IsUnknown() {
+		data.Content = types.StringUnknown()
+		data.Timestamp = types.StringUnknown()
+		data.CreateTime = types.StringUnknown()
+		data.UpdateTime = types.StringUnknown()
+		data.Reports = types.ListUnknown(types.StringType)
+		data.Labels = types.ListUnknown(datasource_annotation.LabelsValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}

--- a/internal/provider/anomaly_data_source.go
+++ b/internal/provider/anomaly_data_source.go
@@ -52,8 +52,23 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if state.Id.IsUnknown() {
+		state.Acknowledged = types.BoolUnknown()
+		state.Attribution = types.StringUnknown()
+		state.BillingAccount = types.StringUnknown()
+		state.CostOfAnomaly = types.Float64Unknown()
+		state.EndTime = types.Int64Unknown()
+		state.Platform = types.StringUnknown()
+		state.ResourceData = types.ListUnknown(datasource_anomaly.ResourceDataValue{}.Type(ctx))
+		state.Scope = types.StringUnknown()
+		state.ServiceName = types.StringUnknown()
+		state.SeverityLevel = types.StringUnknown()
+		state.StartTime = types.Int64Unknown()
+		state.Status = types.StringUnknown()
+		state.TimeFrame = types.StringUnknown()
+		state.Top3skus = types.ListUnknown(datasource_anomaly.Top3skusValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/asset_data_source.go
+++ b/internal/provider/asset_data_source.go
@@ -53,8 +53,15 @@ func (ds *assetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if state.Id.IsUnknown() {
+		state.Name = types.StringUnknown()
+		state.Type = types.StringUnknown()
+		state.Url = types.StringUnknown()
+		state.Quantity = types.Int64Unknown()
+		state.CreateTime = types.Int64Unknown()
+		state.Properties = datasource_asset.NewPropertiesValueUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/budget_data_source.go
+++ b/internal/provider/budget_data_source.go
@@ -62,8 +62,32 @@ func (d *budgetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if data.Id.IsUnknown() {
+		data.Name = types.StringUnknown()
+		data.Description = types.StringUnknown()
+		data.Amount = types.Float64Unknown()
+		data.Currency = types.StringUnknown()
+		data.Type = types.StringUnknown()
+		data.TimeInterval = types.StringUnknown()
+		data.StartPeriod = types.Int64Unknown()
+		data.EndPeriod = types.Int64Unknown()
+		data.Metric = types.StringUnknown()
+		data.GrowthPerPeriod = types.Float64Unknown()
+		data.UsePrevSpend = types.BoolUnknown()
+		data.Public = types.StringUnknown()
+		data.CreateTime = types.Int64Unknown()
+		data.UpdateTime = types.Int64Unknown()
+		data.CurrentUtilization = types.Float64Unknown()
+		data.ForecastedUtilization = types.Float64Unknown()
+		data.Alerts = types.ListUnknown(datasource_budget.AlertsValue{}.Type(ctx))
+		data.Collaborators = types.ListUnknown(datasource_budget.CollaboratorsValue{}.Type(ctx))
+		data.Recipients = types.ListUnknown(types.StringType)
+		data.RecipientsSlackChannels = types.ListUnknown(datasource_budget.RecipientsSlackChannelsValue{}.Type(ctx))
+		data.Scope = types.ListUnknown(types.StringType)
+		data.Scopes = types.ListUnknown(datasource_budget.ScopesValue{}.Type(ctx))
+		data.SeasonalAmounts = types.ListUnknown(types.Float64Type)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}

--- a/internal/provider/cloud_incident_data_source.go
+++ b/internal/provider/cloud_incident_data_source.go
@@ -51,8 +51,18 @@ func (ds *cloudIncidentDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if state.Id.IsUnknown() {
+		state.CreateTime = types.Int64Unknown()
+		state.Description = types.StringUnknown()
+		state.Platform = types.StringUnknown()
+		state.Product = types.StringUnknown()
+		state.Status = types.StringUnknown()
+		state.Summary = types.StringUnknown()
+		state.Symptoms = types.StringUnknown()
+		state.Title = types.StringUnknown()
+		state.Workaround = types.StringUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/commitment_data_source.go
+++ b/internal/provider/commitment_data_source.go
@@ -69,8 +69,19 @@ func (ds *commitmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if state.Id.IsUnknown() {
+		state.Name = types.StringUnknown()
+		state.Currency = types.StringUnknown()
+		state.CloudProvider = types.StringUnknown()
+		state.CreateTime = types.Int64Unknown()
+		state.UpdateTime = types.Int64Unknown()
+		state.TotalCommitmentValue = types.Float64Unknown()
+		state.TotalCurrentAttainment = types.Float64Unknown()
+		state.StartDate = types.StringUnknown()
+		state.EndDate = types.StringUnknown()
+		state.Periods = types.ListUnknown(datasource_commitment.PeriodsValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/datahub_dataset_data_source.go
+++ b/internal/provider/datahub_dataset_data_source.go
@@ -53,8 +53,13 @@ func (ds *datahubDatasetDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	// If name is unknown (depends on a resource not yet created), return early
+	// If name is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if state.Name.IsUnknown() {
+		state.Description = types.StringUnknown()
+		state.Records = types.Int64Unknown()
+		state.UpdatedBy = types.StringUnknown()
+		state.LastUpdated = types.StringUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/invoice_data_source.go
+++ b/internal/provider/invoice_data_source.go
@@ -52,8 +52,18 @@ func (ds *invoiceDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if state.Id.IsUnknown() {
+		state.BalanceAmount = types.Float64Unknown()
+		state.Currency = types.StringUnknown()
+		state.DueDate = types.Int64Unknown()
+		state.InvoiceDate = types.Int64Unknown()
+		state.LineItems = types.ListUnknown(datasource_invoice.LineItemsValue{}.Type(ctx))
+		state.Platform = types.StringUnknown()
+		state.Status = types.StringUnknown()
+		state.TotalAmount = types.Float64Unknown()
+		state.Url = types.StringUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/label_data_source.go
+++ b/internal/provider/label_data_source.go
@@ -60,8 +60,14 @@ func (d *labelDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if data.Id.IsUnknown() {
+		data.Name = types.StringUnknown()
+		data.Color = types.StringUnknown()
+		data.Type = types.StringUnknown()
+		data.CreateTime = types.StringUnknown()
+		data.UpdateTime = types.StringUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -64,8 +64,14 @@ func (ds *reportDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	// If ID is unknown (depends on a resource not yet created), return early
+	// If ID is unknown (depends on a resource not yet created), set all computed
+	// attributes to unknown so consumers don't treat null as a real value during planning.
 	if data.Id.IsUnknown() {
+		data.Name = types.StringUnknown()
+		data.Description = types.StringUnknown()
+		data.Type = types.StringUnknown()
+		data.Labels = types.ListUnknown(types.StringType)
+		data.Config = datasource_report.NewConfigValueUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}


### PR DESCRIPTION
## What

Fix 12 singular data sources that returned `Null` instead of `Unknown` for computed attributes when input IDs were unknown during planning.

## Why

When a data source input (e.g. `id`) depends on a not-yet-created resource, Terraform passes it as `Unknown` during `plan`. Previously, computed attributes were left as `Null` (meaning "does not exist"), which could cause downstream consumers like `data.doit_budget.example.name` to incorrectly treat `Null` as the actual value.

The correct behavior is to return `Unknown` (meaning "not yet determined"), which Terraform propagates correctly through the plan graph.

## Fixed data sources

| Data Source | Computed attributes set to Unknown |
|---|---|
| `alert` | name, create_time, update_time, last_alerted, recipients, config |
| `allocation` | name, description, type, allocation_type, anomaly_detection, create_time, update_time, unallocated_costs, rule, rules |
| `annotation` | content, timestamp, create_time, update_time, reports, labels |
| `anomaly` | 14 fields incl. resource_data, top3skus lists |
| `asset` | name, type, url, quantity, create_time, properties |
| `budget` | 22 fields incl. alerts, collaborators, scopes, seasonal_amounts lists |
| `cloud_incident` | 9 fields incl. platform, status |
| `commitment` | 10 fields incl. periods list |
| `datahub_dataset` | description, records, updated_by, last_updated |
| `invoice` | 9 fields incl. line_items list |
| `label` | name, color, type, create_time, update_time |
| `report` | name, description, type, labels, config |

## How validated

- `make build` passes
- All pre-commit hooks pass (golangci-lint, formatting, yaml)