### PR TITLE
chore: sync OpenAPI spec with upstream Ava endpoints

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -60,6 +60,8 @@ tags:
     description: Create and manage support tickets with DoiT.
   - name: Commitment Manager
     description: View and manage commitment contracts with DoiT.
+  - name: Ava
+    description: Interact with Ava, DoiT's AI-powered cloud assistant.
 
 paths:
   /analytics/v1/alerts:
@@ -3700,6 +3702,120 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+  /ava/v1/ask:
+    post:
+      tags:
+        - Ava
+      summary: Ask Ava (streaming)
+      description: |-
+        Send a question to Ava and receive a streaming response via Server-Sent Events (SSE).
+        The response streams back events containing the answer text, conversation ID, and message metadata.
+      operationId: askAvaStreaming
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AvaAskRequest"
+      responses:
+        "200":
+          description: OK - SSE stream of Ava response events.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+  /ava/v1/askSync:
+    post:
+      tags:
+        - Ava
+      summary: Ask Ava
+      description: |-
+        Send a question to Ava and receive a synchronous response.
+        Returns the full answer as a single string once generation is complete.
+      operationId: askAvaSync
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AvaAskSyncRequest"
+      responses:
+        "200":
+          description: OK - Ava response returned.
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+  /ava/v1/feedback:
+    post:
+      tags:
+        - Ava
+      summary: Submit feedback
+      description: Submit feedback on an Ava answer to help improve response quality.
+      operationId: avaFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AvaFeedbackRequest"
+      responses:
+        "200":
+          description: OK - Feedback submitted.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+  /ava/v1/deleteConversation:
+    delete:
+      tags:
+        - Ava
+      summary: Delete a conversation
+      description: Deletes an Ava conversation by its ID.
+      operationId: deleteAvaConversation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  description: The ID of the conversation to delete.
+              required:
+                - conversationId
+      responses:
+        "200":
+          description: OK - Conversation deleted.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
 components:
   schemas:
     AccountManagerListItem:
@@ -7199,6 +7315,46 @@ components:
           type: number
           format: double
           description: The marketplace limit as a percentage (0-100).
+    AvaAskRequest:
+      type: object
+      properties:
+        question:
+          type: string
+          description: The question to ask Ava.
+      required:
+        - question
+    AvaAskSyncRequest:
+      type: object
+      properties:
+        question:
+          type: string
+          description: The question to ask Ava.
+      required:
+        - question
+    AvaFeedbackRequest:
+      type: object
+      properties:
+        conversationId:
+          type: string
+          description: The conversation ID the feedback relates to.
+        answerId:
+          type: string
+          description: The specific answer ID within the conversation.
+        feedback:
+          type: object
+          properties:
+            positive:
+              type: boolean
+              description: Whether the feedback is positive or negative.
+            text:
+              type: string
+              description: Optional text providing additional feedback details.
+          required:
+            - positive
+      required:
+        - conversationId
+        - answerId
+        - feedback
   responses:
     "400":
       description: >-

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -60,6 +60,8 @@ tags:
     description: Create and manage support tickets with DoiT.
   - name: Commitment Manager
     description: View and manage commitment contracts with DoiT.
+  - name: Ava
+    description: Interact with Ava, DoiT's AI-powered cloud assistant.
 paths:
   /analytics/v1/alerts:
     get:
@@ -3085,6 +3087,114 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+  /ava/v1/ask:
+    post:
+      tags:
+        - Ava
+      summary: Ask Ava (streaming)
+      description: |-
+        Send a question to Ava and receive a streaming response via Server-Sent Events (SSE).
+        The response streams back events containing the answer text, conversation ID, and message metadata.
+      operationId: askAvaStreaming
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AvaAskRequest"
+      responses:
+        "200":
+          description: OK - SSE stream of Ava response events.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+  /ava/v1/askSync:
+    post:
+      tags:
+        - Ava
+      summary: Ask Ava
+      description: |-
+        Send a question to Ava and receive a synchronous response.
+        Returns the full answer as a single string once generation is complete.
+      operationId: askAvaSync
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AvaAskSyncRequest"
+      responses:
+        "200":
+          description: OK - Ava response returned.
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+  /ava/v1/feedback:
+    post:
+      tags:
+        - Ava
+      summary: Submit feedback
+      description: Submit feedback on an Ava answer to help improve response quality.
+      operationId: avaFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AvaFeedbackRequest"
+      responses:
+        "200":
+          description: OK - Feedback submitted.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+  /ava/v1/deleteConversation:
+    delete:
+      tags:
+        - Ava
+      summary: Delete a conversation
+      description: Deletes an Ava conversation by its ID.
+      operationId: deleteAvaConversation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteAvaConversationRequestBody'
+      responses:
+        "200":
+          description: OK - Conversation deleted.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
 components:
   schemas:
     AccountManagerListItem:
@@ -3973,6 +4083,48 @@ components:
           type: integer
           description: Last time the attribution was modified (in unix milliseconds).
           format: int64
+    AvaAskRequest:
+      type: object
+      properties:
+        question:
+          type: string
+          description: The question to ask Ava.
+      required:
+        - question
+    AvaAskSyncRequest:
+      type: object
+      properties:
+        question:
+          type: string
+          description: The question to ask Ava.
+      required:
+        - question
+    AvaFeedbackRequest:
+      type: object
+      properties:
+        conversationId:
+          type: string
+          description: The conversation ID the feedback relates to.
+        answerId:
+          type: string
+          description: The specific answer ID within the conversation.
+        feedback:
+          $ref: '#/components/schemas/AvaFeedbackRequestFeedback'
+      required:
+        - conversationId
+        - answerId
+        - feedback
+    AvaFeedbackRequestFeedback:
+      type: object
+      properties:
+        positive:
+          type: boolean
+          description: Whether the feedback is positive or negative.
+        text:
+          type: string
+          description: Optional text providing additional feedback details.
+      required:
+        - positive
     BlockingResources:
       type: object
       description: Map of resources that block deletion operations.
@@ -4917,6 +5069,14 @@ components:
           type: string
           description: 'The type of the metric. If you choose "cost" or "usage", it will map to the basic "Cost" or "Usage" metric in Cloud Analytics reports. You can also use this field to define custom metric types, such as "working_hours", "ride", etc.'
           example: "cost"
+    DeleteAvaConversationRequestBody:
+      type: object
+      properties:
+        conversationId:
+          type: string
+          description: The ID of the conversation to delete.
+      required:
+        - conversationId
     DeleteDatahubDataset200Response:
       type: object
       properties:

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3058,6 +3058,37 @@ type AttributionListItem struct {
 	UpdateTime *int64 `json:"updateTime,omitempty"`
 }
 
+// AvaAskRequest defines model for AvaAskRequest.
+type AvaAskRequest struct {
+	// Question The question to ask Ava.
+	Question string `json:"question"`
+}
+
+// AvaAskSyncRequest defines model for AvaAskSyncRequest.
+type AvaAskSyncRequest struct {
+	// Question The question to ask Ava.
+	Question string `json:"question"`
+}
+
+// AvaFeedbackRequest defines model for AvaFeedbackRequest.
+type AvaFeedbackRequest struct {
+	// AnswerId The specific answer ID within the conversation.
+	AnswerId string `json:"answerId"`
+
+	// ConversationId The conversation ID the feedback relates to.
+	ConversationId string                     `json:"conversationId"`
+	Feedback       AvaFeedbackRequestFeedback `json:"feedback"`
+}
+
+// AvaFeedbackRequestFeedback defines model for AvaFeedbackRequestFeedback.
+type AvaFeedbackRequestFeedback struct {
+	// Positive Whether the feedback is positive or negative.
+	Positive bool `json:"positive"`
+
+	// Text Optional text providing additional feedback details.
+	Text *string `json:"text,omitempty"`
+}
+
 // BlockingResources Map of resources that block deletion operations.
 type BlockingResources struct {
 	// Alerts List of alerts using this resource.
@@ -3622,6 +3653,12 @@ type DatahubEventsRequestBodyEventsItemMetricsItem struct {
 
 	// Value The value of the metric.
 	Value *float64 `json:"value,omitempty"`
+}
+
+// DeleteAvaConversationRequestBody defines model for DeleteAvaConversationRequestBody.
+type DeleteAvaConversationRequestBody struct {
+	// ConversationId The ID of the conversation to delete.
+	ConversationId string `json:"conversationId"`
 }
 
 // DeleteDatahubDataset200Response defines model for DeleteDatahubDataset200Response.
@@ -5756,6 +5793,18 @@ type QueryJSONRequestBody = QueryRequestBody
 // UpdateReportJSONRequestBody defines body for UpdateReport for application/json ContentType.
 type UpdateReportJSONRequestBody = ExternalUpdateReport
 
+// AskAvaStreamingJSONRequestBody defines body for AskAvaStreaming for application/json ContentType.
+type AskAvaStreamingJSONRequestBody = AvaAskRequest
+
+// AskAvaSyncJSONRequestBody defines body for AskAvaSync for application/json ContentType.
+type AskAvaSyncJSONRequestBody = AvaAskSyncRequest
+
+// DeleteAvaConversationJSONRequestBody defines body for DeleteAvaConversation for application/json ContentType.
+type DeleteAvaConversationJSONRequestBody = DeleteAvaConversationRequestBody
+
+// AvaFeedbackJSONRequestBody defines body for AvaFeedback for application/json ContentType.
+type AvaFeedbackJSONRequestBody = AvaFeedbackRequest
+
 // IdOfAssetJSONRequestBody defines body for IdOfAsset for application/json ContentType.
 type IdOfAssetJSONRequestBody = IdOfAssetRequestBody
 
@@ -6206,6 +6255,26 @@ type ClientInterface interface {
 
 	// Validate request
 	Validate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AskAvaStreamingWithBody request with any body
+	AskAvaStreamingWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AskAvaStreaming(ctx context.Context, body AskAvaStreamingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AskAvaSyncWithBody request with any body
+	AskAvaSyncWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AskAvaSync(ctx context.Context, body AskAvaSyncJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteAvaConversationWithBody request with any body
+	DeleteAvaConversationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	DeleteAvaConversation(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AvaFeedbackWithBody request with any body
+	AvaFeedbackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AvaFeedback(ctx context.Context, body AvaFeedbackJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// IdOfAssets request
 	IdOfAssets(ctx context.Context, params *IdOfAssetsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7152,6 +7221,102 @@ func (c *Client) GetAnomaly(ctx context.Context, id string, reqEditors ...Reques
 
 func (c *Client) Validate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewValidateRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AskAvaStreamingWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAskAvaStreamingRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AskAvaStreaming(ctx context.Context, body AskAvaStreamingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAskAvaStreamingRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AskAvaSyncWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAskAvaSyncRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AskAvaSync(ctx context.Context, body AskAvaSyncJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAskAvaSyncRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAvaConversationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAvaConversationRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAvaConversation(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAvaConversationRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AvaFeedbackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAvaFeedbackRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AvaFeedback(ctx context.Context, body AvaFeedbackJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAvaFeedbackRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -10542,6 +10707,166 @@ func NewValidateRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewAskAvaStreamingRequest calls the generic AskAvaStreaming builder with application/json body
+func NewAskAvaStreamingRequest(server string, body AskAvaStreamingJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAskAvaStreamingRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAskAvaStreamingRequestWithBody generates requests for AskAvaStreaming with any type of body
+func NewAskAvaStreamingRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ava/v1/ask")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewAskAvaSyncRequest calls the generic AskAvaSync builder with application/json body
+func NewAskAvaSyncRequest(server string, body AskAvaSyncJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAskAvaSyncRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAskAvaSyncRequestWithBody generates requests for AskAvaSync with any type of body
+func NewAskAvaSyncRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ava/v1/askSync")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteAvaConversationRequest calls the generic DeleteAvaConversation builder with application/json body
+func NewDeleteAvaConversationRequest(server string, body DeleteAvaConversationJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewDeleteAvaConversationRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewDeleteAvaConversationRequestWithBody generates requests for DeleteAvaConversation with any type of body
+func NewDeleteAvaConversationRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ava/v1/deleteConversation")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewAvaFeedbackRequest calls the generic AvaFeedback builder with application/json body
+func NewAvaFeedbackRequest(server string, body AvaFeedbackJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAvaFeedbackRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAvaFeedbackRequestWithBody generates requests for AvaFeedback with any type of body
+func NewAvaFeedbackRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ava/v1/feedback")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewIdOfAssetsRequest generates requests for IdOfAssets
 func NewIdOfAssetsRequest(server string, params *IdOfAssetsParams) (*http.Request, error) {
 	var err error
@@ -12366,6 +12691,26 @@ type ClientWithResponsesInterface interface {
 	// ValidateWithResponse request
 	ValidateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ValidateResp, error)
 
+	// AskAvaStreamingWithBodyWithResponse request with any body
+	AskAvaStreamingWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AskAvaStreamingResp, error)
+
+	AskAvaStreamingWithResponse(ctx context.Context, body AskAvaStreamingJSONRequestBody, reqEditors ...RequestEditorFn) (*AskAvaStreamingResp, error)
+
+	// AskAvaSyncWithBodyWithResponse request with any body
+	AskAvaSyncWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AskAvaSyncResp, error)
+
+	AskAvaSyncWithResponse(ctx context.Context, body AskAvaSyncJSONRequestBody, reqEditors ...RequestEditorFn) (*AskAvaSyncResp, error)
+
+	// DeleteAvaConversationWithBodyWithResponse request with any body
+	DeleteAvaConversationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error)
+
+	DeleteAvaConversationWithResponse(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error)
+
+	// AvaFeedbackWithBodyWithResponse request with any body
+	AvaFeedbackWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AvaFeedbackResp, error)
+
+	AvaFeedbackWithResponse(ctx context.Context, body AvaFeedbackJSONRequestBody, reqEditors ...RequestEditorFn) (*AvaFeedbackResp, error)
+
 	// IdOfAssetsWithResponse request
 	IdOfAssetsWithResponse(ctx context.Context, params *IdOfAssetsParams, reqEditors ...RequestEditorFn) (*IdOfAssetsResp, error)
 
@@ -13809,6 +14154,107 @@ func (r ValidateResp) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ValidateResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AskAvaStreamingResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *N400
+	JSON401      *N401
+	JSON403      *N403
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r AskAvaStreamingResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AskAvaStreamingResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AskAvaSyncResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *string
+	JSON400      *N400
+	JSON401      *N401
+	JSON403      *N403
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r AskAvaSyncResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AskAvaSyncResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteAvaConversationResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *N400
+	JSON401      *N401
+	JSON403      *N403
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteAvaConversationResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteAvaConversationResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AvaFeedbackResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *N400
+	JSON401      *N401
+	JSON403      *N403
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r AvaFeedbackResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AvaFeedbackResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -15299,6 +15745,74 @@ func (c *ClientWithResponses) ValidateWithResponse(ctx context.Context, reqEdito
 		return nil, err
 	}
 	return ParseValidateResp(rsp)
+}
+
+// AskAvaStreamingWithBodyWithResponse request with arbitrary body returning *AskAvaStreamingResp
+func (c *ClientWithResponses) AskAvaStreamingWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AskAvaStreamingResp, error) {
+	rsp, err := c.AskAvaStreamingWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAskAvaStreamingResp(rsp)
+}
+
+func (c *ClientWithResponses) AskAvaStreamingWithResponse(ctx context.Context, body AskAvaStreamingJSONRequestBody, reqEditors ...RequestEditorFn) (*AskAvaStreamingResp, error) {
+	rsp, err := c.AskAvaStreaming(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAskAvaStreamingResp(rsp)
+}
+
+// AskAvaSyncWithBodyWithResponse request with arbitrary body returning *AskAvaSyncResp
+func (c *ClientWithResponses) AskAvaSyncWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AskAvaSyncResp, error) {
+	rsp, err := c.AskAvaSyncWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAskAvaSyncResp(rsp)
+}
+
+func (c *ClientWithResponses) AskAvaSyncWithResponse(ctx context.Context, body AskAvaSyncJSONRequestBody, reqEditors ...RequestEditorFn) (*AskAvaSyncResp, error) {
+	rsp, err := c.AskAvaSync(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAskAvaSyncResp(rsp)
+}
+
+// DeleteAvaConversationWithBodyWithResponse request with arbitrary body returning *DeleteAvaConversationResp
+func (c *ClientWithResponses) DeleteAvaConversationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error) {
+	rsp, err := c.DeleteAvaConversationWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAvaConversationResp(rsp)
+}
+
+func (c *ClientWithResponses) DeleteAvaConversationWithResponse(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error) {
+	rsp, err := c.DeleteAvaConversation(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAvaConversationResp(rsp)
+}
+
+// AvaFeedbackWithBodyWithResponse request with arbitrary body returning *AvaFeedbackResp
+func (c *ClientWithResponses) AvaFeedbackWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AvaFeedbackResp, error) {
+	rsp, err := c.AvaFeedbackWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAvaFeedbackResp(rsp)
+}
+
+func (c *ClientWithResponses) AvaFeedbackWithResponse(ctx context.Context, body AvaFeedbackJSONRequestBody, reqEditors ...RequestEditorFn) (*AvaFeedbackResp, error) {
+	rsp, err := c.AvaFeedback(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAvaFeedbackResp(rsp)
 }
 
 // IdOfAssetsWithResponse request returning *IdOfAssetsResp
@@ -18423,6 +18937,201 @@ func ParseValidateResp(rsp *http.Response) (*ValidateResp, error) {
 			return nil, err
 		}
 		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAskAvaStreamingResp parses an HTTP response from a AskAvaStreamingWithResponse call
+func ParseAskAvaStreamingResp(rsp *http.Response) (*AskAvaStreamingResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AskAvaStreamingResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest N403
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAskAvaSyncResp parses an HTTP response from a AskAvaSyncWithResponse call
+func ParseAskAvaSyncResp(rsp *http.Response) (*AskAvaSyncResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AskAvaSyncResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest string
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest N403
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteAvaConversationResp parses an HTTP response from a DeleteAvaConversationWithResponse call
+func ParseDeleteAvaConversationResp(rsp *http.Response) (*DeleteAvaConversationResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteAvaConversationResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest N403
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAvaFeedbackResp parses an HTTP response from a AvaFeedbackWithResponse call
+func ParseAvaFeedbackResp(rsp *http.Response) (*AvaFeedbackResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AvaFeedbackResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest N403
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
 
 	}
 


### PR DESCRIPTION
## Summary

Syncs the local OpenAPI spec with the upstream addition of Ava AI assistant endpoints and regenerates Go models.

## New Endpoints

| Method | Path | Description |
|:-------|:-----|:------------|
| `POST` | `/ava/v1/ask` | Ask Ava (SSE streaming response) |
| `POST` | `/ava/v1/askSync` | Ask Ava (synchronous response) |
| `POST` | `/ava/v1/feedback` | Submit feedback on an Ava answer |
| `DELETE` | `/ava/v1/deleteConversation` | Delete a conversation by ID |

## Terraform Impact

None — these are interactive/conversational endpoints with no GET or list methods and no state to manage. Not suitable for Terraform resources or data sources.

## Changes

- Updated `OpenAPI/openapi_spec_full.yml` with new Ava tag and 4 endpoints
- Regenerated `OpenAPI/openapi_spec_processed.yml` and `internal/provider/models/models_gen.go`