### PR TITLE
chore: sync ava spec update from upstream

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -3793,18 +3793,13 @@ paths:
       summary: Delete a conversation
       description: Deletes an Ava conversation by its ID.
       operationId: deleteAvaConversation
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                conversationId:
-                  type: string
-                  description: The ID of the conversation to delete.
-              required:
-                - conversationId
+      parameters:
+        - name: conversationId
+          in: query
+          description: The ID of the conversation to delete.
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: OK - Conversation deleted.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -3178,12 +3178,13 @@ paths:
       summary: Delete a conversation
       description: Deletes an Ava conversation by its ID.
       operationId: deleteAvaConversation
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeleteAvaConversationRequestBody'
+      parameters:
+        - name: conversationId
+          in: query
+          description: The ID of the conversation to delete.
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: OK - Conversation deleted.
@@ -5069,14 +5070,6 @@ components:
           type: string
           description: 'The type of the metric. If you choose "cost" or "usage", it will map to the basic "Cost" or "Usage" metric in Cloud Analytics reports. You can also use this field to define custom metric types, such as "working_hours", "ride", etc.'
           example: "cost"
-    DeleteAvaConversationRequestBody:
-      type: object
-      properties:
-        conversationId:
-          type: string
-          description: The ID of the conversation to delete.
-      required:
-        - conversationId
     DeleteDatahubDataset200Response:
       type: object
       properties:

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3655,12 +3655,6 @@ type DatahubEventsRequestBodyEventsItemMetricsItem struct {
 	Value *float64 `json:"value,omitempty"`
 }
 
-// DeleteAvaConversationRequestBody defines model for DeleteAvaConversationRequestBody.
-type DeleteAvaConversationRequestBody struct {
-	// ConversationId The ID of the conversation to delete.
-	ConversationId string `json:"conversationId"`
-}
-
 // DeleteDatahubDataset200Response defines model for DeleteDatahubDataset200Response.
 type DeleteDatahubDataset200Response struct {
 	Message *string `json:"message,omitempty"`
@@ -5641,6 +5635,12 @@ type ListAnomaliesParams struct {
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 }
 
+// DeleteAvaConversationParams defines parameters for DeleteAvaConversation.
+type DeleteAvaConversationParams struct {
+	// ConversationId The ID of the conversation to delete.
+	ConversationId string `form:"conversationId" json:"conversationId"`
+}
+
 // IdOfAssetsParams defines parameters for IdOfAssets.
 type IdOfAssetsParams struct {
 	// MaxResults The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
@@ -5798,9 +5798,6 @@ type AskAvaStreamingJSONRequestBody = AvaAskRequest
 
 // AskAvaSyncJSONRequestBody defines body for AskAvaSync for application/json ContentType.
 type AskAvaSyncJSONRequestBody = AvaAskSyncRequest
-
-// DeleteAvaConversationJSONRequestBody defines body for DeleteAvaConversation for application/json ContentType.
-type DeleteAvaConversationJSONRequestBody = DeleteAvaConversationRequestBody
 
 // AvaFeedbackJSONRequestBody defines body for AvaFeedback for application/json ContentType.
 type AvaFeedbackJSONRequestBody = AvaFeedbackRequest
@@ -6266,10 +6263,8 @@ type ClientInterface interface {
 
 	AskAvaSync(ctx context.Context, body AskAvaSyncJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteAvaConversationWithBody request with any body
-	DeleteAvaConversationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	DeleteAvaConversation(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteAvaConversation request
+	DeleteAvaConversation(ctx context.Context, params *DeleteAvaConversationParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// AvaFeedbackWithBody request with any body
 	AvaFeedbackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7279,20 +7274,8 @@ func (c *Client) AskAvaSync(ctx context.Context, body AskAvaSyncJSONRequestBody,
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteAvaConversationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteAvaConversationRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) DeleteAvaConversation(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteAvaConversationRequest(c.Server, body)
+func (c *Client) DeleteAvaConversation(ctx context.Context, params *DeleteAvaConversationParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAvaConversationRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -10787,19 +10770,8 @@ func NewAskAvaSyncRequestWithBody(server string, contentType string, body io.Rea
 	return req, nil
 }
 
-// NewDeleteAvaConversationRequest calls the generic DeleteAvaConversation builder with application/json body
-func NewDeleteAvaConversationRequest(server string, body DeleteAvaConversationJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewDeleteAvaConversationRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewDeleteAvaConversationRequestWithBody generates requests for DeleteAvaConversation with any type of body
-func NewDeleteAvaConversationRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+// NewDeleteAvaConversationRequest generates requests for DeleteAvaConversation
+func NewDeleteAvaConversationRequest(server string, params *DeleteAvaConversationParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -10817,12 +10789,28 @@ func NewDeleteAvaConversationRequestWithBody(server string, contentType string, 
 		return nil, err
 	}
 
-	req, err := http.NewRequest("DELETE", queryURL.String(), body)
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "conversationId", params.ConversationId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -12701,10 +12689,8 @@ type ClientWithResponsesInterface interface {
 
 	AskAvaSyncWithResponse(ctx context.Context, body AskAvaSyncJSONRequestBody, reqEditors ...RequestEditorFn) (*AskAvaSyncResp, error)
 
-	// DeleteAvaConversationWithBodyWithResponse request with any body
-	DeleteAvaConversationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error)
-
-	DeleteAvaConversationWithResponse(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error)
+	// DeleteAvaConversationWithResponse request
+	DeleteAvaConversationWithResponse(ctx context.Context, params *DeleteAvaConversationParams, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error)
 
 	// AvaFeedbackWithBodyWithResponse request with any body
 	AvaFeedbackWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AvaFeedbackResp, error)
@@ -15781,17 +15767,9 @@ func (c *ClientWithResponses) AskAvaSyncWithResponse(ctx context.Context, body A
 	return ParseAskAvaSyncResp(rsp)
 }
 
-// DeleteAvaConversationWithBodyWithResponse request with arbitrary body returning *DeleteAvaConversationResp
-func (c *ClientWithResponses) DeleteAvaConversationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error) {
-	rsp, err := c.DeleteAvaConversationWithBody(ctx, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteAvaConversationResp(rsp)
-}
-
-func (c *ClientWithResponses) DeleteAvaConversationWithResponse(ctx context.Context, body DeleteAvaConversationJSONRequestBody, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error) {
-	rsp, err := c.DeleteAvaConversation(ctx, body, reqEditors...)
+// DeleteAvaConversationWithResponse request returning *DeleteAvaConversationResp
+func (c *ClientWithResponses) DeleteAvaConversationWithResponse(ctx context.Context, params *DeleteAvaConversationParams, reqEditors ...RequestEditorFn) (*DeleteAvaConversationResp, error) {
+	rsp, err := c.DeleteAvaConversation(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request refactors the API for deleting an Ava conversation to use a query parameter instead of a JSON request body. The changes update the OpenAPI spec and the generated Go client to reflect this new approach, simplifying the API and making it more consistent with RESTful conventions.

**OpenAPI Spec Changes:**
- Refactored the `deleteAvaConversation` endpoint to accept `conversationId` as a required query parameter instead of in the request body. [[1]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3796-L3807) [[2]](diffhunk://#diff-389d555bd5509e14e730dff6a1354d7cb61a2b9bf99e1a547a547513b508385cL3181-R3187)
- Removed the now-unused `DeleteAvaConversationRequestBody` schema from the OpenAPI components section.

**Go Client Code Generation Updates:**
- Removed the `DeleteAvaConversationRequestBody` struct and related type aliases from `models_gen.go`. [[1]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL3658-L3663) [[2]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL5802-L5804)
- Added a new `DeleteAvaConversationParams` struct to represent the query parameter for the delete operation.
- Refactored the client interface and implementation to accept `DeleteAvaConversationParams` as a parameter instead of a request body, and updated the HTTP request builder to use the query parameter. [[1]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL6269-R6267) [[2]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL7282-R7278) [[3]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL10790-R10774) [[4]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL10820-R10813)
- Updated the response interface and implementations to match the new parameter-based signature for the delete operation. [[1]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL12704-R12693) [[2]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbL15784-R15772)

This is just a sync from upstream. No provider code is actually affected by this.