### PR TITLE
feat: add caseInsensitive filter support

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -139,6 +139,13 @@
 										"nested_object": {
 											"attributes": [
 												{
+													"name": "case_insensitive",
+													"bool": {
+														"computed_optional_required": "computed",
+														"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+													}
+												},
+												{
 													"name": "id",
 													"string": {
 														"computed_optional_required": "computed",
@@ -396,6 +403,13 @@
 														"nested_object": {
 															"attributes": [
 																{
+																	"name": "case_insensitive",
+																	"bool": {
+																		"computed_optional_required": "computed",
+																		"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+																	}
+																},
+																{
 																	"name": "id",
 																	"string": {
 																		"computed_optional_required": "computed",
@@ -582,6 +596,13 @@
 										"nested_object": {
 											"attributes": [
 												{
+													"name": "case_insensitive",
+													"bool": {
+														"computed_optional_required": "computed",
+														"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+													}
+												},
+												{
 													"name": "include_null",
 													"bool": {
 														"computed_optional_required": "computed",
@@ -661,6 +682,13 @@
 											"computed_optional_required": "computed",
 											"nested_object": {
 												"attributes": [
+													{
+														"name": "case_insensitive",
+														"bool": {
+															"computed_optional_required": "computed",
+															"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+														}
+													},
 													{
 														"name": "include_null",
 														"bool": {
@@ -2080,6 +2108,13 @@
 							"nested_object": {
 								"attributes": [
 									{
+										"name": "case_insensitive",
+										"bool": {
+											"computed_optional_required": "computed",
+											"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+										}
+									},
+									{
 										"name": "id",
 										"string": {
 											"computed_optional_required": "computed",
@@ -2317,6 +2352,13 @@
 											"computed_optional_required": "computed",
 											"nested_object": {
 												"attributes": [
+													{
+														"name": "case_insensitive",
+														"bool": {
+															"computed_optional_required": "computed",
+															"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+														}
+													},
 													{
 														"name": "id",
 														"string": {
@@ -3837,6 +3879,13 @@
 										"computed_optional_required": "computed",
 										"nested_object": {
 											"attributes": [
+												{
+													"name": "case_insensitive",
+													"bool": {
+														"computed_optional_required": "computed",
+														"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+													}
+												},
 												{
 													"name": "id",
 													"string": {

--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -110,6 +110,16 @@
 										"nested_object": {
 											"attributes": [
 												{
+													"name": "case_insensitive",
+													"bool": {
+														"computed_optional_required": "computed_optional",
+														"default": {
+															"static": false
+														},
+														"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+													}
+												},
+												{
 													"name": "id",
 													"string": {
 														"computed_optional_required": "required",
@@ -298,6 +308,16 @@
 										"nested_object": {
 											"attributes": [
 												{
+													"name": "case_insensitive",
+													"bool": {
+														"computed_optional_required": "computed_optional",
+														"default": {
+															"static": false
+														},
+														"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+													}
+												},
+												{
 													"name": "include_null",
 													"bool": {
 														"computed_optional_required": "computed_optional",
@@ -419,6 +439,16 @@
 											"computed_optional_required": "computed_optional",
 											"nested_object": {
 												"attributes": [
+													{
+														"name": "case_insensitive",
+														"bool": {
+															"computed_optional_required": "computed_optional",
+															"default": {
+																"static": false
+															},
+															"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+														}
+													},
 													{
 														"name": "include_null",
 														"bool": {
@@ -1131,6 +1161,16 @@
 							"nested_object": {
 								"attributes": [
 									{
+										"name": "case_insensitive",
+										"bool": {
+											"computed_optional_required": "computed_optional",
+											"default": {
+												"static": false
+											},
+											"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+										}
+									},
+									{
 										"name": "id",
 										"string": {
 											"computed_optional_required": "required",
@@ -1707,6 +1747,16 @@
 										"computed_optional_required": "computed_optional",
 										"nested_object": {
 											"attributes": [
+												{
+													"name": "case_insensitive",
+													"bool": {
+														"computed_optional_required": "computed_optional",
+														"default": {
+															"static": false
+														},
+														"description": "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise."
+													}
+												},
 												{
 													"name": "id",
 													"string": {

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -4210,6 +4210,10 @@ components:
           type: boolean
           description: Include null values.
           default: false
+        caseInsensitive:
+          type: boolean
+          description: If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+          default: false
         mode:
           type: string
           description: Filter mode to apply. When type is "allocation_rule", only "is" and "contains" modes are supported.
@@ -4511,6 +4515,10 @@ components:
         inverse_selection:
           type: boolean
           description: If true, all selected values will be excluded.
+        caseInsensitive:
+          type: boolean
+          description: If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+          default: false
         key:
           type: string
           description: 'Key of a dimension. Examples: "service_id", "cloud_provider", "sku_description"'
@@ -5743,6 +5751,10 @@ components:
         inverse:
           type: boolean
           description: Set to `true` to exclude the values.
+        caseInsensitive:
+          type: boolean
+          description: If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+          default: false
         values:
           type: array
           description: Values to filter on.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -3462,6 +3462,10 @@ components:
           type: boolean
           description: Include null values.
           default: false
+        caseInsensitive:
+          type: boolean
+          description: If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+          default: false
         mode:
           type: string
           description: Filter mode to apply. When type is "allocation_rule", only "is" and "contains" modes are supported.
@@ -3846,6 +3850,10 @@ components:
         inverse_selection:
           type: boolean
           description: If true, all selected values will be excluded.
+        caseInsensitive:
+          type: boolean
+          description: If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+          default: false
         key:
           type: string
           description: 'Key of a dimension. Examples: "service_id", "cloud_provider", "sku_description"'
@@ -5505,6 +5513,10 @@ components:
         inverse:
           type: boolean
           description: Set to `true` to exclude the values.
+        caseInsensitive:
+          type: boolean
+          description: If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+          default: false
         values:
           type: array
           description: Values to filter on.

--- a/internal/provider/alert.go
+++ b/internal/provider/alert.go
@@ -126,11 +126,12 @@ func (plan *alertResourceModel) toAlertConfig(ctx context.Context) (config model
 			filterMode := models.ExternalConfigFilterMode(scope.Mode.ValueString())
 
 			apiScopes[i] = models.ExternalConfigFilter{
-				Id:          scope.Id.ValueString(),
-				IncludeNull: scope.IncludeNull.ValueBoolPointer(),
-				Inverse:     scope.Inverse.ValueBoolPointer(),
-				Mode:        filterMode,
-				Type:        filterType,
+				CaseInsensitive: scope.CaseInsensitive.ValueBoolPointer(),
+				Id:              scope.Id.ValueString(),
+				IncludeNull:     scope.IncludeNull.ValueBoolPointer(),
+				Inverse:         scope.Inverse.ValueBoolPointer(),
+				Mode:            filterMode,
+				Type:            filterType,
 			}
 			if !scope.Values.IsNull() && !scope.Values.IsUnknown() {
 				var values []string
@@ -214,6 +215,7 @@ func mapAlertToModel(ctx context.Context, resp *models.Alert, state *alertResour
 		// (e.g. "allocation_rule"), while the API returns canonical names ("attribution").
 		var existingScopeTypes, existingScopeIDs []string
 		var existingScopeIncludeNull []*bool
+		var existingScopeCaseInsensitive []*bool
 		if !state.Config.IsNull() && !state.Config.IsUnknown() &&
 			!state.Config.Scopes.IsNull() && !state.Config.Scopes.IsUnknown() {
 			var existingScopes []resource_alert.ScopesValue
@@ -222,10 +224,11 @@ func mapAlertToModel(ctx context.Context, resp *models.Alert, state *alertResour
 					existingScopeTypes = append(existingScopeTypes, es.ScopesType.ValueString())
 					existingScopeIDs = append(existingScopeIDs, es.Id.ValueString())
 					existingScopeIncludeNull = append(existingScopeIncludeNull, es.IncludeNull.ValueBoolPointer())
+					existingScopeCaseInsensitive = append(existingScopeCaseInsensitive, es.CaseInsensitive.ValueBoolPointer())
 				}
 			}
 		}
-		configVal, configDiags := mapAlertConfigToModel(ctx, resp.Config, existingScopeTypes, existingScopeIDs, existingScopeIncludeNull)
+		configVal, configDiags := mapAlertConfigToModel(ctx, resp.Config, existingScopeTypes, existingScopeIDs, existingScopeIncludeNull, existingScopeCaseInsensitive)
 		diags.Append(configDiags...)
 		state.Config = configVal
 	}
@@ -234,7 +237,7 @@ func mapAlertToModel(ctx context.Context, resp *models.Alert, state *alertResour
 }
 
 // mapAlertConfigToModel maps the API AlertConfig to the Terraform ConfigValue.
-func mapAlertConfigToModel(ctx context.Context, config *models.AlertConfig, existingScopeTypes, existingScopeIDs []string, existingScopeIncludeNull []*bool) (resource_alert.ConfigValue, diag.Diagnostics) {
+func mapAlertConfigToModel(ctx context.Context, config *models.AlertConfig, existingScopeTypes, existingScopeIDs []string, existingScopeIncludeNull []*bool, existingScopeCaseInsensitive []*bool) (resource_alert.ConfigValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	// Build attributions list
@@ -289,13 +292,23 @@ func mapAlertConfigToModel(ctx context.Context, config *models.AlertConfig, exis
 				includeNullVal = types.BoolValue(*scope.IncludeNull)
 			}
 
+			// The API may not reliably echo caseInsensitive — always prefer the plan/state
+			// value when available.
+			caseInsensitiveVal := types.BoolValue(false)
+			if i < len(existingScopeCaseInsensitive) && existingScopeCaseInsensitive[i] != nil {
+				caseInsensitiveVal = types.BoolValue(*existingScopeCaseInsensitive[i])
+			} else if scope.CaseInsensitive != nil {
+				caseInsensitiveVal = types.BoolValue(*scope.CaseInsensitive)
+			}
+
 			scopeAttrs := map[string]attr.Value{
-				"id":           types.StringValue(scopeID),
-				"include_null": includeNullVal,
-				"inverse":      types.BoolPointerValue(scope.Inverse),
-				"mode":         types.StringValue(string(scope.Mode)),
-				"type":         types.StringValue(scopeType),
-				"values":       valuesVal,
+				"case_insensitive": caseInsensitiveVal,
+				"id":               types.StringValue(scopeID),
+				"include_null":     includeNullVal,
+				"inverse":          types.BoolPointerValue(scope.Inverse),
+				"mode":             types.StringValue(string(scope.Mode)),
+				"type":             types.StringValue(scopeType),
+				"values":           valuesVal,
 			}
 			var d diag.Diagnostics
 			scopesList[i], d = resource_alert.NewScopesValue(resource_alert.ScopesValue{}.AttributeTypes(ctx), scopeAttrs)

--- a/internal/provider/alert_data_source.go
+++ b/internal/provider/alert_data_source.go
@@ -272,12 +272,13 @@ func (ds *alertDataSource) mapScopeToModel(ctx context.Context, scope *models.Ex
 	scopeVal, d := datasource_alert.NewScopesValue(
 		datasource_alert.ScopesValue{}.AttributeTypes(ctx),
 		map[string]attr.Value{
-			"id":           types.StringValue(scope.Id),
-			"include_null": types.BoolPointerValue(scope.IncludeNull),
-			"type":         types.StringValue(string(scope.Type)),
-			"mode":         mode,
-			"inverse":      inverse,
-			"values":       values,
+			"case_insensitive": types.BoolPointerValue(scope.CaseInsensitive),
+			"id":               types.StringValue(scope.Id),
+			"include_null":     types.BoolPointerValue(scope.IncludeNull),
+			"type":             types.StringValue(string(scope.Type)),
+			"mode":             mode,
+			"inverse":          inverse,
+			"values":           values,
 		},
 	)
 	diags.Append(d...)

--- a/internal/provider/alert_resource_test.go
+++ b/internal/provider/alert_resource_test.go
@@ -964,3 +964,73 @@ resource "doit_alert" "this" {
 }
 `, i)
 }
+
+// TestAccAlert_CaseInsensitive tests that the case_insensitive property on alert scopes
+// round-trips correctly without causing drift. Uses mode="contains" with a lowercase
+// value to exercise the case-insensitive matching path.
+func TestAccAlert_CaseInsensitive(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertWithCaseInsensitive(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_alert.this",
+						tfjsonpath.New("config").AtMapKey("scopes"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("fixed"),
+								"id":               knownvalue.StringExact("cloud_provider"),
+								"mode":             knownvalue.StringExact("contains"),
+								"case_insensitive": knownvalue.Bool(true),
+								"values":           knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("aws")}),
+							}),
+						}),
+					),
+				},
+			},
+			// Verify no drift on re-apply
+			{
+				Config: testAccAlertWithCaseInsensitive(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAlertWithCaseInsensitive(i int) string {
+	return fmt.Sprintf(`
+resource "doit_alert" "this" {
+  name = "test-alert-case-insensitive-%d"
+  config = {
+    metric = {
+      type  = "basic"
+      value = "cost"
+    }
+    time_interval = "month"
+    value         = 500
+    currency      = "USD"
+    condition     = "value"
+    operator      = "gt"
+    scopes = [
+      {
+        type             = "fixed"
+        id               = "cloud_provider"
+        mode             = "contains"
+        case_insensitive = true
+        values           = ["aws"]
+      }
+    ]
+  }
+}
+`, i)
+}

--- a/internal/provider/alerts_data_source.go
+++ b/internal/provider/alerts_data_source.go
@@ -321,12 +321,13 @@ func mapAlertScopes(ctx context.Context, scopes *[]models.ExternalConfigFilter, 
 		scopeVal, diags := datasource_alerts.NewScopesValue(
 			datasource_alerts.ScopesValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
-				"id":           types.StringValue(s.Id),
-				"include_null": types.BoolPointerValue(s.IncludeNull),
-				"inverse":      types.BoolPointerValue(s.Inverse),
-				"mode":         types.StringValue(string(s.Mode)),
-				"type":         types.StringValue(string(s.Type)),
-				"values":       valuesList,
+				"case_insensitive": types.BoolPointerValue(s.CaseInsensitive),
+				"id":               types.StringValue(s.Id),
+				"include_null":     types.BoolPointerValue(s.IncludeNull),
+				"inverse":          types.BoolPointerValue(s.Inverse),
+				"mode":             types.StringValue(string(s.Mode)),
+				"type":             types.StringValue(string(s.Type)),
+				"values":           valuesList,
 			},
 		)
 		diagnostics.Append(diags...)

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -54,6 +54,7 @@ func convertComponentsToModels(ctx context.Context, components []resource_alloca
 	result = make([]models.AllocationComponent, len(components))
 	for i := range components {
 		result[i] = models.AllocationComponent{
+			CaseInsensitive:  components[i].CaseInsensitive.ValueBoolPointer(),
 			IncludeNull:      components[i].IncludeNull.ValueBoolPointer(),
 			InverseSelection: components[i].InverseSelection.ValueBoolPointer(),
 			Key:              components[i].Key.ValueString(),
@@ -228,22 +229,19 @@ func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *mod
 			"formula": types.StringValue(resp.Rule.Formula),
 		}
 		if resp.Rule.Components != nil {
-			// Get existing component types from state for alias normalization
-			var existingTypes []string
-			var existingIncludeNull, existingInverseSelection []*bool
+			// Get existing component values from state for alias normalization and state preservation.
+			// The API does not reliably echo include_null / inverse_selection, so we preserve
+			// those from state. case_insensitive IS echoed and uses direct API mapping.
+			var existingComponents []resource_allocation.ComponentsValue
 			if !state.Rule.IsNull() && !state.Rule.IsUnknown() &&
 				!state.Rule.Components.IsNull() && !state.Rule.Components.IsUnknown() {
-				var existingComponents []resource_allocation.ComponentsValue
-				if d := state.Rule.Components.ElementsAs(ctx, &existingComponents, false); !d.HasError() {
-					for _, ec := range existingComponents {
-						existingTypes = append(existingTypes, ec.ComponentsType.ValueString())
-						existingIncludeNull = append(existingIncludeNull, ec.IncludeNull.ValueBoolPointer())
-						existingInverseSelection = append(existingInverseSelection, ec.InverseSelection.ValueBoolPointer())
-					}
+				if d := state.Rule.Components.ElementsAs(ctx, &existingComponents, false); d.HasError() {
+					diags.Append(d...)
+					return
 				}
 			}
 			var d diag.Diagnostics
-			m["components"], d = toAllocationRuleComponentsListValue(ctx, resp.Rule.Components, existingTypes, existingIncludeNull, existingInverseSelection)
+			m["components"], d = toAllocationRuleComponentsListValue(ctx, resp.Rule.Components, existingComponents)
 			diags.Append(d...)
 			if diags.HasError() {
 				return
@@ -337,25 +335,20 @@ func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *mod
 				"name":        types.StringPointerValue(rule.Name),
 			}
 			if len(components) > 0 {
-				// Get existing component types, include_null, and inverse_selection from state.
+				// Get existing component values from state for alias normalization and state preservation.
 				// We reuse stateRules (parsed once before the loop) instead of re-parsing state.Rules on each iteration.
-				var existingTypes []string
-				var existingIncludeNull, existingInverseSelection []*bool
+				var existingComponents []resource_allocation.ComponentsValue
 				if ruleIndex < len(stateRules) {
 					sr := stateRules[ruleIndex]
 					if !sr.Components.IsNull() && !sr.Components.IsUnknown() {
-						var existingComps []resource_allocation.ComponentsValue
-						if cd := sr.Components.ElementsAs(ctx, &existingComps, false); !cd.HasError() {
-							for _, ec := range existingComps {
-								existingTypes = append(existingTypes, ec.ComponentsType.ValueString())
-								existingIncludeNull = append(existingIncludeNull, ec.IncludeNull.ValueBoolPointer())
-								existingInverseSelection = append(existingInverseSelection, ec.InverseSelection.ValueBoolPointer())
-							}
+						if d := sr.Components.ElementsAs(ctx, &existingComponents, false); d.HasError() {
+							diags.Append(d...)
+							return
 						}
 					}
 				}
 				var d diag.Diagnostics
-				m["components"], d = toAllocationRuleComponentsListValue(ctx, components, existingTypes, existingIncludeNull, existingInverseSelection)
+				m["components"], d = toAllocationRuleComponentsListValue(ctx, components, existingComponents)
 				diags.Append(d...)
 				if diags.HasError() {
 					return
@@ -389,7 +382,7 @@ func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *mod
 	return
 }
 
-func toAllocationRuleComponentsListValue(ctx context.Context, components []models.AllocationComponent, existingTypes []string, existingIncludeNull, existingInverseSelection []*bool) (res basetypes.ListValue, diags diag.Diagnostics) {
+func toAllocationRuleComponentsListValue(ctx context.Context, components []models.AllocationComponent, existingComponents []resource_allocation.ComponentsValue) (res basetypes.ListValue, diags diag.Diagnostics) {
 	// Handle empty slice: return an empty list without indexing stateComponents[0].
 	if len(components) == 0 {
 		res, diags = types.ListValueFrom(ctx, resource_allocation.ComponentsValue{}.Type(ctx), []resource_allocation.ComponentsValue{})
@@ -399,29 +392,39 @@ func toAllocationRuleComponentsListValue(ctx context.Context, components []model
 	for i, component := range components {
 		// Normalize alias types to preserve user's configured value
 		compType := string(component.Type)
-		if i < len(existingTypes) {
-			compType = normalizeDimensionsType(compType, existingTypes[i])
+		if i < len(existingComponents) {
+			compType = normalizeDimensionsType(compType, existingComponents[i].ComponentsType.ValueString())
 		}
 
 		// The API does not reliably echo include_null / inverse_selection — it may
-		// return nil regardless of the value sent. Always prefer the plan/state value
+		// return false regardless of the value sent. Always prefer the plan/state value
 		// when available. The API response is only used as a fallback (e.g., during
 		// ImportState when there is no prior plan/state).
+		// The API may not reliably echo case_insensitive — always prefer the plan/state
+		// value when available.
+		caseInsensitiveVal := types.BoolValue(false)
+		if i < len(existingComponents) {
+			caseInsensitiveVal = types.BoolValue(existingComponents[i].CaseInsensitive.ValueBool())
+		} else if component.CaseInsensitive != nil {
+			caseInsensitiveVal = types.BoolValue(*component.CaseInsensitive)
+		}
+
 		includeNullVal := types.BoolValue(false)
-		if i < len(existingIncludeNull) && existingIncludeNull[i] != nil {
-			includeNullVal = types.BoolValue(*existingIncludeNull[i])
+		if i < len(existingComponents) {
+			includeNullVal = types.BoolValue(existingComponents[i].IncludeNull.ValueBool())
 		} else if component.IncludeNull != nil {
 			includeNullVal = types.BoolValue(*component.IncludeNull)
 		}
 
 		inverseSelectionVal := types.BoolValue(false)
-		if i < len(existingInverseSelection) && existingInverseSelection[i] != nil {
-			inverseSelectionVal = types.BoolValue(*existingInverseSelection[i])
+		if i < len(existingComponents) {
+			inverseSelectionVal = types.BoolValue(existingComponents[i].InverseSelection.ValueBool())
 		} else if component.InverseSelection != nil {
 			inverseSelectionVal = types.BoolValue(*component.InverseSelection)
 		}
 
 		m := map[string]attr.Value{
+			"case_insensitive":  caseInsensitiveVal,
 			"include_null":      includeNullVal,
 			"inverse_selection": inverseSelectionVal,
 			"key":               types.StringValue(component.Key),

--- a/internal/provider/allocation_components_validator_internal_test.go
+++ b/internal/provider/allocation_components_validator_internal_test.go
@@ -22,6 +22,7 @@ func TestAllocationComponentsValidator(t *testing.T) {
 				"mode":              types.StringValue(mode),
 				"type":              types.StringValue(compType),
 				"values":            types.ListValueMust(types.StringType, []attr.Value{types.StringValue("some-id")}),
+				"case_insensitive":  types.BoolValue(false),
 				"include_null":      types.BoolValue(false),
 				"inverse_selection": types.BoolValue(false),
 			},

--- a/internal/provider/allocation_data_source.go
+++ b/internal/provider/allocation_data_source.go
@@ -227,6 +227,7 @@ func (ds *allocationDataSource) mapComponentsToList(ctx context.Context, compone
 		}
 
 		componentMap := map[string]attr.Value{
+			"case_insensitive":  types.BoolPointerValue(component.CaseInsensitive),
 			"include_null":      types.BoolPointerValue(component.IncludeNull),
 			"inverse_selection": types.BoolPointerValue(component.InverseSelection),
 			"key":               types.StringValue(component.Key),

--- a/internal/provider/allocation_internal_test.go
+++ b/internal/provider/allocation_internal_test.go
@@ -14,7 +14,7 @@ func TestToAllocationRuleComponentsListValue_EmptySlice(t *testing.T) {
 	ctx := context.Background()
 
 	// This must not panic
-	result, diags := toAllocationRuleComponentsListValue(ctx, []models.AllocationComponent{}, nil, nil, nil)
+	result, diags := toAllocationRuleComponentsListValue(ctx, []models.AllocationComponent{}, nil)
 
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -530,6 +530,63 @@ resource "doit_allocation" "flags" {
 `, rName, rName, rName)
 }
 
+// TestAccAllocation_CaseInsensitive tests the case_insensitive flag on
+// allocation rule components. Requires mode=contains|starts_with|ends_with.
+func TestAccAllocation_CaseInsensitive(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllocationCaseInsensitive(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("doit_allocation.ci", "id"),
+					resource.TestCheckResourceAttr("doit_allocation.ci", "rules.0.components.0.case_insensitive", "true"),
+					resource.TestCheckResourceAttr("doit_allocation.ci", "rules.0.components.0.mode", "contains"),
+				),
+			},
+			// Verify no drift on re-apply
+			{
+				Config: testAccAllocationCaseInsensitive(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationCaseInsensitive(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "ci" {
+    name = "%s-ci"
+    description = "Test allocation with case-insensitive filter"
+    unallocated_costs = "%s-other"
+    rules = [
+        {
+            action = "create"
+            name   = "%s-ci-rule"
+            formula = "A"
+            components = [
+                {
+                    key              = "country"
+                    mode             = "contains"
+                    type             = "fixed"
+                    values           = ["jp"]
+                    case_insensitive = true
+                }
+            ]
+        }
+    ]
+}
+`, rName, rName, rName)
+}
+
 // TestAccAllocation_Disappears verifies that Terraform correctly handles
 // resources that are deleted outside of Terraform (externally deleted).
 // This tests the Read method's 404 handling and RemoveResource call.

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -128,11 +128,12 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 			filterMode := models.ExternalConfigFilterMode(scope.Mode.ValueString())
 
 			reqScopes[i] = models.ExternalConfigFilter{
-				Id:          scope.Id.ValueString(),
-				IncludeNull: scope.IncludeNull.ValueBoolPointer(),
-				Inverse:     scope.Inverse.ValueBoolPointer(),
-				Mode:        filterMode,
-				Type:        filterType,
+				CaseInsensitive: scope.CaseInsensitive.ValueBoolPointer(),
+				Id:              scope.Id.ValueString(),
+				IncludeNull:     scope.IncludeNull.ValueBoolPointer(),
+				Inverse:         scope.Inverse.ValueBoolPointer(),
+				Mode:            filterMode,
+				Type:            filterType,
 			}
 			if !scope.Values.IsNull() && !scope.Values.IsUnknown() {
 				var values []string
@@ -343,6 +344,7 @@ func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budget
 		var existingScopeTypes []string
 		var existingScopeIDs []string
 		var existingScopeIncludeNull []*bool
+		var existingScopeCaseInsensitive []*bool
 		if !state.Scopes.IsNull() && !state.Scopes.IsUnknown() {
 			var existingScopes []resource_budget.ScopesValue
 			if d := state.Scopes.ElementsAs(ctx, &existingScopes, false); !d.HasError() {
@@ -350,6 +352,7 @@ func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budget
 					existingScopeTypes = append(existingScopeTypes, es.ScopesType.ValueString())
 					existingScopeIDs = append(existingScopeIDs, es.Id.ValueString())
 					existingScopeIncludeNull = append(existingScopeIncludeNull, es.IncludeNull.ValueBoolPointer())
+					existingScopeCaseInsensitive = append(existingScopeCaseInsensitive, es.CaseInsensitive.ValueBoolPointer())
 				}
 			}
 		}
@@ -390,13 +393,23 @@ func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budget
 				includeNullVal = types.BoolValue(*scope.IncludeNull)
 			}
 
+			// The API may not reliably echo caseInsensitive — always prefer the plan/state
+			// value when available.
+			caseInsensitiveVal := types.BoolValue(false)
+			if i < len(existingScopeCaseInsensitive) && existingScopeCaseInsensitive[i] != nil {
+				caseInsensitiveVal = types.BoolValue(*existingScopeCaseInsensitive[i])
+			} else if scope.CaseInsensitive != nil {
+				caseInsensitiveVal = types.BoolValue(*scope.CaseInsensitive)
+			}
+
 			scopeAttrs := map[string]attr.Value{
-				"id":           types.StringValue(scopeID),
-				"include_null": includeNullVal,
-				"inverse":      types.BoolPointerValue(scope.Inverse),
-				"mode":         types.StringValue(string(scope.Mode)),
-				"type":         types.StringValue(scopeType),
-				"values":       valuesVal,
+				"case_insensitive": caseInsensitiveVal,
+				"id":               types.StringValue(scopeID),
+				"include_null":     includeNullVal,
+				"inverse":          types.BoolPointerValue(scope.Inverse),
+				"mode":             types.StringValue(string(scope.Mode)),
+				"type":             types.StringValue(scopeType),
+				"values":           valuesVal,
 			}
 			var d diag.Diagnostics
 			scopesList[i], d = resource_budget.NewScopesValue(resource_budget.ScopesValue{}.AttributeTypes(ctx), scopeAttrs)

--- a/internal/provider/budget_data_source.go
+++ b/internal/provider/budget_data_source.go
@@ -267,12 +267,13 @@ func (d *budgetDataSource) mapBudgetToModel(ctx context.Context, budget *models.
 			}
 
 			scopeAttrs := map[string]attr.Value{
-				"id":           types.StringValue(scope.Id),
-				"include_null": types.BoolPointerValue(scope.IncludeNull),
-				"inverse":      types.BoolPointerValue(scope.Inverse),
-				"mode":         types.StringValue(string(scope.Mode)),
-				"type":         types.StringValue(string(scope.Type)),
-				"values":       valuesVal,
+				"case_insensitive": types.BoolPointerValue(scope.CaseInsensitive),
+				"id":               types.StringValue(scope.Id),
+				"include_null":     types.BoolPointerValue(scope.IncludeNull),
+				"inverse":          types.BoolPointerValue(scope.Inverse),
+				"mode":             types.StringValue(string(scope.Mode)),
+				"type":             types.StringValue(string(scope.Type)),
+				"values":           valuesVal,
 			}
 			var d diag.Diagnostics
 			scopesList[i], d = datasource_budget.NewScopesValue(datasource_budget.ScopesValue{}.AttributeTypes(ctx), scopeAttrs)

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -1076,3 +1076,81 @@ resource "doit_budget" "this" {
 }
 `, budgetStartPeriod(), i, testUser())
 }
+
+// TestAccBudget_CaseInsensitive tests that the case_insensitive property on budget scopes
+// round-trips correctly without causing drift. Uses mode="contains" with a lowercase
+// value to exercise the case-insensitive matching path.
+func TestAccBudget_CaseInsensitive(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetWithCaseInsensitive(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("scopes"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("fixed"),
+								"id":               knownvalue.StringExact("cloud_provider"),
+								"mode":             knownvalue.StringExact("contains"),
+								"case_insensitive": knownvalue.Bool(true),
+								"values":           knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("aws")}),
+							}),
+						}),
+					),
+				},
+			},
+			// Verify no drift on re-apply
+			{
+				Config: testAccBudgetWithCaseInsensitive(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetWithCaseInsensitive(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name          = "test-case-insensitive-%d"
+  amount        = 100
+  currency      = "EUR"
+  time_interval = "month"
+  scopes = [
+    {
+      type             = "fixed"
+      id               = "cloud_provider"
+      mode             = "contains"
+      case_insensitive = true
+      values           = ["aws"]
+    }
+  ]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    },
+  ]
+  type          = "recurring"
+  start_period  = local.start_period
+}
+`, budgetStartPeriod(), i, testUser())
+}

--- a/internal/provider/budgets_data_source.go
+++ b/internal/provider/budgets_data_source.go
@@ -280,12 +280,13 @@ func mapBudgetScopes(ctx context.Context, scopes *[]models.ExternalConfigFilter)
 		val, diags := datasource_budgets.NewScopesValue(
 			datasource_budgets.ScopesValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
-				"id":           types.StringValue(s.Id),
-				"include_null": types.BoolPointerValue(s.IncludeNull),
-				"inverse":      types.BoolPointerValue(s.Inverse),
-				"mode":         types.StringValue(string(s.Mode)),
-				"type":         types.StringValue(string(s.Type)),
-				"values":       valuesList,
+				"case_insensitive": types.BoolPointerValue(s.CaseInsensitive),
+				"id":               types.StringValue(s.Id),
+				"include_null":     types.BoolPointerValue(s.IncludeNull),
+				"inverse":          types.BoolPointerValue(s.Inverse),
+				"mode":             types.StringValue(string(s.Mode)),
+				"type":             types.StringValue(string(s.Type)),
+				"values":           valuesList,
 			},
 		)
 		if diags.HasError() {

--- a/internal/provider/datasource_alert/alert_data_source_gen.go
+++ b/internal/provider/datasource_alert/alert_data_source_gen.go
@@ -73,6 +73,11 @@ func AlertDataSourceSchema(ctx context.Context) schema.Schema {
 					"scopes": schema.ListNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
+								"case_insensitive": schema.BoolAttribute{
+									Computed:            true,
+									Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+								},
 								"id": schema.StringAttribute{
 									Computed:            true,
 									Description:         "The field to filter on",
@@ -1474,6 +1479,24 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -1587,13 +1610,14 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -1660,6 +1684,24 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		return NewScopesValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewScopesValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -1773,13 +1815,14 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -1851,21 +1894,23 @@ func (t ScopesType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ScopesValue{}
 
 type ScopesValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	ScopesType  basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	ScopesType      basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -1879,7 +1924,15 @@ func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -1972,11 +2025,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -1984,11 +2038,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -2005,12 +2060,13 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.ScopesType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.ScopesType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -2029,6 +2085,10 @@ func (v ScopesValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -2068,11 +2128,12 @@ func (v ScopesValue) Type(ctx context.Context) attr.Type {
 
 func (v ScopesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/datasource_alerts/alerts_data_source_gen.go
+++ b/internal/provider/datasource_alerts/alerts_data_source_gen.go
@@ -78,6 +78,11 @@ func AlertsDataSourceSchema(ctx context.Context) schema.Schema {
 								"scopes": schema.ListNestedAttribute{
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
+											"case_insensitive": schema.BoolAttribute{
+												Computed:            true,
+												Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+												MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+											},
 											"id": schema.StringAttribute{
 												Computed:            true,
 												Description:         "The field to filter on",
@@ -2247,6 +2252,24 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -2360,13 +2383,14 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -2433,6 +2457,24 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		return NewScopesValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewScopesValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -2546,13 +2588,14 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -2624,21 +2667,23 @@ func (t ScopesType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ScopesValue{}
 
 type ScopesValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	ScopesType  basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	ScopesType      basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -2652,7 +2697,15 @@ func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -2745,11 +2798,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -2757,11 +2811,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -2778,12 +2833,13 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.ScopesType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.ScopesType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -2802,6 +2858,10 @@ func (v ScopesValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -2841,11 +2901,12 @@ func (v ScopesValue) Type(ctx context.Context) attr.Type {
 
 func (v ScopesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/datasource_allocation/allocation_data_source_gen.go
+++ b/internal/provider/datasource_allocation/allocation_data_source_gen.go
@@ -53,6 +53,11 @@ func AllocationDataSourceSchema(ctx context.Context) schema.Schema {
 					"components": schema.ListNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
+								"case_insensitive": schema.BoolAttribute{
+									Computed:            true,
+									Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+								},
 								"include_null": schema.BoolAttribute{
 									Computed:            true,
 									Description:         "Include null values.",
@@ -121,6 +126,11 @@ func AllocationDataSourceSchema(ctx context.Context) schema.Schema {
 						"components": schema.ListNestedAttribute{
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
+									"case_insensitive": schema.BoolAttribute{
+										Computed:            true,
+										Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+										MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									},
 									"include_null": schema.BoolAttribute{
 										Computed:            true,
 										Description:         "Include null values.",
@@ -643,6 +653,24 @@ func (t ComponentsType) ValueFromObject(ctx context.Context, in basetypes.Object
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	includeNullAttribute, ok := attributes["include_null"]
 
 	if !ok {
@@ -756,6 +784,7 @@ func (t ComponentsType) ValueFromObject(ctx context.Context, in basetypes.Object
 	}
 
 	return ComponentsValue{
+		CaseInsensitive:  caseInsensitiveVal,
 		IncludeNull:      includeNullVal,
 		InverseSelection: inverseSelectionVal,
 		Key:              keyVal,
@@ -829,6 +858,24 @@ func NewComponentsValue(attributeTypes map[string]attr.Type, attributes map[stri
 		return NewComponentsValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewComponentsValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	includeNullAttribute, ok := attributes["include_null"]
 
 	if !ok {
@@ -942,6 +989,7 @@ func NewComponentsValue(attributeTypes map[string]attr.Type, attributes map[stri
 	}
 
 	return ComponentsValue{
+		CaseInsensitive:  caseInsensitiveVal,
 		IncludeNull:      includeNullVal,
 		InverseSelection: inverseSelectionVal,
 		Key:              keyVal,
@@ -1020,6 +1068,7 @@ func (t ComponentsType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ComponentsValue{}
 
 type ComponentsValue struct {
+	CaseInsensitive  basetypes.BoolValue   `tfsdk:"case_insensitive"`
 	IncludeNull      basetypes.BoolValue   `tfsdk:"include_null"`
 	InverseSelection basetypes.BoolValue   `tfsdk:"inverse_selection"`
 	Key              basetypes.StringValue `tfsdk:"key"`
@@ -1030,11 +1079,12 @@ type ComponentsValue struct {
 }
 
 func (v ComponentsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse_selection"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
@@ -1048,7 +1098,15 @@ func (v ComponentsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, e
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.IncludeNull.ToTerraformValue(ctx)
 
@@ -1141,6 +1199,7 @@ func (v ComponentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVal
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
+			"case_insensitive":  basetypes.BoolType{},
 			"include_null":      basetypes.BoolType{},
 			"inverse_selection": basetypes.BoolType{},
 			"key":               basetypes.StringType{},
@@ -1153,6 +1212,7 @@ func (v ComponentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVal
 	}
 
 	attributeTypes := map[string]attr.Type{
+		"case_insensitive":  basetypes.BoolType{},
 		"include_null":      basetypes.BoolType{},
 		"inverse_selection": basetypes.BoolType{},
 		"key":               basetypes.StringType{},
@@ -1174,6 +1234,7 @@ func (v ComponentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVal
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
+			"case_insensitive":  v.CaseInsensitive,
 			"include_null":      v.IncludeNull,
 			"inverse_selection": v.InverseSelection,
 			"key":               v.Key,
@@ -1198,6 +1259,10 @@ func (v ComponentsValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.IncludeNull.Equal(other.IncludeNull) {
@@ -1237,6 +1302,7 @@ func (v ComponentsValue) Type(ctx context.Context) attr.Type {
 
 func (v ComponentsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
+		"case_insensitive":  basetypes.BoolType{},
 		"include_null":      basetypes.BoolType{},
 		"inverse_selection": basetypes.BoolType{},
 		"key":               basetypes.StringType{},

--- a/internal/provider/datasource_budget/budget_data_source_gen.go
+++ b/internal/provider/datasource_budget/budget_data_source_gen.go
@@ -164,6 +164,11 @@ func BudgetDataSourceSchema(ctx context.Context) schema.Schema {
 			"scopes": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"case_insensitive": schema.BoolAttribute{
+							Computed:            true,
+							Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+							MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+						},
 						"id": schema.StringAttribute{
 							Computed:            true,
 							Description:         "The field to filter on",
@@ -1707,6 +1712,24 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -1820,13 +1843,14 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -1893,6 +1917,24 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		return NewScopesValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewScopesValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -2006,13 +2048,14 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -2084,21 +2127,23 @@ func (t ScopesType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ScopesValue{}
 
 type ScopesValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	ScopesType  basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	ScopesType      basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -2112,7 +2157,15 @@ func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -2205,11 +2258,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -2217,11 +2271,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -2238,12 +2293,13 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.ScopesType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.ScopesType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -2262,6 +2318,10 @@ func (v ScopesValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -2301,11 +2361,12 @@ func (v ScopesValue) Type(ctx context.Context) attr.Type {
 
 func (v ScopesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/datasource_budgets/budgets_data_source_gen.go
+++ b/internal/provider/datasource_budgets/budgets_data_source_gen.go
@@ -76,6 +76,11 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 						"scopes": schema.ListNestedAttribute{
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
+									"case_insensitive": schema.BoolAttribute{
+										Computed:            true,
+										Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+										MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									},
 									"id": schema.StringAttribute{
 										Computed:            true,
 										Description:         "The field to filter on",
@@ -1814,6 +1819,24 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -1927,13 +1950,14 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -2000,6 +2024,24 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		return NewScopesValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewScopesValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -2113,13 +2155,14 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -2191,21 +2234,23 @@ func (t ScopesType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ScopesValue{}
 
 type ScopesValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	ScopesType  basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	ScopesType      basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -2219,7 +2264,15 @@ func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -2312,11 +2365,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -2324,11 +2378,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -2345,12 +2400,13 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.ScopesType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.ScopesType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -2369,6 +2425,10 @@ func (v ScopesValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -2408,11 +2468,12 @@ func (v ScopesValue) Type(ctx context.Context) attr.Type {
 
 func (v ScopesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/datasource_report/report_data_source_gen.go
+++ b/internal/provider/datasource_report/report_data_source_gen.go
@@ -113,6 +113,11 @@ func ReportDataSourceSchema(ctx context.Context) schema.Schema {
 					"filters": schema.ListNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
+								"case_insensitive": schema.BoolAttribute{
+									Computed:            true,
+									Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+								},
 								"id": schema.StringAttribute{
 									Computed:            true,
 									Description:         "The field to filter on",
@@ -3421,6 +3426,24 @@ func (t FiltersType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -3534,13 +3557,14 @@ func (t FiltersType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 	}
 
 	return FiltersValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		FiltersType: typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		FiltersType:     typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -3607,6 +3631,24 @@ func NewFiltersValue(attributeTypes map[string]attr.Type, attributes map[string]
 		return NewFiltersValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewFiltersValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -3720,13 +3762,14 @@ func NewFiltersValue(attributeTypes map[string]attr.Type, attributes map[string]
 	}
 
 	return FiltersValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		FiltersType: typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		FiltersType:     typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -3798,21 +3841,23 @@ func (t FiltersType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = FiltersValue{}
 
 type FiltersValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	FiltersType basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	FiltersType     basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v FiltersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -3826,7 +3871,15 @@ func (v FiltersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -3919,11 +3972,12 @@ func (v FiltersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -3931,11 +3985,12 @@ func (v FiltersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -3952,12 +4007,13 @@ func (v FiltersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.FiltersType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.FiltersType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -3976,6 +4032,10 @@ func (v FiltersValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -4015,11 +4075,12 @@ func (v FiltersValue) Type(ctx context.Context) attr.Type {
 
 func (v FiltersValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -2583,6 +2583,9 @@ type AllocationAllocationType string
 // When the type is "allocation_rule", the component references existing allocation rules (nested allocation rules).
 // A maximum nesting depth of 3 levels is supported, and circular references are not allowed.
 type AllocationComponent struct {
+	// CaseInsensitive If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+	CaseInsensitive *bool `json:"caseInsensitive,omitempty"`
+
 	// IncludeNull Include null values.
 	IncludeNull *bool `json:"include_null,omitempty"`
 
@@ -2876,6 +2879,9 @@ type AttributionAPI struct {
 
 // AttributionComponent A filter component of an attribution.
 type AttributionComponent struct {
+	// CaseInsensitive If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+	CaseInsensitive *bool `json:"caseInsensitive,omitempty"`
+
 	// IncludeNull Include null value.
 	IncludeNull *bool `json:"include_null,omitempty"`
 
@@ -3909,6 +3915,9 @@ type ExternalConfigCustomTimeRange struct {
 // When using allocation rules as a filter, both the type and the ID must be "allocation_rule", and the values array contains the allocation rule IDs.
 // When using allocations as a filter, the type must be "allocation" and the ID is the actual allocation group ID.
 type ExternalConfigFilter struct {
+	// CaseInsensitive If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
+	CaseInsensitive *bool `json:"caseInsensitive,omitempty"`
+
 	// Id The field to filter on
 	Id string `json:"id"`
 

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -235,10 +235,11 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 			for i, f := range filters {
 				filterType := models.DimensionsTypes(f.FiltersType.ValueString())
 				externalFilters[i] = models.ExternalConfigFilter{
-					Id:          f.Id.ValueString(),
-					IncludeNull: f.IncludeNull.ValueBoolPointer(),
-					Inverse:     f.Inverse.ValueBoolPointer(),
-					Type:        filterType,
+					CaseInsensitive: f.CaseInsensitive.ValueBoolPointer(),
+					Id:              f.Id.ValueString(),
+					IncludeNull:     f.IncludeNull.ValueBoolPointer(),
+					Inverse:         f.Inverse.ValueBoolPointer(),
+					Type:            filterType,
 				}
 				if !f.Values.IsNull() && !f.Values.IsUnknown() {
 					var values []string
@@ -602,6 +603,7 @@ func (r *reportResource) populateState(ctx context.Context, state *reportResourc
 		var existingFilterIDs []string
 		var existingFilterIncludeNull []*bool
 		var existingFilterInverse []*bool
+		var existingFilterCaseInsensitive []*bool
 		if !state.Config.IsNull() && !state.Config.IsUnknown() &&
 			!state.Config.Filters.IsNull() && !state.Config.Filters.IsUnknown() {
 			var existingFilters []resource_report.FiltersValue
@@ -611,6 +613,7 @@ func (r *reportResource) populateState(ctx context.Context, state *reportResourc
 					existingFilterIDs = append(existingFilterIDs, ef.Id.ValueString())
 					existingFilterIncludeNull = append(existingFilterIncludeNull, ef.IncludeNull.ValueBoolPointer())
 					existingFilterInverse = append(existingFilterInverse, ef.Inverse.ValueBoolPointer())
+					existingFilterCaseInsensitive = append(existingFilterCaseInsensitive, ef.CaseInsensitive.ValueBoolPointer())
 				}
 			}
 		}
@@ -647,10 +650,20 @@ func (r *reportResource) populateState(ctx context.Context, state *reportResourc
 				inverseVal = types.BoolPointerValue(nil)
 			}
 
+			// The API may not reliably echo caseInsensitive — always prefer the plan/state
+			// value when available.
+			caseInsensitiveVal := types.BoolValue(false)
+			if i < len(existingFilterCaseInsensitive) && existingFilterCaseInsensitive[i] != nil {
+				caseInsensitiveVal = types.BoolValue(*existingFilterCaseInsensitive[i])
+			} else if f.CaseInsensitive != nil {
+				caseInsensitiveVal = types.BoolValue(*f.CaseInsensitive)
+			}
+
 			m := map[string]attr.Value{
-				"id":           types.StringValue(fID),
-				"include_null": includeNullVal,
-				"inverse":      inverseVal,
+				"case_insensitive": caseInsensitiveVal,
+				"id":               types.StringValue(fID),
+				"include_null":     includeNullVal,
+				"inverse":          inverseVal,
 				// filters type enum cast
 				"type": types.StringValue(fType),
 				"mode": types.StringValue(string(f.Mode)),

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -253,11 +253,12 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 		for i, f := range *config.Filters {
 			fType := string(f.Type)
 			m := map[string]attr.Value{
-				"id":           types.StringValue(f.Id),
-				"include_null": types.BoolPointerValue(f.IncludeNull),
-				"inverse":      types.BoolPointerValue(f.Inverse),
-				"type":         types.StringValue(fType),
-				"mode":         types.StringValue(string(f.Mode)),
+				"case_insensitive": types.BoolPointerValue(f.CaseInsensitive),
+				"id":               types.StringValue(f.Id),
+				"include_null":     types.BoolPointerValue(f.IncludeNull),
+				"inverse":          types.BoolPointerValue(f.Inverse),
+				"type":             types.StringValue(fType),
+				"mode":             types.StringValue(string(f.Mode)),
 			}
 
 			if f.Values != nil {

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -1979,6 +1979,48 @@ func TestAccReport_FilterValuesPreservedOnUpdate(t *testing.T) {
 	})
 }
 
+// TestAccReport_CaseInsensitive tests that the case_insensitive property on report filters
+// round-trips correctly without causing drift. Uses mode="contains" with a lowercase
+// value to exercise the case-insensitive matching path.
+func TestAccReport_CaseInsensitive(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportWithCaseInsensitive(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_report.this",
+						tfjsonpath.New("config").AtMapKey("filters"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("fixed"),
+								"id":               knownvalue.StringExact("country"),
+								"mode":             knownvalue.StringExact("contains"),
+								"case_insensitive": knownvalue.Bool(true),
+								"values":           knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("be")}),
+							}),
+						}),
+					),
+				},
+			},
+			// Verify no drift on re-apply
+			{
+				Config: testAccReportWithCaseInsensitive(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 // Step 1: Report with filter, no labels.
 func testAccReportFilterValuesStep1(i int) string {
 	return fmt.Sprintf(`
@@ -2045,6 +2087,37 @@ resource "doit_report" "filter_update" {
     }
 }
 `, i, i)
+}
+
+func testAccReportWithCaseInsensitive(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "this" {
+    name = "test-case-insensitive-%d"
+	description = "Report testing case_insensitive filter property"
+	config = {
+		metric = {
+		  type  = "basic"
+		  value = "cost"
+		}
+		aggregation   = "total"
+		time_interval = "month"
+		filters = [
+		  {
+			id               = "country"
+			type             = "fixed"
+			inverse          = false
+			case_insensitive = true
+			values           = ["be"]
+			mode             = "contains"
+		  }
+		]
+		data_source    = "billing"
+		display_values = "actuals_only"
+		currency       = "USD"
+		layout         = "table"
+	}
+}
+`, i)
 }
 
 // TestAccReport_FilterWithoutInverse verifies that a filter config omitting

--- a/internal/provider/resource_alert/alert_resource_gen.go
+++ b/internal/provider/resource_alert/alert_resource_gen.go
@@ -119,6 +119,13 @@ func AlertResourceSchema(ctx context.Context) schema.Schema {
 					"scopes": schema.ListNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
+								"case_insensitive": schema.BoolAttribute{
+									Optional:            true,
+									Computed:            true,
+									Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									Default:             booldefault.StaticBool(false),
+								},
 								"id": schema.StringAttribute{
 									Required:            true,
 									Description:         "The field to filter on",
@@ -1564,6 +1571,24 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -1677,13 +1702,14 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -1750,6 +1776,24 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		return NewScopesValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewScopesValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -1863,13 +1907,14 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -1941,21 +1986,23 @@ func (t ScopesType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ScopesValue{}
 
 type ScopesValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	ScopesType  basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	ScopesType      basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -1969,7 +2016,15 @@ func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -2062,11 +2117,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -2074,11 +2130,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -2095,12 +2152,13 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.ScopesType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.ScopesType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -2119,6 +2177,10 @@ func (v ScopesValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -2158,11 +2220,12 @@ func (v ScopesValue) Type(ctx context.Context) attr.Type {
 
 func (v ScopesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/resource_allocation/allocation_resource_gen.go
+++ b/internal/provider/resource_allocation/allocation_resource_gen.go
@@ -56,6 +56,13 @@ func AllocationResourceSchema(ctx context.Context) schema.Schema {
 					"components": schema.ListNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
+								"case_insensitive": schema.BoolAttribute{
+									Optional:            true,
+									Computed:            true,
+									Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									Default:             booldefault.StaticBool(false),
+								},
 								"include_null": schema.BoolAttribute{
 									Optional:            true,
 									Computed:            true,
@@ -159,6 +166,13 @@ func AllocationResourceSchema(ctx context.Context) schema.Schema {
 						"components": schema.ListNestedAttribute{
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
+									"case_insensitive": schema.BoolAttribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+										MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+										Default:             booldefault.StaticBool(false),
+									},
 									"include_null": schema.BoolAttribute{
 										Optional:            true,
 										Computed:            true,
@@ -715,6 +729,24 @@ func (t ComponentsType) ValueFromObject(ctx context.Context, in basetypes.Object
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	includeNullAttribute, ok := attributes["include_null"]
 
 	if !ok {
@@ -828,6 +860,7 @@ func (t ComponentsType) ValueFromObject(ctx context.Context, in basetypes.Object
 	}
 
 	return ComponentsValue{
+		CaseInsensitive:  caseInsensitiveVal,
 		IncludeNull:      includeNullVal,
 		InverseSelection: inverseSelectionVal,
 		Key:              keyVal,
@@ -901,6 +934,24 @@ func NewComponentsValue(attributeTypes map[string]attr.Type, attributes map[stri
 		return NewComponentsValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewComponentsValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	includeNullAttribute, ok := attributes["include_null"]
 
 	if !ok {
@@ -1014,6 +1065,7 @@ func NewComponentsValue(attributeTypes map[string]attr.Type, attributes map[stri
 	}
 
 	return ComponentsValue{
+		CaseInsensitive:  caseInsensitiveVal,
 		IncludeNull:      includeNullVal,
 		InverseSelection: inverseSelectionVal,
 		Key:              keyVal,
@@ -1092,6 +1144,7 @@ func (t ComponentsType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ComponentsValue{}
 
 type ComponentsValue struct {
+	CaseInsensitive  basetypes.BoolValue   `tfsdk:"case_insensitive"`
 	IncludeNull      basetypes.BoolValue   `tfsdk:"include_null"`
 	InverseSelection basetypes.BoolValue   `tfsdk:"inverse_selection"`
 	Key              basetypes.StringValue `tfsdk:"key"`
@@ -1102,11 +1155,12 @@ type ComponentsValue struct {
 }
 
 func (v ComponentsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse_selection"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
@@ -1120,7 +1174,15 @@ func (v ComponentsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, e
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.IncludeNull.ToTerraformValue(ctx)
 
@@ -1213,6 +1275,7 @@ func (v ComponentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVal
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
+			"case_insensitive":  basetypes.BoolType{},
 			"include_null":      basetypes.BoolType{},
 			"inverse_selection": basetypes.BoolType{},
 			"key":               basetypes.StringType{},
@@ -1225,6 +1288,7 @@ func (v ComponentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVal
 	}
 
 	attributeTypes := map[string]attr.Type{
+		"case_insensitive":  basetypes.BoolType{},
 		"include_null":      basetypes.BoolType{},
 		"inverse_selection": basetypes.BoolType{},
 		"key":               basetypes.StringType{},
@@ -1246,6 +1310,7 @@ func (v ComponentsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVal
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
+			"case_insensitive":  v.CaseInsensitive,
 			"include_null":      v.IncludeNull,
 			"inverse_selection": v.InverseSelection,
 			"key":               v.Key,
@@ -1270,6 +1335,10 @@ func (v ComponentsValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.IncludeNull.Equal(other.IncludeNull) {
@@ -1309,6 +1378,7 @@ func (v ComponentsValue) Type(ctx context.Context) attr.Type {
 
 func (v ComponentsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
+		"case_insensitive":  basetypes.BoolType{},
 		"include_null":      basetypes.BoolType{},
 		"inverse_selection": basetypes.BoolType{},
 		"key":               basetypes.StringType{},

--- a/internal/provider/resource_budget/budget_resource_gen.go
+++ b/internal/provider/resource_budget/budget_resource_gen.go
@@ -255,6 +255,13 @@ func BudgetResourceSchema(ctx context.Context) schema.Schema {
 			"scopes": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"case_insensitive": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+							MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+							Default:             booldefault.StaticBool(false),
+						},
 						"id": schema.StringAttribute{
 							Required:            true,
 							Description:         "The field to filter on",
@@ -1835,6 +1842,24 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -1948,13 +1973,14 @@ func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -2021,6 +2047,24 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		return NewScopesValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewScopesValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -2134,13 +2178,14 @@ func NewScopesValue(attributeTypes map[string]attr.Type, attributes map[string]a
 	}
 
 	return ScopesValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		ScopesType:  typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		ScopesType:      typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -2212,21 +2257,23 @@ func (t ScopesType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = ScopesValue{}
 
 type ScopesValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	ScopesType  basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	ScopesType      basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -2240,7 +2287,15 @@ func (v ScopesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -2333,11 +2388,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -2345,11 +2401,12 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -2366,12 +2423,13 @@ func (v ScopesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.ScopesType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.ScopesType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -2390,6 +2448,10 @@ func (v ScopesValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -2429,11 +2491,12 @@ func (v ScopesValue) Type(ctx context.Context) attr.Type {
 
 func (v ScopesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -200,6 +200,13 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 					"filters": schema.ListNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
+								"case_insensitive": schema.BoolAttribute{
+									Optional:            true,
+									Computed:            true,
+									Description:         "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									MarkdownDescription: "If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.",
+									Default:             booldefault.StaticBool(false),
+								},
 								"id": schema.StringAttribute{
 									Required:            true,
 									Description:         "The field to filter on",
@@ -3790,6 +3797,24 @@ func (t FiltersType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 
 	attributes := in.Attributes()
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return nil, diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -3903,13 +3928,14 @@ func (t FiltersType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 	}
 
 	return FiltersValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		FiltersType: typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		FiltersType:     typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -3976,6 +4002,24 @@ func NewFiltersValue(attributeTypes map[string]attr.Type, attributes map[string]
 		return NewFiltersValueUnknown(), diags
 	}
 
+	caseInsensitiveAttribute, ok := attributes["case_insensitive"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`case_insensitive is missing from object`)
+
+		return NewFiltersValueUnknown(), diags
+	}
+
+	caseInsensitiveVal, ok := caseInsensitiveAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`case_insensitive expected to be basetypes.BoolValue, was: %T`, caseInsensitiveAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -4089,13 +4133,14 @@ func NewFiltersValue(attributeTypes map[string]attr.Type, attributes map[string]
 	}
 
 	return FiltersValue{
-		Id:          idVal,
-		IncludeNull: includeNullVal,
-		Inverse:     inverseVal,
-		Mode:        modeVal,
-		FiltersType: typeVal,
-		Values:      valuesVal,
-		state:       attr.ValueStateKnown,
+		CaseInsensitive: caseInsensitiveVal,
+		Id:              idVal,
+		IncludeNull:     includeNullVal,
+		Inverse:         inverseVal,
+		Mode:            modeVal,
+		FiltersType:     typeVal,
+		Values:          valuesVal,
+		state:           attr.ValueStateKnown,
 	}, diags
 }
 
@@ -4167,21 +4212,23 @@ func (t FiltersType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = FiltersValue{}
 
 type FiltersValue struct {
-	Id          basetypes.StringValue `tfsdk:"id"`
-	IncludeNull basetypes.BoolValue   `tfsdk:"include_null"`
-	Inverse     basetypes.BoolValue   `tfsdk:"inverse"`
-	Mode        basetypes.StringValue `tfsdk:"mode"`
-	FiltersType basetypes.StringValue `tfsdk:"type"`
-	Values      basetypes.ListValue   `tfsdk:"values"`
-	state       attr.ValueState
+	CaseInsensitive basetypes.BoolValue   `tfsdk:"case_insensitive"`
+	Id              basetypes.StringValue `tfsdk:"id"`
+	IncludeNull     basetypes.BoolValue   `tfsdk:"include_null"`
+	Inverse         basetypes.BoolValue   `tfsdk:"inverse"`
+	Mode            basetypes.StringValue `tfsdk:"mode"`
+	FiltersType     basetypes.StringValue `tfsdk:"type"`
+	Values          basetypes.ListValue   `tfsdk:"values"`
+	state           attr.ValueState
 }
 
 func (v FiltersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 6)
+	attrTypes := make(map[string]tftypes.Type, 7)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["case_insensitive"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["include_null"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["inverse"] = basetypes.BoolType{}.TerraformType(ctx)
@@ -4195,7 +4242,15 @@ func (v FiltersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 6)
+		vals := make(map[string]tftypes.Value, 7)
+
+		val, err = v.CaseInsensitive.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["case_insensitive"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -4288,11 +4343,12 @@ func (v FiltersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
-			"id":           basetypes.StringType{},
-			"include_null": basetypes.BoolType{},
-			"inverse":      basetypes.BoolType{},
-			"mode":         basetypes.StringType{},
-			"type":         basetypes.StringType{},
+			"case_insensitive": basetypes.BoolType{},
+			"id":               basetypes.StringType{},
+			"include_null":     basetypes.BoolType{},
+			"inverse":          basetypes.BoolType{},
+			"mode":             basetypes.StringType{},
+			"type":             basetypes.StringType{},
 			"values": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -4300,11 +4356,12 @@ func (v FiltersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -4321,12 +4378,13 @@ func (v FiltersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"id":           v.Id,
-			"include_null": v.IncludeNull,
-			"inverse":      v.Inverse,
-			"mode":         v.Mode,
-			"type":         v.FiltersType,
-			"values":       valuesVal,
+			"case_insensitive": v.CaseInsensitive,
+			"id":               v.Id,
+			"include_null":     v.IncludeNull,
+			"inverse":          v.Inverse,
+			"mode":             v.Mode,
+			"type":             v.FiltersType,
+			"values":           valuesVal,
 		})
 
 	return objVal, diags
@@ -4345,6 +4403,10 @@ func (v FiltersValue) Equal(o attr.Value) bool {
 
 	if v.state != attr.ValueStateKnown {
 		return true
+	}
+
+	if !v.CaseInsensitive.Equal(other.CaseInsensitive) {
+		return false
 	}
 
 	if !v.Id.Equal(other.Id) {
@@ -4384,11 +4446,12 @@ func (v FiltersValue) Type(ctx context.Context) attr.Type {
 
 func (v FiltersValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           basetypes.StringType{},
-		"include_null": basetypes.BoolType{},
-		"inverse":      basetypes.BoolType{},
-		"mode":         basetypes.StringType{},
-		"type":         basetypes.StringType{},
+		"case_insensitive": basetypes.BoolType{},
+		"id":               basetypes.StringType{},
+		"include_null":     basetypes.BoolType{},
+		"inverse":          basetypes.BoolType{},
+		"mode":             basetypes.StringType{},
+		"type":             basetypes.StringType{},
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},


### PR DESCRIPTION
## Summary

Add support for the `caseInsensitive` attribute across alert, budget, report, and allocation resources and data sources. This attribute allows users to specify case-insensitive matching for filter values when using `starts_with`, `ends_with`, or `contains` modes.

## Changes

### Resources (request construction + response mapping)
- **Alert** (`alert.go`): Map `case_insensitive` in scope construction and `mapAlertConfigToModel` with state-preservation
- **Budget** (`budget.go`): Map `case_insensitive` in scope construction and `mapBudgetScopesToModel` with state-preservation
- **Report** (`report.go`): Map `case_insensitive` in filter construction and response mapping with state-preservation
- **Allocation** (`allocation.go`): Map `case_insensitive` in component construction and `toAllocationRuleComponentsListValue` with state-preservation

### Data Sources (response mapping)
- `alert_data_source.go`, `alerts_data_source.go`
- `budget_data_source.go`, `budgets_data_source.go`
- `report_data_source.go`
- `allocation_data_source.go`

### OpenAPI Spec & Code Generation
- Updated `openapi_spec_full.yml` to include `caseInsensitive` for `ExternalConfigFilter` and `AllocationComponent`
- Regenerated schemas and models via `make generate`

### Tests
- `TestAccAlert_CaseInsensitive` — validates round-trip with `case_insensitive = true`
- `TestAccBudget_CaseInsensitive` — validates round-trip with `case_insensitive = true`
- `TestAccReport_CaseInsensitive` — validates round-trip with `case_insensitive = true` and `mode = "contains"`
- `TestAccAllocation_CaseInsensitive` — validates round-trip with `case_insensitive = true`

All tests pass locally ✅

## State Preservation

The `case_insensitive` attribute uses the same state-preservation pattern as `include_null` and `inverse_selection` for consistency and as a safety measure against potential API echo regressions.

## Validation

`caseInsensitive` is only valid with `starts_with`, `ends_with`, and `contains` modes. The attribute is accepted by the API for other modes but has no effect.
