### PR TITLE
chore: sync Ava spec and regenerate models

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -1901,6 +1901,13 @@
 						}
 					},
 					{
+						"name": "answer_id",
+						"string": {
+							"computed_optional_required": "computed",
+							"description": "The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint."
+						}
+					},
+					{
 						"name": "conversation_id",
 						"string": {
 							"computed_optional_required": "computed",

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -6614,6 +6614,9 @@ components:
         question:
           type: string
           description: The question to ask Ava.
+        conversationId:
+          type: string
+          description: Optional ID of an existing conversation to continue.
       required:
         - question
     AvaAskSyncRequest:
@@ -6640,6 +6643,9 @@ components:
         conversationId:
           type: string
           description: The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.
+        answerId:
+          type: string
+          description: The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.
       required:
         - answer
     AvaFeedbackRequest:

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -3440,6 +3440,9 @@ components:
         question:
           type: string
           description: The question to ask Ava.
+        conversationId:
+          type: string
+          description: Optional ID of an existing conversation to continue.
       required:
         - question
     AvaAskSyncRequest:
@@ -3466,6 +3469,9 @@ components:
         conversationId:
           type: string
           description: The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.
+        answerId:
+          type: string
+          description: The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.
       required:
         - answer
     AvaFeedbackRequest:

--- a/internal/provider/datasource_ava/ava_data_source_gen.go
+++ b/internal/provider/datasource_ava/ava_data_source_gen.go
@@ -17,6 +17,11 @@ func AvaDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The Ava response text.",
 				MarkdownDescription: "The Ava response text.",
 			},
+			"answer_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.",
+				MarkdownDescription: "The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.",
+			},
 			"conversation_id": schema.StringAttribute{
 				Computed:            true,
 				Description:         "The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.",
@@ -30,5 +35,6 @@ func AvaDataSourceSchema(ctx context.Context) schema.Schema {
 
 type AvaModel struct {
 	Answer         types.String `tfsdk:"answer"`
+	AnswerId       types.String `tfsdk:"answer_id"`
 	ConversationId types.String `tfsdk:"conversation_id"`
 }

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -2717,6 +2717,9 @@ type AssignObjectsToLabelRequest struct {
 
 // AvaAskRequest defines model for AvaAskRequest.
 type AvaAskRequest struct {
+	// ConversationId Optional ID of an existing conversation to continue.
+	ConversationId *string `json:"conversationId,omitempty"`
+
 	// Question The question to ask Ava.
 	Question string `json:"question"`
 }
@@ -2737,6 +2740,9 @@ type AvaAskSyncRequest struct {
 type AvaAskSyncResponse struct {
 	// Answer The Ava response text.
 	Answer string `json:"answer"`
+
+	// AnswerId The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.
+	AnswerId *string `json:"answerId,omitempty"`
 
 	// ConversationId The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.
 	ConversationId *string `json:"conversationId,omitempty"`


### PR DESCRIPTION
## Summary

The upstream Ava API (`AvaAskSyncResponse`) added two new fields:
- `answerId`
- `conversationId`

This PR syncs the OpenAPI specs and regenerates the Go models and tfplugingen schema output via `make generate`.

## What's changed

| File | Change |
|------|--------|
| `OpenAPI/openapi_spec_full.yml` | Added `answerId` and `conversationId` to `AvaAskSyncResponse` |
| `OpenAPI/openapi_spec_processed.yml` | Same |
| `OpenAPI/2_tfplugingen-framework/output_datasources.json` | Regenerated |
| `internal/provider/datasource_ava/ava_data_source_gen.go` | Regenerated schema with new fields |
| `internal/provider/models/models_gen.go` | Regenerated Go models with new fields |

## What's intentionally NOT changed

The `doit_ava` data source implementation (`ava_data_source.go`) is unchanged. Both `answer_id` and `conversation_id` are **always `null`** when `ephemeral: true`, which is the mode this provider always uses. Exposing null-only fields in the schema was intentionally rejected in #135.