### PR TITLE
test: add drift detection steps to acceptance tests

### DIFF
--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -47,6 +47,15 @@ func TestAccAllocation(t *testing.T) {
 					},
 				},
 			},
+			// Drift detection: re-apply same config, expect no changes.
+			{
+				Config: testAccAllocationSingle(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 			{
 				Config: testAccAllocationSingleUpdate(rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -102,6 +111,15 @@ func TestAccAllocation_Group(t *testing.T) {
 						"doit_allocation.group",
 						tfjsonpath.New("allocation_type"),
 						knownvalue.StringExact("group")),
+				},
+			},
+			// Drift detection: re-apply same config, expect no changes.
+			{
+				Config: testAccAllocationGroup(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
 				},
 			},
 			{

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -1525,7 +1525,7 @@ resource "doit_budget" "this" {
 
 // TestAccBudget_DriftDetection_CustomerPattern tests for drift using the
 // customer's exact pattern from ticket 300568: uses metric, growth_per_period,
-// recipients_slack_channels=[], and scopes with attribution type.
+// recipients_slack_channels=[], and a fixed cloud_provider scope.
 // These are the attributes the customer had to add ignore_changes for.
 func TestAccBudget_DriftDetection_CustomerPattern(t *testing.T) {
 	n := acctest.RandInt()
@@ -1546,12 +1546,13 @@ func TestAccBudget_DriftDetection_CustomerPattern(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("doit_budget.drift_test", plancheck.ResourceActionCreate),
 					},
 				},
 			},
 			// Drift detection: re-apply same config, expect no changes.
-			// This catches drift from: amount, seasonal_amounts, scope (deprecated),
-			// alerts[].forecasted_date, alerts[].triggered
+			// This catches drift from attributes exercised here: amount,
+			// recipients_slack_channels, scopes, and alerts[].percentage.
 			{
 				Config: testAccBudgetCustomerPattern(n),
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -53,6 +53,15 @@ func TestAccBudget(t *testing.T) {
 						knownvalue.StringExact("recurring")),
 				},
 			},
+			// Drift detection: re-apply same config, expect no changes.
+			{
+				Config: testAccBudget(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 			// Test Budget Update (In-place)
 			{
 				Config: testAccBudgetUpdate(n),
@@ -305,6 +314,15 @@ func TestAccBudget_Scopes(t *testing.T) {
 						},
 						),
 					),
+				},
+			},
+			// Drift detection: re-apply same config, expect no changes.
+			{
+				Config: testAccBudgetScopes(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
 				},
 			},
 		},
@@ -1503,4 +1521,86 @@ resource "doit_budget" "this" {
   start_period = local.start_period
 }
 `, budgetStartPeriod(), i, testUser())
+}
+
+// TestAccBudget_DriftDetection_CustomerPattern tests for drift using the
+// customer's exact pattern from ticket 300568: uses metric, growth_per_period,
+// recipients_slack_channels=[], and scopes with attribution type.
+// These are the attributes the customer had to add ignore_changes for.
+func TestAccBudget_DriftDetection_CustomerPattern(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetCustomerPattern(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+			},
+			// Drift detection: re-apply same config, expect no changes.
+			// This catches drift from: amount, seasonal_amounts, scope (deprecated),
+			// alerts[].forecasted_date, alerts[].triggered
+			{
+				Config: testAccBudgetCustomerPattern(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetCustomerPattern(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "drift_test" {
+  name              = "test-drift-customer-%d"
+  currency          = "USD"
+  type              = "recurring"
+  amount            = 100
+  time_interval     = "month"
+  growth_per_period = 1
+  metric            = "amortized_cost"
+  start_period      = local.start_period
+  recipients = [
+    "%s"
+  ]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 },
+    { "percentage" : 120 }
+  ]
+  use_prev_spend = false
+  # Customer sets this to empty list — potential drift source
+  recipients_slack_channels = []
+  scopes = [
+    {
+      type   = "fixed"
+      id     = "cloud_provider"
+      mode   = "is"
+      values = ["amazon-web-services"]
+    }
+  ]
+}
+`, budgetStartPeriod(), i, testUser(), testUser())
 }

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -36,6 +36,15 @@ func TestAccReport(t *testing.T) {
 					},
 				},
 			},
+			// Drift detection: re-apply same config, expect no changes.
+			{
+				Config: testAccReport(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 			{
 				Config: testAccReportUpdate(n),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -2446,6 +2455,77 @@ resource "doit_report" "this" {
         display_values = "actuals_only"
         currency       = "USD"
         layout         = "table"
+    }
+}
+`, i)
+}
+
+// TestAccReport_DriftDetection_CustomerPattern tests for drift using the
+// customer's exact pattern from ticket 300568: uses metrics (plural list)
+// instead of metric (singular), and does NOT set custom_time_range, metric,
+// or secondary_time_range. These are the attributes the customer had to add
+// ignore_changes blocks for.
+func TestAccReport_DriftDetection_CustomerPattern(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportCustomerPattern(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_report.drift_test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+			},
+			// Drift detection: re-apply same config, expect no changes.
+			// This catches drift from API-computed fields like custom_time_range,
+			// metric (singular), and secondary_time_range being returned by the
+			// API even when the user didn't set them.
+			{
+				Config: testAccReportCustomerPattern(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportCustomerPattern(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "drift_test" {
+    name        = "test-drift-customer-pattern-%d"
+    description = "Mirrors customer pattern: uses metrics (plural) and omits optional computed fields"
+    config = {
+        # Uses metrics (plural list) — NOT metric (singular)
+        metrics = [{
+            type  = "extended"
+            value = "amortized_cost"
+        }]
+        include_promotional_credits = false
+        advanced_analysis = {
+            trending_up   = false
+            trending_down = false
+            not_trending  = false
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        # Intentionally NOT setting: custom_time_range, metric, secondary_time_range
+        # These are the attributes the customer had to add ignore_changes for
+        data_source    = "billing"
+        display_values = "actuals_only"
+        layout         = "table"
+        currency       = "USD"
     }
 }
 `, i)


### PR DESCRIPTION
## Summary

Adds `ExpectEmptyPlan()` drift detection steps to allocation, budget, and report acceptance tests. After creating a resource, these steps re-apply the same config and verify no changes are planned.

## Context (Ticket 300568)

The customer reported having to add extensive `ignore_changes` blocks when upgrading from v1.0.0 to v1.3.0. Investigation revealed this was caused by **cross-version state migration** — new schema attributes (`case_insensitive`, `include_null`) added to nested objects (`scopes`, `filters`, `components`) between versions. Old state written by v1.0.0 didn't have these fields, causing Terraform to see `null → false` drift.

**Resolution for the customer**: Remove `ignore_changes` blocks and run `terraform apply -refresh-only` to re-sync state.

## Changes

### Drift detection steps added to existing tests:
- `TestAccAllocation` (single allocation)
- `TestAccAllocation_Group` (group allocation)
- `TestAccBudget` (recurring budget)
- `TestAccBudget_Scopes` (budget with scopes)
- `TestAccReport` (full report config)

### New customer-pattern tests:
- `TestAccReport_DriftDetection_CustomerPattern` — uses `metrics` (plural) and omits `custom_time_range`/`metric`/`secondary_time_range`
- `TestAccBudget_DriftDetection_CustomerPattern` — uses `metric`, `growth_per_period`, `recipients_slack_channels=[]`, `scopes`

All tests pass, confirming no drift on the current provider version.