### PR TITLE
docs: update description for cost_of_anomaly to clarify excess cost

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -1265,7 +1265,7 @@
 										"name": "cost_of_anomaly",
 										"float64": {
 											"computed_optional_required": "computed",
-											"description": "Cost of the anomaly over and above the expected normal cost."
+											"description": "Excess cost over and above the expected normal cost."
 										}
 									},
 									{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -3961,7 +3961,7 @@ components:
           description: Billing account ID.
         costOfAnomaly:
           type: number
-          description: Cost of the anomaly over and above the expected normal cost.
+          description: Excess cost over and above the expected normal cost.
           format: double
         id:
           type: string
@@ -6762,7 +6762,7 @@ components:
                 description: Billing account ID
               costOfAnomaly:
                 type: number
-                description: Cost of the anomaly over and above the expected normal cost
+                description: Excess cost over and above the expected normal cost
                 format: double
               platform:
                 type: string

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -3276,7 +3276,7 @@ components:
           description: Billing account ID.
         costOfAnomaly:
           type: number
-          description: Cost of the anomaly over and above the expected normal cost.
+          description: Excess cost over and above the expected normal cost.
           format: double
         id:
           type: string
@@ -6810,7 +6810,7 @@ components:
                 description: Billing account ID
               costOfAnomaly:
                 type: number
-                description: Cost of the anomaly over and above the expected normal cost
+                description: Excess cost over and above the expected normal cost
                 format: double
               platform:
                 type: string

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -103,7 +103,7 @@ Read-Only:
 - `acknowledged` (Boolean) Has the anomaly been acknowledged
 - `attribution` (String) Attribution ID.
 - `billing_account` (String) Billing account ID.
-- `cost_of_anomaly` (Number) Cost of the anomaly over and above the expected normal cost.
+- `cost_of_anomaly` (Number) Excess cost over and above the expected normal cost.
 - `end_time` (Number) End of the anomaly.
 - `id` (String)
 - `platform` (String) Cloud Provider name.

--- a/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
+++ b/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
@@ -38,8 +38,8 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 						},
 						"cost_of_anomaly": schema.Float64Attribute{
 							Computed:            true,
-							Description:         "Cost of the anomaly over and above the expected normal cost.",
-							MarkdownDescription: "Cost of the anomaly over and above the expected normal cost.",
+							Description:         "Excess cost over and above the expected normal cost.",
+							MarkdownDescription: "Excess cost over and above the expected normal cost.",
 						},
 						"end_time": schema.Int64Attribute{
 							Computed:            true,

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -2583,7 +2583,7 @@ type AnomalyItem struct {
 	// BillingAccount Billing account ID.
 	BillingAccount string `json:"billingAccount"`
 
-	// CostOfAnomaly Cost of the anomaly over and above the expected normal cost.
+	// CostOfAnomaly Excess cost over and above the expected normal cost.
 	CostOfAnomaly float64 `json:"costOfAnomaly"`
 
 	// EndTime End of the anomaly.


### PR DESCRIPTION
This pull request updates the description for the `cost_of_anomaly` field across the codebase and documentation to clarify its meaning. The description now consistently reads "Excess cost over and above the expected normal cost" instead of the previous wording. This change improves clarity for both developers and end users.

**API and Schema Documentation Updates:**

* Updated the description for the `cost_of_anomaly` field in the OpenAPI JSON schema (`OpenAPI/2_tfplugingen-framework/output_datasources.json`), OpenAPI YAML specs (`OpenAPI/openapi_spec_full.yml`, `OpenAPI/openapi_spec_processed.yml`), and the Markdown documentation (`docs/data-sources/anomalies.md`) to use the new wording. [[1]](diffhunk://#diff-ecc852b2651ff7f04d95524a117dfd0bdbc6e360803a765b78fe1686f351a4cbL1268-R1268) [[2]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3964-R3964) [[3]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL6765-R6765) [[4]](diffhunk://#diff-389d555bd5509e14e730dff6a1354d7cb61a2b9bf99e1a547a547513b508385cL3279-R3279) [[5]](diffhunk://#diff-389d555bd5509e14e730dff6a1354d7cb61a2b9bf99e1a547a547513b508385cL6813-R6813) [[6]](diffhunk://#diff-69be2407c8e86c7a20d3891b2c0ba5f81899906df9cbf78e0b54441829419cdbL106-R106)

**Provider Code Updates:**

* Updated the `Description` and `MarkdownDescription` for the `cost_of_anomaly` attribute in the Terraform provider schema (`internal/provider/datasource_anomalies/anomalies_data_source_gen.go`).
* Updated the struct field comment for `CostOfAnomaly` in the provider models to match the new description (`internal/provider/models/models_gen.go`).