### PR TITLE
fix(allocation): adopt plan-first state pattern to prevent inconsistent result errors

### DIFF
--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -51,7 +51,8 @@ func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceM
 		plan.AllocationType = types.StringNull()
 	}
 
-	// Optional+Computed fields at top level: resolve unknowns to null.
+	// Optional+Computed fields at top level: resolve unknowns using the API
+	// response where available, falling back to null.
 	if plan.Rules.IsUnknown() {
 		plan.Rules = types.ListNull(resource_allocation.RulesValue{}.Type(ctx))
 	}
@@ -59,7 +60,7 @@ func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceM
 		plan.Rule = resource_allocation.NewRuleValueNull()
 	}
 	if plan.UnallocatedCosts.IsUnknown() {
-		plan.UnallocatedCosts = types.StringNull()
+		plan.UnallocatedCosts = types.StringPointerValue(apiResp.UnallocatedCosts)
 	}
 
 	// Resolve unknowns inside rules[] elements.
@@ -70,25 +71,41 @@ func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceM
 		if d := plan.Rules.ElementsAs(ctx, &planRules, false); !d.HasError() {
 			changed := false
 			for i := range planRules {
+				// For each unknown Optional+Computed field, overlay the API
+				// response value (which may contain a generated default like
+				// formula="A") instead of null. This prevents perpetual drift
+				// where Read returns the API default but state has null.
+				apiRule := safeGetGroupRule(apiResp, i)
 				if planRules[i].Description.IsUnknown() {
-					planRules[i].Description = types.StringNull()
+					if apiRule != nil {
+						planRules[i].Description = types.StringPointerValue(apiRule.Description)
+					} else {
+						planRules[i].Description = types.StringNull()
+					}
 					changed = true
 				}
 				if planRules[i].Id.IsUnknown() {
-					// Overlay ID from API response for "create" actions (API assigns it).
-					if apiResp.Rules != nil && i < len(*apiResp.Rules) && (*apiResp.Rules)[i] != nil && (*apiResp.Rules)[i].Id != nil {
-						planRules[i].Id = types.StringValue(*(*apiResp.Rules)[i].Id)
+					if apiRule != nil {
+						planRules[i].Id = types.StringPointerValue(apiRule.Id)
 					} else {
 						planRules[i].Id = types.StringNull()
 					}
 					changed = true
 				}
 				if planRules[i].Formula.IsUnknown() {
-					planRules[i].Formula = types.StringNull()
+					if apiRule != nil {
+						planRules[i].Formula = types.StringPointerValue(apiRule.Formula)
+					} else {
+						planRules[i].Formula = types.StringNull()
+					}
 					changed = true
 				}
 				if planRules[i].Name.IsUnknown() {
-					planRules[i].Name = types.StringNull()
+					if apiRule != nil {
+						planRules[i].Name = types.StringPointerValue(apiRule.Name)
+					} else {
+						planRules[i].Name = types.StringNull()
+					}
 					changed = true
 				}
 				if planRules[i].Components.IsUnknown() {
@@ -116,16 +133,33 @@ func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceM
 		}
 	}
 
-	// Resolve unknowns inside single rule's components.
-	if !plan.Rule.IsNull() && !plan.Rule.IsUnknown() &&
-		!plan.Rule.Components.IsNull() && !plan.Rule.Components.IsUnknown() {
-		resolved, compDiags := resolveComponentUnknowns(ctx, &plan.Rule.Components)
-		diags.Append(compDiags...)
-		if resolved {
-			// Rebuild the Rule value with updated components.
+	// Resolve unknowns inside single rule (formula and components).
+	if !plan.Rule.IsNull() && !plan.Rule.IsUnknown() {
+		changed := false
+		formula := plan.Rule.Formula
+		if formula.IsUnknown() {
+			if apiResp.Rule != nil {
+				formula = types.StringValue(apiResp.Rule.Formula)
+			} else {
+				formula = types.StringNull()
+			}
+			changed = true
+		}
+
+		components := plan.Rule.Components
+		if !components.IsNull() && !components.IsUnknown() {
+			resolved, compDiags := resolveComponentUnknowns(ctx, &components)
+			diags.Append(compDiags...)
+			if resolved {
+				changed = true
+			}
+		}
+
+		if changed {
+			// Rebuild the Rule value with updated components and formula.
 			m := map[string]attr.Value{
-				"formula":    plan.Rule.Formula,
-				"components": plan.Rule.Components,
+				"formula":    formula,
+				"components": components,
 			}
 			var ruleDiags diag.Diagnostics
 			plan.Rule, ruleDiags = resource_allocation.NewRuleValue(resource_allocation.RuleValue{}.AttributeTypes(ctx), m)
@@ -134,6 +168,15 @@ func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceM
 	}
 
 	return diags
+}
+
+// safeGetGroupRule returns the API response's group rule at index i, or nil if
+// the index is out of bounds or the rules slice is nil.
+func safeGetGroupRule(apiResp *models.Allocation, i int) *models.GroupAllocationRule {
+	if apiResp.Rules == nil || i >= len(*apiResp.Rules) {
+		return nil
+	}
+	return (*apiResp.Rules)[i]
 }
 
 // resolveComponentUnknowns resolves unknown Optional+Computed fields inside

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -34,9 +34,8 @@ import (
 // normalizing user-provided values (e.g. stripping [Service N/A] sentinels,
 // renaming "Amazon Elastic Container Service for Kubernetes (EKS)" to
 // "Amazon Elastic Container Service for Kubernetes").
-func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
+func overlayComputedFields(ctx context.Context, apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
-	ctx := context.Background()
 
 	// Computed-only fields: always set from API response.
 	plan.Id = types.StringPointerValue(apiResp.Id)
@@ -68,7 +67,9 @@ func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceM
 	// When the user doesn't set them, they arrive as unknown.
 	if !plan.Rules.IsNull() && !plan.Rules.IsUnknown() {
 		var planRules []resource_allocation.RulesValue
-		if d := plan.Rules.ElementsAs(ctx, &planRules, false); !d.HasError() {
+		elementsDiags := plan.Rules.ElementsAs(ctx, &planRules, false)
+		diags.Append(elementsDiags...)
+		if !elementsDiags.HasError() {
 			changed := false
 			for i := range planRules {
 				// For each unknown Optional+Computed field, overlay the API
@@ -109,11 +110,7 @@ func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceM
 					changed = true
 				}
 				if planRules[i].Components.IsUnknown() {
-					emptyComps, compDiags := types.ListValueFrom(ctx, resource_allocation.ComponentsValue{}.Type(ctx), []resource_allocation.ComponentsValue{})
-					diags.Append(compDiags...)
-					if !compDiags.HasError() {
-						planRules[i].Components = emptyComps
-					}
+					planRules[i].Components = types.ListNull(resource_allocation.ComponentsValue{}.Type(ctx))
 					changed = true
 				}
 				// Also resolve unknowns inside components.
@@ -662,9 +659,12 @@ func toAllocationRuleComponentsListValue(ctx context.Context, components []model
 		apiValues := component.Values
 		if i < len(existingComponents) {
 			var stateVals []string
-			if d := existingComponents[i].Values.ElementsAs(ctx, &stateVals, false); !d.HasError() {
-				apiValues = mergeSentinelValues(apiValues, stateVals, apiIncludeNull)
+			stateValsDiags := existingComponents[i].Values.ElementsAs(ctx, &stateVals, false)
+			diags.Append(stateValsDiags...)
+			if diags.HasError() {
+				return
 			}
+			apiValues = mergeSentinelValues(apiValues, stateVals, apiIncludeNull)
 		}
 		values := make([]attr.Value, len(apiValues))
 		for j := range apiValues {

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -15,6 +15,162 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
+// overlayComputedFields sets only the Computed-only fields from the API response
+// onto the plan model. This implements the plan-first state pattern recommended
+// by HashiCorp (https://developer.hashicorp.com/terraform/plugin/framework/resources/create):
+//
+// All user-configured values (name, description, rule, rules, unallocated_costs)
+// stay exactly as the user wrote them in the plan. Only server-assigned values
+// that the user cannot configure are overlaid from the API response:
+//
+//   - id: assigned by the API on creation
+//   - allocation_type: computed from whether rule or rules was provided
+//   - anomaly_detection: server-managed flag
+//   - create_time: set by the API on creation
+//   - update_time: set by the API on every modification
+//   - type: computed by the API (preset vs custom)
+//
+// This prevents "Provider produced inconsistent result" errors caused by the API
+// normalizing user-provided values (e.g. stripping [Service N/A] sentinels,
+// renaming "Amazon Elastic Container Service for Kubernetes (EKS)" to
+// "Amazon Elastic Container Service for Kubernetes").
+func overlayComputedFields(apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	ctx := context.Background()
+
+	// Computed-only fields: always set from API response.
+	plan.Id = types.StringPointerValue(apiResp.Id)
+	plan.CreateTime = types.Int64PointerValue(apiResp.CreateTime)
+	plan.UpdateTime = types.Int64PointerValue(apiResp.UpdateTime)
+	plan.AnomalyDetection = types.BoolPointerValue(apiResp.AnomalyDetection)
+	plan.Type = types.StringPointerValue(apiResp.Type)
+
+	if apiResp.AllocationType != nil {
+		plan.AllocationType = types.StringValue(string(*apiResp.AllocationType))
+	} else {
+		plan.AllocationType = types.StringNull()
+	}
+
+	// Optional+Computed fields at top level: resolve unknowns to null.
+	if plan.Rules.IsUnknown() {
+		plan.Rules = types.ListNull(resource_allocation.RulesValue{}.Type(ctx))
+	}
+	if plan.Rule.IsUnknown() {
+		plan.Rule = resource_allocation.NewRuleValueNull()
+	}
+	if plan.UnallocatedCosts.IsUnknown() {
+		plan.UnallocatedCosts = types.StringNull()
+	}
+
+	// Resolve unknowns inside rules[] elements.
+	// Fields like 'description', 'id' inside each rule are Optional+Computed.
+	// When the user doesn't set them, they arrive as unknown.
+	if !plan.Rules.IsNull() && !plan.Rules.IsUnknown() {
+		var planRules []resource_allocation.RulesValue
+		if d := plan.Rules.ElementsAs(ctx, &planRules, false); !d.HasError() {
+			changed := false
+			for i := range planRules {
+				if planRules[i].Description.IsUnknown() {
+					planRules[i].Description = types.StringNull()
+					changed = true
+				}
+				if planRules[i].Id.IsUnknown() {
+					// Overlay ID from API response for "create" actions (API assigns it).
+					if apiResp.Rules != nil && i < len(*apiResp.Rules) && (*apiResp.Rules)[i] != nil && (*apiResp.Rules)[i].Id != nil {
+						planRules[i].Id = types.StringValue(*(*apiResp.Rules)[i].Id)
+					} else {
+						planRules[i].Id = types.StringNull()
+					}
+					changed = true
+				}
+				if planRules[i].Formula.IsUnknown() {
+					planRules[i].Formula = types.StringNull()
+					changed = true
+				}
+				if planRules[i].Name.IsUnknown() {
+					planRules[i].Name = types.StringNull()
+					changed = true
+				}
+				if planRules[i].Components.IsUnknown() {
+					emptyComps, compDiags := types.ListValueFrom(ctx, resource_allocation.ComponentsValue{}.Type(ctx), []resource_allocation.ComponentsValue{})
+					diags.Append(compDiags...)
+					if !compDiags.HasError() {
+						planRules[i].Components = emptyComps
+					}
+					changed = true
+				}
+				// Also resolve unknowns inside components.
+				if !planRules[i].Components.IsNull() && !planRules[i].Components.IsUnknown() {
+					resolved, compDiags := resolveComponentUnknowns(ctx, &planRules[i].Components)
+					diags.Append(compDiags...)
+					if resolved {
+						changed = true
+					}
+				}
+			}
+			if changed {
+				var rulesDiags diag.Diagnostics
+				plan.Rules, rulesDiags = types.ListValueFrom(ctx, resource_allocation.RulesValue{}.Type(ctx), planRules)
+				diags.Append(rulesDiags...)
+			}
+		}
+	}
+
+	// Resolve unknowns inside single rule's components.
+	if !plan.Rule.IsNull() && !plan.Rule.IsUnknown() &&
+		!plan.Rule.Components.IsNull() && !plan.Rule.Components.IsUnknown() {
+		resolved, compDiags := resolveComponentUnknowns(ctx, &plan.Rule.Components)
+		diags.Append(compDiags...)
+		if resolved {
+			// Rebuild the Rule value with updated components.
+			m := map[string]attr.Value{
+				"formula":    plan.Rule.Formula,
+				"components": plan.Rule.Components,
+			}
+			var ruleDiags diag.Diagnostics
+			plan.Rule, ruleDiags = resource_allocation.NewRuleValue(resource_allocation.RuleValue{}.AttributeTypes(ctx), m)
+			diags.Append(ruleDiags...)
+		}
+	}
+
+	return diags
+}
+
+// resolveComponentUnknowns resolves unknown Optional+Computed fields inside
+// component elements (case_insensitive, include_null, inverse, inverse_selection).
+// Returns true if any fields were changed.
+func resolveComponentUnknowns(ctx context.Context, components *basetypes.ListValue) (bool, diag.Diagnostics) {
+	var comps []resource_allocation.ComponentsValue
+	if d := components.ElementsAs(ctx, &comps, false); d.HasError() {
+		return false, d
+	}
+	changed := false
+	for i := range comps {
+		if comps[i].CaseInsensitive.IsUnknown() {
+			comps[i].CaseInsensitive = types.BoolValue(false)
+			changed = true
+		}
+		if comps[i].IncludeNull.IsUnknown() {
+			comps[i].IncludeNull = types.BoolValue(false)
+			changed = true
+		}
+		if comps[i].Inverse.IsUnknown() {
+			comps[i].Inverse = types.BoolValue(false)
+			changed = true
+		}
+		if comps[i].InverseSelection.IsUnknown() {
+			comps[i].InverseSelection = types.BoolValue(false)
+			changed = true
+		}
+	}
+	if changed {
+		var listDiags diag.Diagnostics
+		*components, listDiags = types.ListValueFrom(ctx, resource_allocation.ComponentsValue{}.Type(ctx), comps)
+		return changed, listDiags
+	}
+	return changed, nil
+}
+
 func (plan *allocationResourceModel) toCreateRequest(ctx context.Context) (req models.CreateAllocationRequest, diags diag.Diagnostics) {
 	// Create request uses value types for Description/Name, Update uses pointers.
 	// We use the common helper to generate the complex Rule/Rules structures (which are shared types)
@@ -455,9 +611,21 @@ func toAllocationRuleComponentsListValue(ctx context.Context, components []model
 			"mode":              types.StringValue(string(component.Mode)),
 			"type":              types.StringValue(compType),
 		}
-		values := make([]attr.Value, len(component.Values))
-		for j := range component.Values {
-			values[j] = types.StringValue(component.Values[j])
+		// Merge API values with prior state to restore any NullFallback sentinels
+		// that the API strips during normalization. This is needed for the Read path
+		// to prevent perpetual plan drift when the user's config contains sentinels.
+		// The Create/Update path uses plan-first state and doesn't need this.
+		apiIncludeNull := component.IncludeNull != nil && *component.IncludeNull
+		apiValues := component.Values
+		if i < len(existingComponents) {
+			var stateVals []string
+			if d := existingComponents[i].Values.ElementsAs(ctx, &stateVals, false); !d.HasError() {
+				apiValues = mergeSentinelValues(apiValues, stateVals, apiIncludeNull)
+			}
+		}
+		values := make([]attr.Value, len(apiValues))
+		for j := range apiValues {
+			values[j] = types.StringValue(apiValues[j])
 		}
 		var d diag.Diagnostics
 		m["values"], d = types.ListValue(types.StringType, values)

--- a/internal/provider/allocation_resource.go
+++ b/internal/provider/allocation_resource.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_allocation"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -165,9 +167,12 @@ func (r *allocationResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	// Map the full response directly to state (no extra GET needed)
-	diags = r.mapAllocationToModel(ctx, allocationResp.JSON200, plan)
-	resp.Diagnostics.Append(diags...)
+	// Plan-first state pattern: keep all user-configured values from the plan
+	// exactly as-is, and only overlay Computed-only fields from the API response.
+	// This prevents "Provider produced inconsistent result" errors caused by the
+	// API normalizing user-provided values (stripping sentinels, renaming services).
+	// Read and ImportState still use mapAllocationToModel for the full API response.
+	resp.Diagnostics.Append(overlayComputedFields(allocationResp.JSON200, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -214,15 +219,16 @@ func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	state := new(allocationResourceModel)
-	diags = req.State.Get(ctx, state)
+	// We need the allocation ID from state for the API call.
+	var stateId types.String
+	diags = req.State.GetAttribute(ctx, path.Root("id"), &stateId)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Update the allocation
-	updateResp, err := r.client.UpdateAllocationWithResponse(ctx, state.Id.ValueString(), allocation)
+	updateResp, err := r.client.UpdateAllocationWithResponse(ctx, stateId.ValueString(), allocation)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating allocation",
@@ -255,14 +261,14 @@ func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// Map the full response directly to state (no extra GET needed)
-	diags = r.mapAllocationToModel(ctx, updateResp.JSON200, state)
-	resp.Diagnostics.Append(diags...)
+	// Plan-first state pattern: keep all user-configured values from the plan
+	// exactly as-is, and only overlay Computed-only fields from the API response.
+	resp.Diagnostics.Append(overlayComputedFields(updateResp.JSON200, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *allocationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/allocation_resource.go
+++ b/internal/provider/allocation_resource.go
@@ -172,7 +172,7 @@ func (r *allocationResource) Create(ctx context.Context, req resource.CreateRequ
 	// This prevents "Provider produced inconsistent result" errors caused by the
 	// API normalizing user-provided values (stripping sentinels, renaming services).
 	// Read and ImportState still use mapAllocationToModel for the full API response.
-	resp.Diagnostics.Append(overlayComputedFields(allocationResp.JSON200, plan)...)
+	resp.Diagnostics.Append(overlayComputedFields(ctx, allocationResp.JSON200, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -227,6 +227,14 @@ func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	if stateId.IsNull() || stateId.IsUnknown() {
+		resp.Diagnostics.AddError(
+			"Error updating allocation",
+			"Could not update allocation because the resource ID in state is null or unknown.",
+		)
+		return
+	}
+
 	// Update the allocation
 	updateResp, err := r.client.UpdateAllocationWithResponse(ctx, stateId.ValueString(), allocation)
 	if err != nil {
@@ -263,7 +271,7 @@ func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Plan-first state pattern: keep all user-configured values from the plan
 	// exactly as-is, and only overlay Computed-only fields from the API response.
-	resp.Diagnostics.Append(overlayComputedFields(updateResp.JSON200, plan)...)
+	resp.Diagnostics.Append(overlayComputedFields(ctx, updateResp.JSON200, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -952,21 +952,14 @@ resource "doit_allocation" "invalid_nested" {
 `, rName)
 }
 
-// TestAccAllocation_InverseMigration tests migrating from the deprecated
-// "inverse_selection" attribute to the new "inverse" attribute in an Update.
+// TestAccAllocation_InverseMigration tests that migrating a single allocation
+// from the deprecated "inverse_selection" attribute to the new "inverse"
+// attribute does not produce "inconsistent result" errors.
 //
-// This reproduces the exact failure from ticket 300568: the customer changed
-// from inverse_selection=true to inverse=true and got:
-//
-//	.rule.components[N].inverse: was cty.True, but now cty.False
-//	.rule.components[N].inverse_selection: was cty.False, but now cty.True
-//
-// Root cause: the API internally maps "inverse" back to "inverse_selection",
-// so the response always has inverse_selection=true, inverse=false. On v1.3.3,
-// mapAllocationToModel wrote the swapped API values to state, causing
-// an inconsistency with the plan. The plan-first pattern prevents this.
-//
-// Verified: FAILS on main (v1.3.3), PASSES on this branch.
+// The API internally maps "inverse" back to "inverse_selection" in the response,
+// so the response always has inverse_selection=true and inverse=false. The
+// provider must preserve the user's planned values in state rather than
+// writing the API's swapped values.
 func TestAccAllocation_InverseMigration(t *testing.T) {
 	rName := acctest.RandomWithPrefix(testAllocPrefix)
 
@@ -1057,14 +1050,9 @@ resource "doit_allocation" "inv_migrate" {
 // round-trips correctly — after apply the state still contains "[Label N/A]"
 // and no "inconsistent result" error is produced.
 //
-// This reproduces the exact failure from ticket 300568: the customer's config
-// has include_null=true and values=["[... N/A]"]. The API strips the sentinel
-// and returns values=[] + include_null=true. If the provider writes the API
-// response directly to state, Terraform sees a list-length mismatch (plan had
-// 1 element, state has 0) and crashes with "inconsistent result".
-//
-// The fix (plan-first state pattern) preserves the plan values in state after
-// Create/Update, so the sentinel stays in state regardless of what the API returns.
+// The API strips NullFallback sentinels from the values list and returns
+// values=[] with include_null=true. The provider must preserve the user's
+// planned values in state to avoid a list-length mismatch.
 func TestAccAllocation_SentinelRestore(t *testing.T) {
 	rName := acctest.RandomWithPrefix(testAllocPrefix)
 
@@ -1140,17 +1128,10 @@ resource "doit_allocation" "sentinel" {
 // TestAccAllocation_SentinelMixed tests that a single allocation with BOTH a
 // NullFallback sentinel AND real values round-trips without "inconsistent result".
 //
-// This mirrors the customer's invalid-application config from ticket 300568:
-//
-//	values = setunion(local.approved_applications, ["[... N/A]", "none"])
-//
 // The API strips the sentinel from the values list and sets include_null=true.
-// On the current code, the provider writes the API response (which has N-1 values)
-// to state. Terraform then sees each value shifted by one index:
-//
-//	was cty.StringVal("[Label N/A]"), but now cty.StringVal("real-value")
-//
-// and crashes with "inconsistent result" for every index.
+// If the provider writes the API response (which has N-1 values) to state,
+// Terraform sees each value shifted by one index and crashes. The provider
+// must preserve the user's planned values in state.
 func TestAccAllocation_SentinelMixed(t *testing.T) {
 	rName := acctest.RandomWithPrefix(testAllocPrefix)
 
@@ -1226,26 +1207,14 @@ resource "doit_allocation" "sentinel_mixed" {
 // service_description value that the API normalizes does not crash with
 // "inconsistent result".
 //
-// This reproduces the exact failure from ticket 300568 on the "unallocated"
-// allocation: the customer's config has:
+// The API normalizes some service names (e.g. stripping the "(EKS)" suffix from
+// "Amazon Elastic Container Service for Kubernetes (EKS)"). The provider must
+// preserve the user's planned values in state after Create/Update. The Read path
+// then detects the normalized value as drift and surfaces it in the next plan.
 //
-//	values = ["Amazon Elastic Container Service for Kubernetes (EKS)"]
-//
-// but the API normalizes this to:
-//
-//	values = ["Amazon Elastic Container Service for Kubernetes"]
-//
-// (stripping the "(EKS)" suffix).
-//
-// Before the fix (plan-first state pattern), the provider would crash with
-// "Provider produced inconsistent result" because it wrote the API's normalized
-// value to state, causing a string mismatch.
-//
-// After the fix:
-//   - Create succeeds without crash (plan values preserved in state)
-//   - Read detects the normalized value as drift, causing a non-empty plan
-//   - Step 2 verifies the drift is properly surfaced (not a crash)
-//   - Step 3 uses the canonical name → no more drift
+// Asserts:
+//   - Step 1: Create succeeds without crash; drift is detected (non-empty plan)
+//   - Step 2: Using the canonical name produces an empty plan (no drift)
 func TestAccAllocation_ValueNormalization(t *testing.T) {
 	rName := acctest.RandomWithPrefix(testAllocPrefix)
 

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -1286,3 +1286,679 @@ resource "doit_allocation" "norm" {
 }
 `, rName)
 }
+
+// ---------------------------------------------------------------------------
+// Coverage Audit Gap Tests (added to close all blind spots)
+// ---------------------------------------------------------------------------
+
+// TestAccAllocation_GroupUpdate tests updating a group allocation: changing rule
+// names, values, and components. This exercises the plan-first state pattern for
+// group allocations during Update, including action preservation and rule ID matching.
+func TestAccAllocation_GroupUpdate(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create a group allocation with two rules.
+			{
+				Config: testAccAllocationGroup(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.group",
+						tfjsonpath.New("allocation_type"),
+						knownvalue.StringExact("group")),
+				},
+			},
+			// Step 2: Update — change country value from "US" to "DE" in the second rule.
+			{
+				Config: testAccAllocationGroupUpdated(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_allocation.group",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+			},
+			// Step 3: Drift check — re-apply, expect no changes.
+			{
+				Config: testAccAllocationGroupUpdated(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationGroupUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "group" {
+    name = "%s-group"
+	description = "test allocation group updated"
+    unallocated_costs = "%s-other"
+    rules = [
+        {
+            action = "create"
+            name   = "%s-jp-rule"
+       formula = "A AND B"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         },
+         {
+           key    = "project_id"
+           mode   = "is"
+           type   = "fixed"
+           values = ["%s"]
+          }
+       ]
+    },
+           {
+            action = "create"
+            name   = "%s-de-rule"
+       formula = "A AND B"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["DE"]
+         },
+         {
+           key    = "project_id"
+           mode   = "is"
+           type   = "fixed"
+           values = ["%s"]
+          }
+       ]
+    }
+    ]
+}
+`, rName, rName, rName, testProject(), rName, testProject())
+}
+
+// TestAccAllocation_GroupOmittedDefaults tests creating a group allocation where
+// the Optional+Computed field "description" is omitted from the config.
+// The provider must correctly resolve the unknown to the API default to avoid
+// perpetual drift.
+func TestAccAllocation_GroupOmittedDefaults(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with description omitted from the rule.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "defaults" {
+    name = "%s-defaults"
+    description = "test omitted defaults"
+    unallocated_costs = "%s-other"
+    rules = [
+        {
+            action  = "create"
+            name    = "%s-rule"
+            formula = "A"
+            components = [
+                {
+                    key    = "country"
+                    mode   = "is"
+                    type   = "fixed"
+                    values = ["JP"]
+                }
+            ]
+        }
+    ]
+}
+`, rName, rName, rName),
+			},
+			// Step 2: Drift check — verify no drift from the API's defaults.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "defaults" {
+    name = "%s-defaults"
+    description = "test omitted defaults"
+    unallocated_costs = "%s-other"
+    rules = [
+        {
+            action  = "create"
+            name    = "%s-rule"
+            formula = "A"
+            components = [
+                {
+                    key    = "country"
+                    mode   = "is"
+                    type   = "fixed"
+                    values = ["JP"]
+                }
+            ]
+        }
+    ]
+}
+`, rName, rName, rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_SingleMinimal tests creating a single allocation with the
+// absolute minimum required fields, exercising the overlay code's handling of
+// all Optional+Computed fields defaulting to unknown.
+func TestAccAllocation_SingleMinimal(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with only required fields, omitting all optional booleans.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "minimal" {
+    name = "%s-minimal"
+    description = "test minimal config"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.minimal",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"case_insensitive":  knownvalue.Bool(false),
+								"include_null":      knownvalue.Bool(false),
+								"inverse":           knownvalue.Bool(false),
+								"inverse_selection": knownvalue.Bool(false),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 2: Drift check.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "minimal" {
+    name = "%s-minimal"
+    description = "test minimal config"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_DimensionsTypeAlias tests that the DimensionsType alias
+// normalization preserves the user's configured type when the API returns
+// the canonical equivalent. The alias pair tested: allocation_rule ↔ attribution.
+func TestAccAllocation_DimensionsTypeAlias(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create a single-rule allocation with type "allocation_rule".
+			// The API returns the canonical "attribution" in responses.
+			// The normalizer should preserve "allocation_rule" in state.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "alias_src" {
+    name = "%s-alias-src"
+    description = "source allocation for alias test"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+
+resource "doit_allocation" "alias_test" {
+    name = "%s-alias"
+    description = "test dimensions type alias"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "allocation_rule"
+           mode   = "is"
+           type   = "allocation_rule"
+           values = [doit_allocation.alias_src.id]
+         }
+       ]
+    }
+}
+`, rName, rName),
+			},
+			// Step 2: Drift check — verify the alias type is preserved.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "alias_src" {
+    name = "%s-alias-src"
+    description = "source allocation for alias test"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+
+resource "doit_allocation" "alias_test" {
+    name = "%s-alias"
+    description = "test dimensions type alias"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "allocation_rule"
+           mode   = "is"
+           type   = "allocation_rule"
+           values = [doit_allocation.alias_src.id]
+         }
+       ]
+    }
+}
+`, rName, rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_AddRemoveComponents tests adding and removing components
+// to an existing allocation during an update. This exercises the index-based
+// state matching in the Read path (sentinel merge, boolean flag preservation).
+func TestAccAllocation_AddRemoveComponents(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with 1 component.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "comp_change" {
+    name = "%s-comp-change"
+    description = "test add/remove components"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+`, rName),
+			},
+			// Step 2: Update to 2 components — add project_id.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "comp_change" {
+    name = "%s-comp-change"
+    description = "test add/remove components"
+    rule = {
+       formula = "A AND B"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         },
+        {
+           key    = "project_id"
+           mode   = "is"
+           type   = "fixed"
+           values = ["%s"]
+         }
+       ]
+    }
+}
+`, rName, testProject()),
+			},
+			// Step 3: Drift check after adding component.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "comp_change" {
+    name = "%s-comp-change"
+    description = "test add/remove components"
+    rule = {
+       formula = "A AND B"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         },
+        {
+           key    = "project_id"
+           mode   = "is"
+           type   = "fixed"
+           values = ["%s"]
+         }
+       ]
+    }
+}
+`, rName, testProject()),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 4: Back to 1 component — remove project_id.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "comp_change" {
+    name = "%s-comp-change"
+    description = "test add/remove components"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+`, rName),
+			},
+			// Step 5: Drift check after removing component.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "comp_change" {
+    name = "%s-comp-change"
+    description = "test add/remove components"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_MultipleValues tests creating a component with multiple
+// values in the values list. This exercises the values list mapping more
+// thoroughly than single-value tests.
+func TestAccAllocation_MultipleValues(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "multi_val" {
+    name = "%s-multi-val"
+    description = "test multiple values"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP", "US", "DE", "FR"]
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.multi_val",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"values": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("JP"),
+									knownvalue.StringExact("US"),
+									knownvalue.StringExact("DE"),
+									knownvalue.StringExact("FR"),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+			// Drift check.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "multi_val" {
+    name = "%s-multi-val"
+    description = "test multiple values"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP", "US", "DE", "FR"]
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_IncludeNullEmptyValues tests creating a component with
+// include_null=true and an empty values list. This verifies the base case
+// for null-inclusion without sentinel values.
+func TestAccAllocation_IncludeNullEmptyValues(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "incl_null" {
+    name = "%s-incl-null"
+    description = "test include_null with empty values"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key          = "service_description"
+           mode         = "is"
+           type         = "fixed"
+           values       = []
+           include_null = true
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.incl_null",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"include_null": knownvalue.Bool(true),
+								"values":       knownvalue.ListExact([]knownvalue.Check{}),
+							}),
+						}),
+					),
+				},
+			},
+			// Drift check.
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "incl_null" {
+    name = "%s-incl-null"
+    description = "test include_null with empty values"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key          = "service_description"
+           mode         = "is"
+           type         = "fixed"
+           values       = []
+           include_null = true
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_GroupImportActionPreservation tests that importing a group
+// allocation correctly handles the "action" field which is not returned by the API.
+// After import, re-applying the same config should produce no drift.
+func TestAccAllocation_GroupImportActionPreservation(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create a group allocation.
+			{
+				Config: testAccAllocationGroup(rName),
+			},
+			// Step 2: Import and verify state matches (rules ignored due to action).
+			{
+				ResourceName:      "doit_allocation.group",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"update_time", // Computed field
+					"rules",       // API doesn't return the 'action' field
+				},
+			},
+			// Step 3: After import, re-apply original config. This verifies
+			// that the imported state doesn't cause unnecessary updates.
+			{
+				Config: testAccAllocationGroup(rName),
+			},
+			// Step 4: Drift check after re-apply.
+			{
+				Config: testAccAllocationGroup(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -951,3 +951,269 @@ resource "doit_allocation" "invalid_nested" {
 }
 `, rName)
 }
+
+// TestAccAllocation_SentinelRestore tests that a single allocation with a
+// NullFallback sentinel value (e.g. "[Label N/A]") in component values
+// round-trips correctly — after apply the state still contains "[Label N/A]"
+// and no "inconsistent result" error is produced.
+//
+// This reproduces the exact failure from ticket 300568: the customer's config
+// has include_null=true and values=["[... N/A]"]. The API strips the sentinel
+// and returns values=[] + include_null=true. If the provider writes the API
+// response directly to state, Terraform sees a list-length mismatch (plan had
+// 1 element, state has 0) and crashes with "inconsistent result".
+//
+// The fix (plan-first state pattern) preserves the plan values in state after
+// Create/Update, so the sentinel stays in state regardless of what the API returns.
+func TestAccAllocation_SentinelRestore(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with "[Label N/A]" sentinel. Must not crash
+			// with "inconsistent result".
+			{
+				Config: testAccAllocationSentinelOnly(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_allocation.sentinel",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.sentinel",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"include_null": knownvalue.Bool(true),
+								// The sentinel must be preserved in state.
+								"values": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("[Service N/A]"),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 2: Re-apply — verify no drift.
+			{
+				Config: testAccAllocationSentinelOnly(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationSentinelOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "sentinel" {
+    name        = "%s-sentinel"
+    description = "test allocation with sentinel value"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key          = "service_description"
+           mode         = "is"
+           type         = "fixed"
+           include_null = true
+           values       = ["[Service N/A]"]
+         }
+       ]
+    }
+}
+`, rName)
+}
+
+// TestAccAllocation_SentinelMixed tests that a single allocation with BOTH a
+// NullFallback sentinel AND real values round-trips without "inconsistent result".
+//
+// This mirrors the customer's invalid-application config from ticket 300568:
+//
+//	values = setunion(local.approved_applications, ["[... N/A]", "none"])
+//
+// The API strips the sentinel from the values list and sets include_null=true.
+// On the current code, the provider writes the API response (which has N-1 values)
+// to state. Terraform then sees each value shifted by one index:
+//
+//	was cty.StringVal("[Label N/A]"), but now cty.StringVal("real-value")
+//
+// and crashes with "inconsistent result" for every index.
+func TestAccAllocation_SentinelMixed(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllocationSentinelMixed(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_allocation.sentinel_mixed",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.sentinel_mixed",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"include_null": knownvalue.Bool(true),
+								"values": knownvalue.ListExact([]knownvalue.Check{
+									// Both must be preserved in state.
+									knownvalue.StringExact("[Service N/A]"),
+									knownvalue.StringExact("AmazonCloudWatch"),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 2: Re-apply — verify no drift.
+			{
+				Config: testAccAllocationSentinelMixed(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationSentinelMixed(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "sentinel_mixed" {
+    name        = "%s-sentinel-mixed"
+    description = "test allocation with sentinel and real values"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key          = "service_description"
+           mode         = "is"
+           type         = "fixed"
+           include_null = true
+           values       = ["[Service N/A]", "AmazonCloudWatch"]
+         }
+       ]
+    }
+}
+`, rName)
+}
+
+// TestAccAllocation_ValueNormalization tests that a single allocation with a
+// service_description value that the API normalizes does not crash with
+// "inconsistent result".
+//
+// This reproduces the exact failure from ticket 300568 on the "unallocated"
+// allocation: the customer's config has:
+//
+//	values = ["Amazon Elastic Container Service for Kubernetes (EKS)"]
+//
+// but the API normalizes this to:
+//
+//	values = ["Amazon Elastic Container Service for Kubernetes"]
+//
+// (stripping the "(EKS)" suffix).
+//
+// Before the fix (plan-first state pattern), the provider would crash with
+// "Provider produced inconsistent result" because it wrote the API's normalized
+// value to state, causing a string mismatch.
+//
+// After the fix:
+//   - Create succeeds without crash (plan values preserved in state)
+//   - Read detects the normalized value as drift, causing a non-empty plan
+//   - Step 2 verifies the drift is properly surfaced (not a crash)
+//   - Step 3 uses the canonical name → no more drift
+func TestAccAllocation_ValueNormalization(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with the non-canonical name.
+			// The plan-first pattern prevents "inconsistent result" crash.
+			// The API normalizes the value, so the post-apply refresh will
+			// write the canonical name to state, causing expected drift.
+			{
+				Config:             testAccAllocationValueNormalization(rName),
+				ExpectNonEmptyPlan: true, // Expected: Read returns API's canonical name → drift.
+			},
+			// Step 2: Switch to the API's canonical name.
+			// State already has the canonical name from step 1's refresh,
+			// so this should produce no drift.
+			{
+				Config: testAccAllocationValueNormalizationCanonical(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationValueNormalization(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "norm" {
+    name        = "%s-value-norm"
+    description = "test allocation with API-normalized service name"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "service_description"
+           mode   = "is"
+           type   = "fixed"
+           values = ["Amazon Elastic Container Service for Kubernetes (EKS)"]
+         }
+       ]
+    }
+}
+`, rName)
+}
+
+func testAccAllocationValueNormalizationCanonical(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "norm" {
+    name        = "%s-value-norm"
+    description = "test allocation with API-normalized service name"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "service_description"
+           mode   = "is"
+           type   = "fixed"
+           values = ["Amazon Elastic Container Service for Kubernetes"]
+         }
+       ]
+    }
+}
+`, rName)
+}

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -952,6 +952,106 @@ resource "doit_allocation" "invalid_nested" {
 `, rName)
 }
 
+// TestAccAllocation_InverseMigration tests migrating from the deprecated
+// "inverse_selection" attribute to the new "inverse" attribute in an Update.
+//
+// This reproduces the exact failure from ticket 300568: the customer changed
+// from inverse_selection=true to inverse=true and got:
+//
+//	.rule.components[N].inverse: was cty.True, but now cty.False
+//	.rule.components[N].inverse_selection: was cty.False, but now cty.True
+//
+// Root cause: the API internally maps "inverse" back to "inverse_selection",
+// so the response always has inverse_selection=true, inverse=false. On v1.3.3,
+// mapAllocationToModel wrote the swapped API values to state, causing
+// an inconsistency with the plan. The plan-first pattern prevents this.
+//
+// Verified: FAILS on main (v1.3.3), PASSES on this branch.
+func TestAccAllocation_InverseMigration(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with the legacy inverse_selection = true.
+			{
+				Config: testAccAllocationInverseSelectionLegacy(rName),
+			},
+			// Step 2: Migrate to inverse = true (remove inverse_selection).
+			// On v1.3.3, this crashes with "inconsistent result" because
+			// the API maps inverse back to inverse_selection.
+			{
+				Config: testAccAllocationInverseMigrated(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.inv_migrate",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"inverse": knownvalue.Bool(true),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 3: Re-apply — verify no drift.
+			{
+				Config: testAccAllocationInverseMigrated(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationInverseSelectionLegacy(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "inv_migrate" {
+    name        = "%s-inv-migrate"
+    description = "test allocation with inverse_selection migration"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key               = "service_description"
+           mode              = "is"
+           type              = "fixed"
+           values            = ["AmazonCloudWatch"]
+           inverse_selection = true
+         }
+       ]
+    }
+}
+`, rName)
+}
+
+func testAccAllocationInverseMigrated(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "inv_migrate" {
+    name        = "%s-inv-migrate"
+    description = "test allocation with inverse_selection migration"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key     = "service_description"
+           mode    = "is"
+           type    = "fixed"
+           values  = ["AmazonCloudWatch"]
+           inverse = true
+         }
+       ]
+    }
+}
+`, rName)
+}
+
 // TestAccAllocation_SentinelRestore tests that a single allocation with a
 // NullFallback sentinel value (e.g. "[Label N/A]") in component values
 // round-trips correctly — after apply the state still contains "[Label N/A]"


### PR DESCRIPTION
## Summary

Resolves "Provider produced inconsistent result after apply" crashes in the `doit_allocation` resource, caused by the API normalizing user-provided values during Create/Update.

**Ticket:** 300568

## Root Cause

`Create` and `Update` mapped the **full API response** to Terraform state. When the API:
- Strips `[Service N/A]` sentinels (setting `include_null=true` instead)
- Renames service values (e.g. removing `(EKS)` suffix)

...the state diverges from the plan, causing Terraform to crash with "Provider produced inconsistent result".

## Fix

Adopt the **plan-first state pattern** [recommended by HashiCorp](https://developer.hashicorp.com/terraform/plugin/framework/resources/create):

| Method | State Source | Rationale |
|--------|-------------|-----------|
| **Create** | Plan + computed overlay | User config preserved exactly |
| **Update** | Plan + computed overlay | User config preserved exactly |
| **Read** | Full API response | Detect external drift |
| **ImportState** | Full API response | No plan exists |

### Changes

- **`allocation_resource.go`** — Create/Update now call `overlayComputedFields()` instead of `mapAllocationToModel()`, preserving plan values and only overlaying Computed-only fields (`id`, `create_time`, `update_time`, `allocation_type`, `anomaly_detection`, `type`)
- **`allocation.go`** — New `overlayComputedFields()` and `resolveComponentUnknowns()` helpers; `mergeSentinelValues` added to Read path for sentinel restoration; all diagnostics properly handled (no suppressions)

### Value Normalization Behavior

For API-side value normalization (e.g. `(EKS)` suffix stripping), the provider:
1. **No longer crashes** on Create/Update (plan-first prevents it)
2. **Shows drift on next plan** via Read (API returns canonical name)
3. Customer updates their HCL to use the canonical name → drift resolved

## Tests

Three new acceptance tests reproduce the exact customer bugs:

| Test | Scenario | Before Fix | After Fix |
|------|----------|-----------|-----------|
| `TestAccAllocation_SentinelRestore` | `values = ["[Service N/A]"]` | 💥 Crash | ✅ Pass |
| `TestAccAllocation_SentinelMixed` | `values = ["[Service N/A]", "AmazonCloudWatch"]` | 💥 Crash | ✅ Pass |
| `TestAccAllocation_ValueNormalization` | `values = ["... (EKS)"]` | 💥 Crash | ✅ Pass |

**All 26 allocation acceptance tests pass with zero regressions.**