### PR TITLE
fix(budget): adopt plan-first state pattern for Create/Update

### DIFF
--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -11,6 +11,326 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// overlayBudgetComputedFields preserves all user-configured values from the Terraform
+// plan and selectively overlays only server-assigned Computed fields from the API response.
+//
+// Computed-only fields (always from API):
+//   - id, create_time, update_time, current_utilization, forecasted_utilization
+//   - alerts[].forecasted_date, alerts[].triggered
+//
+// Optional+Computed fields: only resolved from the API when IsUnknown() (user omitted them).
+// Known values are never touched — the user's plan is the source of truth.
+//
+// This prevents "Provider produced inconsistent result" errors caused by the API
+// normalizing user-provided values (e.g. stripping [Service N/A] sentinels,
+// renaming alias types like allocation_rule → attribution).
+func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI, plan *budgetResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// ── Computed-only fields: ALWAYS set from API response ──
+	plan.Id = types.StringPointerValue(apiResp.Id)
+	plan.CreateTime = types.Int64PointerValue(apiResp.CreateTime)
+	plan.UpdateTime = types.Int64PointerValue(apiResp.UpdateTime)
+	plan.CurrentUtilization = types.Float64PointerValue(apiResp.CurrentUtilization)
+	plan.ForecastedUtilization = types.Float64PointerValue(apiResp.ForecastedUtilization)
+
+	// ── Alerts: mixed Computed + user-configurable ──
+	// The user sets percentage; the API computes forecasted_date and triggered.
+	// We preserve the user's percentages and overlay the computed sub-fields.
+	if !plan.Alerts.IsNull() && !plan.Alerts.IsUnknown() {
+		var planAlerts []resource_budget.AlertsValue
+		alertsDiags := plan.Alerts.ElementsAs(ctx, &planAlerts, false)
+		diags.Append(alertsDiags...)
+		if !alertsDiags.HasError() && len(planAlerts) > 0 {
+			changed := false
+			for i := range planAlerts {
+				// Overlay computed sub-fields from the API response.
+				var apiAlert *models.ExternalBudgetAlert
+				if apiResp.Alerts != nil && i < len(*apiResp.Alerts) {
+					apiAlert = &(*apiResp.Alerts)[i]
+				}
+
+				// forecasted_date and triggered are Computed-only: always overlay.
+				forecastedDate := types.Int64Null()
+				triggered := types.BoolNull()
+				if apiAlert != nil {
+					forecastedDate = types.Int64PointerValue(apiAlert.ForecastedDate)
+					triggered = types.BoolPointerValue(apiAlert.Triggered)
+				}
+
+				// percentage is Optional+Computed: resolve only when unknown.
+				percentage := planAlerts[i].Percentage
+				if percentage.IsUnknown() {
+					if apiAlert != nil {
+						percentage = types.Float64PointerValue(apiAlert.Percentage)
+					} else {
+						percentage = types.Float64Null()
+					}
+				}
+
+				// Rebuild the alert value with preserved percentage + overlaid computed fields.
+				alertAttrs := map[string]attr.Value{
+					"forecasted_date": forecastedDate,
+					"percentage":      percentage,
+					"triggered":       triggered,
+				}
+				var d diag.Diagnostics
+				planAlerts[i], d = resource_budget.NewAlertsValue(resource_budget.AlertsValue{}.AttributeTypes(ctx), alertAttrs)
+				diags.Append(d...)
+				changed = true
+			}
+			if changed {
+				alertsListValue, d := types.ListValueFrom(ctx, resource_budget.AlertsValue{}.Type(ctx), planAlerts)
+				diags.Append(d...)
+				plan.Alerts = alertsListValue
+			}
+		}
+	} else if plan.Alerts.IsUnknown() {
+		// User omitted alerts entirely — resolve from API response since the
+		// API provides default alerts.
+		if apiResp.Alerts != nil && len(*apiResp.Alerts) > 0 {
+			alertsList := make([]resource_budget.AlertsValue, len(*apiResp.Alerts))
+			for i, alert := range *apiResp.Alerts {
+				alertAttrs := map[string]attr.Value{
+					"forecasted_date": types.Int64PointerValue(alert.ForecastedDate),
+					"percentage":      types.Float64PointerValue(alert.Percentage),
+					"triggered":       types.BoolPointerValue(alert.Triggered),
+				}
+				var d diag.Diagnostics
+				alertsList[i], d = resource_budget.NewAlertsValue(resource_budget.AlertsValue{}.AttributeTypes(ctx), alertAttrs)
+				diags.Append(d...)
+			}
+			alertsListValue, d := types.ListValueFrom(ctx, resource_budget.AlertsValue{}.Type(ctx), alertsList)
+			diags.Append(d...)
+			plan.Alerts = alertsListValue
+		} else {
+			emptyAlerts, d := types.ListValueFrom(ctx, resource_budget.AlertsValue{}.Type(ctx), []resource_budget.AlertsValue{})
+			diags.Append(d...)
+			plan.Alerts = emptyAlerts
+		}
+	}
+
+	// ── Optional+Computed scalar fields: resolve only when unknown ──
+
+	if plan.Amount.IsUnknown() {
+		plan.Amount = types.Float64PointerValue(apiResp.Amount)
+	}
+	if plan.Currency.IsUnknown() {
+		plan.Currency = types.StringValue(string(apiResp.Currency))
+	}
+	if plan.Description.IsUnknown() {
+		plan.Description = types.StringPointerValue(apiResp.Description)
+	}
+	if plan.EndPeriod.IsUnknown() {
+		if apiResp.EndPeriod != nil && *apiResp.EndPeriod > 0 {
+			plan.EndPeriod = types.Int64PointerValue(apiResp.EndPeriod)
+		} else {
+			plan.EndPeriod = types.Int64Null()
+		}
+	}
+	if plan.GrowthPerPeriod.IsUnknown() {
+		plan.GrowthPerPeriod = types.Float64PointerValue(apiResp.GrowthPerPeriod)
+	}
+	if plan.Metric.IsUnknown() {
+		plan.Metric = types.StringPointerValue(apiResp.Metric)
+	}
+	if plan.Name.IsUnknown() {
+		plan.Name = types.StringValue(apiResp.Name)
+	}
+	if plan.Public.IsUnknown() {
+		if apiResp.Public != nil && *apiResp.Public != "" {
+			plan.Public = types.StringValue(string(*apiResp.Public))
+		} else {
+			plan.Public = types.StringNull()
+		}
+	}
+	if plan.StartPeriod.IsUnknown() {
+		plan.StartPeriod = types.Int64Value(apiResp.StartPeriod)
+	}
+	if plan.TimeInterval.IsUnknown() {
+		plan.TimeInterval = types.StringValue(apiResp.TimeInterval)
+	}
+	if plan.Type.IsUnknown() {
+		plan.Type = types.StringValue(apiResp.Type)
+	}
+	if plan.UsePrevSpend.IsUnknown() {
+		plan.UsePrevSpend = types.BoolPointerValue(apiResp.UsePrevSpend)
+	}
+
+	// ── Optional+Computed list fields: resolve only when unknown ──
+	// Known lists (including []) are never touched.
+	// Lists where the API auto-populates defaults (e.g. collaborators adds creator
+	// as owner, recipients may be auto-set) must resolve from the API response
+	// to capture those defaults. Lists where the API returns null/empty when
+	// omitted can safely resolve to null.
+
+	if plan.Collaborators.IsUnknown() {
+		// API auto-adds creator as owner — resolve from API response.
+		if apiResp.Collaborators != nil && len(*apiResp.Collaborators) > 0 {
+			collabsList := make([]resource_budget.CollaboratorsValue, len(*apiResp.Collaborators))
+			for i, collab := range *apiResp.Collaborators {
+				collabAttrs := map[string]attr.Value{
+					"email": types.StringPointerValue(collab.Email),
+					"role":  types.StringPointerValue((*string)(collab.Role)),
+				}
+				var d diag.Diagnostics
+				collabsList[i], d = resource_budget.NewCollaboratorsValue(resource_budget.CollaboratorsValue{}.AttributeTypes(ctx), collabAttrs)
+				diags.Append(d...)
+			}
+			collabsListValue, d := types.ListValueFrom(ctx, resource_budget.CollaboratorsValue{}.Type(ctx), collabsList)
+			diags.Append(d...)
+			plan.Collaborators = collabsListValue
+		} else {
+			emptyCollabs, d := types.ListValueFrom(ctx, resource_budget.CollaboratorsValue{}.Type(ctx), []resource_budget.CollaboratorsValue{})
+			diags.Append(d...)
+			plan.Collaborators = emptyCollabs
+		}
+	}
+	if plan.Recipients.IsUnknown() {
+		// API may auto-populate recipients — resolve from API response.
+		if apiResp.Recipients != nil {
+			recipientsList, d := types.ListValueFrom(ctx, types.StringType, *apiResp.Recipients)
+			diags.Append(d...)
+			plan.Recipients = recipientsList
+		} else {
+			var emptyDiags diag.Diagnostics
+			plan.Recipients, emptyDiags = types.ListValue(types.StringType, []attr.Value{})
+			diags.Append(emptyDiags...)
+		}
+	}
+	if plan.RecipientsSlackChannels.IsUnknown() {
+		plan.RecipientsSlackChannels = types.ListNull(resource_budget.RecipientsSlackChannelsValue{}.Type(ctx))
+	}
+	if plan.Scope.IsUnknown() {
+		plan.Scope = types.ListNull(types.StringType)
+	}
+	if plan.Scopes.IsUnknown() {
+		plan.Scopes = types.ListNull(resource_budget.ScopesValue{}.Type(ctx))
+	}
+	if plan.SeasonalAmounts.IsUnknown() {
+		plan.SeasonalAmounts = types.ListNull(types.Float64Type)
+	}
+
+	// ── Resolve unknowns inside scopes[] elements ──
+	// Scopes have Optional+Computed boolean fields (inverse, include_null, case_insensitive)
+	// and an Optional+Computed list field (values) that arrive as Unknown when the user
+	// omits them. We must resolve these to known values (defaulting to false/empty).
+	if !plan.Scopes.IsNull() && !plan.Scopes.IsUnknown() {
+		var planScopes []resource_budget.ScopesValue
+		scopesDiags := plan.Scopes.ElementsAs(ctx, &planScopes, false)
+		diags.Append(scopesDiags...)
+		if !scopesDiags.HasError() {
+			changed := false
+			for i := range planScopes {
+				if planScopes[i].Inverse.IsUnknown() {
+					planScopes[i].Inverse = types.BoolValue(false)
+					changed = true
+				}
+				if planScopes[i].IncludeNull.IsUnknown() {
+					planScopes[i].IncludeNull = types.BoolValue(false)
+					changed = true
+				}
+				if planScopes[i].CaseInsensitive.IsUnknown() {
+					planScopes[i].CaseInsensitive = types.BoolValue(false)
+					changed = true
+				}
+				if planScopes[i].Values.IsUnknown() {
+					var emptyDiags diag.Diagnostics
+					planScopes[i].Values, emptyDiags = types.ListValue(types.StringType, []attr.Value{})
+					diags.Append(emptyDiags...)
+					changed = true
+				}
+				if planScopes[i].Id.IsUnknown() {
+					planScopes[i].Id = types.StringNull()
+					changed = true
+				}
+				if planScopes[i].Mode.IsUnknown() {
+					planScopes[i].Mode = types.StringNull()
+					changed = true
+				}
+				if planScopes[i].ScopesType.IsUnknown() {
+					planScopes[i].ScopesType = types.StringNull()
+					changed = true
+				}
+			}
+			if changed {
+				// Rebuild the scopes list — framework treats list elements as immutable.
+				scopesListValue, d := types.ListValueFrom(ctx, resource_budget.ScopesValue{}.Type(ctx), planScopes)
+				diags.Append(d...)
+				plan.Scopes = scopesListValue
+			}
+		}
+	}
+
+	// ── Resolve unknowns inside collaborators[] elements ──
+	if !plan.Collaborators.IsNull() && !plan.Collaborators.IsUnknown() {
+		var planCollabs []resource_budget.CollaboratorsValue
+		collabsDiags := plan.Collaborators.ElementsAs(ctx, &planCollabs, false)
+		diags.Append(collabsDiags...)
+		if !collabsDiags.HasError() {
+			changed := false
+			for i := range planCollabs {
+				if planCollabs[i].Email.IsUnknown() {
+					planCollabs[i].Email = types.StringNull()
+					changed = true
+				}
+				if planCollabs[i].Role.IsUnknown() {
+					planCollabs[i].Role = types.StringNull()
+					changed = true
+				}
+			}
+			if changed {
+				collabsListValue, d := types.ListValueFrom(ctx, resource_budget.CollaboratorsValue{}.Type(ctx), planCollabs)
+				diags.Append(d...)
+				plan.Collaborators = collabsListValue
+			}
+		}
+	}
+
+	// ── Resolve unknowns inside recipients_slack_channels[] elements ──
+	if !plan.RecipientsSlackChannels.IsNull() && !plan.RecipientsSlackChannels.IsUnknown() {
+		var planChannels []resource_budget.RecipientsSlackChannelsValue
+		channelsDiags := plan.RecipientsSlackChannels.ElementsAs(ctx, &planChannels, false)
+		diags.Append(channelsDiags...)
+		if !channelsDiags.HasError() {
+			changed := false
+			for i := range planChannels {
+				if planChannels[i].CustomerId.IsUnknown() {
+					planChannels[i].CustomerId = types.StringNull()
+					changed = true
+				}
+				if planChannels[i].Id.IsUnknown() {
+					planChannels[i].Id = types.StringNull()
+					changed = true
+				}
+				if planChannels[i].Name.IsUnknown() {
+					planChannels[i].Name = types.StringNull()
+					changed = true
+				}
+				if planChannels[i].Shared.IsUnknown() {
+					planChannels[i].Shared = types.BoolValue(false)
+					changed = true
+				}
+				if planChannels[i].RecipientsSlackChannelsType.IsUnknown() {
+					planChannels[i].RecipientsSlackChannelsType = types.StringNull()
+					changed = true
+				}
+				if planChannels[i].Workspace.IsUnknown() {
+					planChannels[i].Workspace = types.StringNull()
+					changed = true
+				}
+			}
+			if changed {
+				channelsListValue, d := types.ListValueFrom(ctx, resource_budget.RecipientsSlackChannelsValue{}.Type(ctx), planChannels)
+				diags.Append(d...)
+				plan.RecipientsSlackChannels = channelsListValue
+			}
+		}
+	}
+
+	return diags
+}
+
 // toUpdateRequest converts the Terraform model to the API BudgetCreateUpdateRequest.
 // This is used for both create and update operations since they use the same request type.
 func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req models.BudgetCreateUpdateRequest, diags diag.Diagnostics) {
@@ -208,6 +528,9 @@ func (r *budgetResource) populateState(ctx context.Context, state *budgetResourc
 	return mapBudgetToModel(ctx, resp, state)
 }
 
+// mapBudgetToModel maps the full API response to the Terraform model.
+// This is used ONLY by Read and ImportState — Create/Update use overlayBudgetComputedFields instead.
+// This function contains sentinel restoration and alias normalization for the Read path.
 func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budgetResourceModel) (diags diag.Diagnostics) {
 	if resp == nil {
 		diags.AddError(

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -199,10 +199,32 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 		}
 	}
 	if plan.RecipientsSlackChannels.IsUnknown() {
-		// Resolve to empty list (not null) to match mapBudgetToModel Read path.
-		emptyChannels, d := types.ListValueFrom(ctx, resource_budget.RecipientsSlackChannelsValue{}.Type(ctx), []resource_budget.RecipientsSlackChannelsValue{})
-		diags.Append(d...)
-		plan.RecipientsSlackChannels = emptyChannels
+		// API may auto-populate Slack channels — resolve from API response when present.
+		if apiResp.RecipientsSlackChannels != nil && len(*apiResp.RecipientsSlackChannels) > 0 {
+			channelsList := make([]resource_budget.RecipientsSlackChannelsValue, len(*apiResp.RecipientsSlackChannels))
+			for i, channel := range *apiResp.RecipientsSlackChannels {
+				channelAttrs := map[string]attr.Value{
+					"customer_id": types.StringPointerValue(channel.CustomerId),
+					"id":          types.StringPointerValue(channel.Id),
+					"name":        types.StringPointerValue(channel.Name),
+					"shared":      types.BoolPointerValue(channel.Shared),
+					"type":        types.StringPointerValue(channel.Type),
+					"workspace":   types.StringPointerValue(channel.Workspace),
+				}
+				var d diag.Diagnostics
+				channelsList[i], d = resource_budget.NewRecipientsSlackChannelsValue(
+					resource_budget.RecipientsSlackChannelsValue{}.AttributeTypes(ctx), channelAttrs)
+				diags.Append(d...)
+			}
+			channelsListValue, d := types.ListValueFrom(ctx, resource_budget.RecipientsSlackChannelsValue{}.Type(ctx), channelsList)
+			diags.Append(d...)
+			plan.RecipientsSlackChannels = channelsListValue
+		} else {
+			// Resolve to empty list (not null) to match mapBudgetToModel Read path.
+			emptyChannels, d := types.ListValueFrom(ctx, resource_budget.RecipientsSlackChannelsValue{}.Type(ctx), []resource_budget.RecipientsSlackChannelsValue{})
+			diags.Append(d...)
+			plan.RecipientsSlackChannels = emptyChannels
+		}
 	}
 	if plan.Scope.IsUnknown() {
 		// Resolve to empty list (not null) to match mapBudgetToModel Read path.
@@ -226,7 +248,11 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 	// ── Resolve unknowns inside scopes[] elements ──
 	// Scopes have Optional+Computed boolean fields (inverse, include_null, case_insensitive)
 	// and an Optional+Computed list field (values) that arrive as Unknown when the user
-	// omits them. We must resolve these to known values (defaulting to false/empty).
+	// omits them. Resolve from API response to match mapBudgetToModel Read path.
+	var apiScopes []models.ExternalConfigFilter
+	if len(apiResp.Scopes) > 0 {
+		apiScopes = apiResp.Scopes
+	}
 	if !plan.Scopes.IsNull() && !plan.Scopes.IsUnknown() {
 		var planScopes []resource_budget.ScopesValue
 		scopesDiags := plan.Scopes.ElementsAs(ctx, &planScopes, false)
@@ -235,15 +261,27 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 			changed := false
 			for i := range planScopes {
 				if planScopes[i].Inverse.IsUnknown() {
-					planScopes[i].Inverse = types.BoolValue(false)
+					if i < len(apiScopes) {
+						planScopes[i].Inverse = types.BoolPointerValue(apiScopes[i].Inverse)
+					} else {
+						planScopes[i].Inverse = types.BoolValue(false)
+					}
 					changed = true
 				}
 				if planScopes[i].IncludeNull.IsUnknown() {
-					planScopes[i].IncludeNull = types.BoolValue(false)
+					if i < len(apiScopes) {
+						planScopes[i].IncludeNull = types.BoolPointerValue(apiScopes[i].IncludeNull)
+					} else {
+						planScopes[i].IncludeNull = types.BoolValue(false)
+					}
 					changed = true
 				}
 				if planScopes[i].CaseInsensitive.IsUnknown() {
-					planScopes[i].CaseInsensitive = types.BoolValue(false)
+					if i < len(apiScopes) {
+						planScopes[i].CaseInsensitive = types.BoolPointerValue(apiScopes[i].CaseInsensitive)
+					} else {
+						planScopes[i].CaseInsensitive = types.BoolValue(false)
+					}
 					changed = true
 				}
 				if planScopes[i].Values.IsUnknown() {
@@ -300,6 +338,11 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 	}
 
 	// ── Resolve unknowns inside recipients_slack_channels[] elements ──
+	// Resolve computed subfields from API response by index matching.
+	var apiChannels []models.SlackChannel
+	if apiResp.RecipientsSlackChannels != nil {
+		apiChannels = *apiResp.RecipientsSlackChannels
+	}
 	if !plan.RecipientsSlackChannels.IsNull() && !plan.RecipientsSlackChannels.IsUnknown() {
 		var planChannels []resource_budget.RecipientsSlackChannelsValue
 		channelsDiags := plan.RecipientsSlackChannels.ElementsAs(ctx, &planChannels, false)
@@ -307,28 +350,58 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 		if !channelsDiags.HasError() {
 			changed := false
 			for i := range planChannels {
+				// Find matching API channel by index (order is preserved by API).
+				var apiCh *models.SlackChannel
+				if i < len(apiChannels) {
+					apiCh = &apiChannels[i]
+				}
+
 				if planChannels[i].CustomerId.IsUnknown() {
-					planChannels[i].CustomerId = types.StringNull()
+					if apiCh != nil {
+						planChannels[i].CustomerId = types.StringPointerValue(apiCh.CustomerId)
+					} else {
+						planChannels[i].CustomerId = types.StringNull()
+					}
 					changed = true
 				}
 				if planChannels[i].Id.IsUnknown() {
-					planChannels[i].Id = types.StringNull()
+					if apiCh != nil {
+						planChannels[i].Id = types.StringPointerValue(apiCh.Id)
+					} else {
+						planChannels[i].Id = types.StringNull()
+					}
 					changed = true
 				}
 				if planChannels[i].Name.IsUnknown() {
-					planChannels[i].Name = types.StringNull()
+					if apiCh != nil {
+						planChannels[i].Name = types.StringPointerValue(apiCh.Name)
+					} else {
+						planChannels[i].Name = types.StringNull()
+					}
 					changed = true
 				}
 				if planChannels[i].Shared.IsUnknown() {
-					planChannels[i].Shared = types.BoolValue(false)
+					if apiCh != nil {
+						planChannels[i].Shared = types.BoolPointerValue(apiCh.Shared)
+					} else {
+						planChannels[i].Shared = types.BoolValue(false)
+					}
 					changed = true
 				}
 				if planChannels[i].RecipientsSlackChannelsType.IsUnknown() {
-					planChannels[i].RecipientsSlackChannelsType = types.StringNull()
+					if apiCh != nil {
+						planChannels[i].RecipientsSlackChannelsType = types.StringPointerValue(apiCh.Type)
+					} else {
+						planChannels[i].RecipientsSlackChannelsType = types.StringNull()
+					}
 					changed = true
 				}
 				if planChannels[i].Workspace.IsUnknown() {
-					planChannels[i].Workspace = types.StringNull()
+					if apiCh != nil {
+						planChannels[i].Workspace = types.StringPointerValue(apiCh.Workspace)
+					} else {
+						planChannels[i].Workspace = types.StringNull()
+					}
 					changed = true
 				}
 			}

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -199,16 +199,28 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 		}
 	}
 	if plan.RecipientsSlackChannels.IsUnknown() {
-		plan.RecipientsSlackChannels = types.ListNull(resource_budget.RecipientsSlackChannelsValue{}.Type(ctx))
+		// Resolve to empty list (not null) to match mapBudgetToModel Read path.
+		emptyChannels, d := types.ListValueFrom(ctx, resource_budget.RecipientsSlackChannelsValue{}.Type(ctx), []resource_budget.RecipientsSlackChannelsValue{})
+		diags.Append(d...)
+		plan.RecipientsSlackChannels = emptyChannels
 	}
 	if plan.Scope.IsUnknown() {
-		plan.Scope = types.ListNull(types.StringType)
+		// Resolve to empty list (not null) to match mapBudgetToModel Read path.
+		var emptyDiags diag.Diagnostics
+		plan.Scope, emptyDiags = types.ListValue(types.StringType, []attr.Value{})
+		diags.Append(emptyDiags...)
 	}
 	if plan.Scopes.IsUnknown() {
-		plan.Scopes = types.ListNull(resource_budget.ScopesValue{}.Type(ctx))
+		// Resolve to empty list (not null) to match mapBudgetToModel Read path.
+		emptyScopes, d := types.ListValueFrom(ctx, resource_budget.ScopesValue{}.Type(ctx), []resource_budget.ScopesValue{})
+		diags.Append(d...)
+		plan.Scopes = emptyScopes
 	}
 	if plan.SeasonalAmounts.IsUnknown() {
-		plan.SeasonalAmounts = types.ListNull(types.Float64Type)
+		// Resolve to empty list (not null) to match mapBudgetToModel Read path.
+		var emptyDiags diag.Diagnostics
+		plan.SeasonalAmounts, emptyDiags = types.ListValue(types.Float64Type, []attr.Value{})
+		diags.Append(emptyDiags...)
 	}
 
 	// ── Resolve unknowns inside scopes[] elements ──

--- a/internal/provider/budget_resource.go
+++ b/internal/provider/budget_resource.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 const budgetSchemaVersion = 1
@@ -134,9 +133,12 @@ func (r *budgetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Map response directly to state
-	plan.Id = types.StringPointerValue(budgetResp.JSON201.Id)
-	resp.Diagnostics.Append(mapBudgetToModel(ctx, budgetResp.JSON201, &plan)...)
+	// Plan-first state pattern: keep all user-configured values from the plan
+	// exactly as-is, and only overlay Computed-only fields from the API response.
+	// This prevents "Provider produced inconsistent result" errors caused by the
+	// API normalizing user-provided values (stripping sentinels, renaming types).
+	// Read and ImportState still use mapBudgetToModel for the full API response.
+	resp.Diagnostics.Append(overlayBudgetComputedFields(ctx, budgetResp.JSON201, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -221,9 +223,9 @@ func (r *budgetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	// Plan-first state pattern: preserve user's plan values, overlay computed fields only.
 	plan.Id = state.Id
-	diags = mapBudgetToModel(ctx, updateResp.JSON200, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(overlayBudgetComputedFields(ctx, updateResp.JSON200, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -1609,8 +1609,29 @@ resource "doit_budget" "drift_test" {
 // TestAccBudget_OmittedOptionalComputed tests that omitting Optional+Computed scalar
 // fields does not cause drift. The plan-first overlay must resolve these unknowns
 // from the API response (or null) and the Read path must agree.
+//
+// Critically, this also verifies that omitted list fields (recipients_slack_channels,
+// scopes, seasonal_amounts) resolve to empty lists [] — not null — matching the
+// Read path (mapBudgetToModel). A null↔[] mismatch would cause state churn.
 func TestAccBudget_OmittedOptionalComputed(t *testing.T) {
 	n := acctest.RandInt()
+
+	// State checks that verify omitted list fields are empty lists, not null.
+	// This directly catches the null↔[] flip between Create/Update and Read.
+	omittedListChecks := []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(
+			"doit_budget.omitted_test",
+			tfjsonpath.New("recipients_slack_channels"),
+			knownvalue.ListSizeExact(0)),
+		statecheck.ExpectKnownValue(
+			"doit_budget.omitted_test",
+			tfjsonpath.New("scopes"),
+			knownvalue.ListSizeExact(0)),
+		statecheck.ExpectKnownValue(
+			"doit_budget.omitted_test",
+			tfjsonpath.New("seasonal_amounts"),
+			knownvalue.ListSizeExact(0)),
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		ExternalProviders: map[string]resource.ExternalProvider{
@@ -1623,7 +1644,8 @@ func TestAccBudget_OmittedOptionalComputed(t *testing.T) {
 		PreCheck:                 testAccPreCheckFunc(t),
 		TerraformVersionChecks:   testAccTFVersionChecks,
 		Steps: []resource.TestStep{
-			// Create a minimal budget omitting description, growth_per_period, metric, public
+			// Create a minimal budget omitting description, growth_per_period, metric, public,
+			// and all optional list fields (recipients_slack_channels, scopes, seasonal_amounts).
 			{
 				Config: testAccBudgetMinimalOmitted(n),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -1632,8 +1654,12 @@ func TestAccBudget_OmittedOptionalComputed(t *testing.T) {
 						plancheck.ExpectResourceAction("doit_budget.omitted_test", plancheck.ResourceActionCreate),
 					},
 				},
+				// Verify after create: omitted lists are [] not null
+				ConfigStateChecks: omittedListChecks,
 			},
-			// Drift check: re-apply same config, expect no changes
+			// Drift check: re-apply same config, expect no changes.
+			// After Read refreshes state from API, lists must still be [] — proving
+			// the overlay and Read path agree on the empty-list representation.
 			{
 				Config: testAccBudgetMinimalOmitted(n),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -1641,6 +1667,7 @@ func TestAccBudget_OmittedOptionalComputed(t *testing.T) {
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
+				ConfigStateChecks: omittedListChecks,
 			},
 		},
 	})

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -1795,3 +1795,257 @@ resource "doit_budget" "this" {
 }
 `, budgetStartPeriod(), i, testAttribution(), testUser(), testUser())
 }
+
+// TestAccBudget_UsePrevSpend tests use_prev_spend = true where the API computes
+// the amount from previous spend. Verifies the overlay correctly preserves the
+// user's use_prev_spend = true and doesn't drift on the API-computed amount.
+func TestAccBudget_UsePrevSpend(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Create with use_prev_spend = true
+			{
+				Config: testAccBudgetUsePrevSpend(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("use_prev_spend"),
+						knownvalue.Bool(true)),
+				},
+			},
+			// Drift check
+			{
+				Config: testAccBudgetUsePrevSpend(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetUsePrevSpend(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name           = "test-prevspend-%d"
+  currency       = "USD"
+  time_interval  = "month"
+  type           = "recurring"
+  start_period   = local.start_period
+  use_prev_spend = true
+  scope          = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 }
+  ]
+  recipients = ["%s"]
+}
+`, budgetStartPeriod(), i, testAttribution(), testUser(), testUser())
+}
+
+// TestAccBudget_FixedToRecurring tests converting a fixed budget to recurring.
+// The end_period field goes from set→omitted, and the overlay must correctly
+// handle this transition without drift.
+func TestAccBudget_FixedToRecurring(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create as fixed budget
+			{
+				Config: testAccBudgetFixedForConversion(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("type"),
+						knownvalue.StringExact("fixed")),
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("end_period"),
+						knownvalue.NotNull()),
+				},
+			},
+			// Step 2: Convert to recurring (end_period disappears)
+			{
+				Config: testAccBudgetRecurringFromFixed(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("type"),
+						knownvalue.StringExact("recurring")),
+				},
+			},
+			// Step 3: Drift check
+			{
+				Config: testAccBudgetRecurringFromFixed(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetFixedForConversion(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name         = "test-fix2rec-%d"
+  amount       = 500
+  currency     = "USD"
+  type         = "fixed"
+  start_period = local.start_period
+  end_period   = local.start_period + (30 * 24 * 60 * 60 * 1000)
+  scope        = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+}
+`, budgetStartPeriod(), i, testAttribution(), testUser())
+}
+
+func testAccBudgetRecurringFromFixed(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name          = "test-fix2rec-%d"
+  amount        = 500
+  currency      = "USD"
+  time_interval = "month"
+  type          = "recurring"
+  start_period  = local.start_period
+  scope         = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 }
+  ]
+  recipients = ["%s"]
+}
+`, budgetStartPeriod(), i, testAttribution(), testUser(), testUser())
+}
+
+// TestAccBudget_PublicField tests the public sharing access level field.
+// Verifies the value is preserved by the overlay and survives Read refresh.
+func TestAccBudget_PublicField(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Create with public = "viewer"
+			{
+				Config: testAccBudgetPublicField(n, "viewer"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("public"),
+						knownvalue.StringExact("viewer")),
+				},
+			},
+			// Drift check
+			{
+				Config: testAccBudgetPublicField(n, "viewer"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Update to public = "editor"
+			{
+				Config: testAccBudgetPublicField(n, "editor"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("public"),
+						knownvalue.StringExact("editor")),
+				},
+			},
+			// Drift check after update
+			{
+				Config: testAccBudgetPublicField(n, "editor"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetPublicField(i int, public string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name          = "test-public-%d"
+  amount        = 100
+  currency      = "USD"
+  time_interval = "month"
+  type          = "recurring"
+  start_period  = local.start_period
+  use_prev_spend = false
+  public        = "%s"
+  scope         = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 }
+  ]
+  recipients = ["%s"]
+}
+`, budgetStartPeriod(), i, public, testAttribution(), testUser(), testUser())
+}

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -1605,3 +1605,166 @@ resource "doit_budget" "drift_test" {
 }
 `, budgetStartPeriod(), i, testUser(), testUser())
 }
+
+// TestAccBudget_OmittedOptionalComputed tests that omitting Optional+Computed scalar
+// fields does not cause drift. The plan-first overlay must resolve these unknowns
+// from the API response (or null) and the Read path must agree.
+func TestAccBudget_OmittedOptionalComputed(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Create a minimal budget omitting description, growth_per_period, metric, public
+			{
+				Config: testAccBudgetMinimalOmitted(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("doit_budget.omitted_test", plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			// Drift check: re-apply same config, expect no changes
+			{
+				Config: testAccBudgetMinimalOmitted(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetMinimalOmitted(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "omitted_test" {
+  name          = "test-omitted-%d"
+  amount        = 100
+  currency      = "USD"
+  time_interval = "month"
+  type          = "recurring"
+  start_period  = local.start_period
+  use_prev_spend = false
+  scope         = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 }
+  ]
+  recipients = ["%s"]
+  # description, growth_per_period, metric, public are intentionally omitted
+}
+`, budgetStartPeriod(), i, testAttribution(), testUser(), testUser())
+}
+
+// TestAccBudget_UpdateOmittedField tests updating from a budget with all fields
+// set to one where some Optional+Computed fields are omitted, verifying no drift.
+func TestAccBudget_UpdateOmittedField(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with explicit description and growth_per_period
+			{
+				Config: testAccBudgetWithOptionalFields(n),
+			},
+			// Step 2: Update to omit description and growth_per_period
+			{
+				Config: testAccBudgetWithoutOptionalFields(n),
+			},
+			// Step 3: Drift check
+			{
+				Config: testAccBudgetWithoutOptionalFields(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetWithOptionalFields(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name              = "test-optional-%d"
+  amount            = 100
+  currency          = "USD"
+  time_interval     = "month"
+  type              = "recurring"
+  start_period      = local.start_period
+  use_prev_spend    = false
+  description       = "A test budget with optional fields"
+  growth_per_period = 5
+  metric            = "cost"
+  scope             = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 80 }
+  ]
+  recipients = ["%s"]
+}
+`, budgetStartPeriod(), i, testAttribution(), testUser(), testUser())
+}
+
+func testAccBudgetWithoutOptionalFields(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name          = "test-optional-%d"
+  amount        = 200
+  currency      = "USD"
+  time_interval = "month"
+  type          = "recurring"
+  start_period  = local.start_period
+  use_prev_spend = false
+  scope         = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 90 }
+  ]
+  recipients = ["%s"]
+  # description, growth_per_period, metric are intentionally omitted
+}
+`, budgetStartPeriod(), i, testAttribution(), testUser(), testUser())
+}

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -282,6 +282,24 @@ func TestAccBudget_Import(t *testing.T) {
 func TestAccBudget_Scopes(t *testing.T) {
 	n := acctest.RandInt()
 
+	// Verify omitted scope booleans resolve correctly from API response.
+	// These booleans are Optional+Computed and arrive as Unknown when the user
+	// omits them. The overlay resolves them from apiResp.Scopes[i].
+	scopeBoolChecks := []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(
+			"doit_budget.this",
+			tfjsonpath.New("scopes").AtSliceIndex(0).AtMapKey("inverse"),
+			knownvalue.Bool(false)),
+		statecheck.ExpectKnownValue(
+			"doit_budget.this",
+			tfjsonpath.New("scopes").AtSliceIndex(0).AtMapKey("include_null"),
+			knownvalue.Bool(false)),
+		statecheck.ExpectKnownValue(
+			"doit_budget.this",
+			tfjsonpath.New("scopes").AtSliceIndex(0).AtMapKey("case_insensitive"),
+			knownvalue.Bool(false)),
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {
@@ -300,7 +318,7 @@ func TestAccBudget_Scopes(t *testing.T) {
 						plancheck.ExpectNonEmptyPlan(),
 					},
 				},
-				ConfigStateChecks: []statecheck.StateCheck{
+				ConfigStateChecks: append([]statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"doit_budget.this",
 						tfjsonpath.New("scopes"),
@@ -314,9 +332,10 @@ func TestAccBudget_Scopes(t *testing.T) {
 						},
 						),
 					),
-				},
+				}, scopeBoolChecks...),
 			},
 			// Drift detection: re-apply same config, expect no changes.
+			// Verifies overlay and Read path agree on boolean resolution.
 			{
 				Config: testAccBudgetScopes(n),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -324,6 +343,7 @@ func TestAccBudget_Scopes(t *testing.T) {
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
+				ConfigStateChecks: scopeBoolChecks,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Applies the **plan-first state pattern** (established in #152 for allocations) to the budget resource.

Create and Update methods now preserve all user-configured values from the Terraform plan and only overlay server-assigned Computed fields from the API response via `overlayBudgetComputedFields`.

## Motivation

This prevents "Provider produced inconsistent result" errors caused by the API normalizing user-provided values (stripping `[... N/A]` sentinels, renaming type aliases like `allocation_rule` → `attribution`, not echoing `includeNull`/`caseInsensitive`).

Previously, the budget used `mapBudgetToModel` in Create/Update which overwrote all plan values with the API response. While `mapBudgetToModel` had inline workarounds for specific fields (sentinel restoration, alias normalization, includeNull preservation), the plan-first pattern eliminates the need for these workarounds in Create/Update entirely.

## Changes

### `budget.go`
- Add `overlayBudgetComputedFields` function with proper field classification:
  - **Computed-only**: `id`, `create_time`, `update_time`, `current_utilization`, `forecasted_utilization`
  - **Alerts**: preserve user `percentage`, overlay `forecasted_date`/`triggered`
  - **Optional+Computed scalars**: resolve from API only when `IsUnknown()`
  - **Nested unknowns**: resolve in `scopes[]`, `collaborators[]`, `recipients_slack_channels[]`
  - **API-defaulted lists**: resolve from API response (not null) for lists the API auto-populates
- Add doc comment to `mapBudgetToModel` clarifying it is Read/ImportState only

### `budget_resource.go`
- Wire `overlayBudgetComputedFields` into Create and Update methods
- Remove unused `types` import

### `budget_resource_test.go`
- Add `TestAccBudget_OmittedOptionalComputed` — verifies no drift when Optional+Computed scalars are omitted
- Add `TestAccBudget_UpdateOmittedField` — verifies updating from full config to minimal config produces no drift

## Test Results

All **19 budget tests pass** (17 existing + 2 new) with 0 regressions, including:
- ✅ Customer drift pattern test (`TestAccBudget_DriftDetection_CustomerPattern`)
- ✅ Import + drift check (`TestAccBudget_Import`)
- ✅ Sentinel restoration (`TestAccBudget_ScopeWithNAValue`, `_MixedNAValue`)
- ✅ Alias normalization (`TestAccBudget_ScopesAliasTypes`)
- ✅ Boolean flag tests (`TestAccBudget_IncludeNull`, `_CaseInsensitive`)
- ✅ List attribute lifecycle (`TestAccBudget_ListAttributes_Collaborators`, `_AlertsAndRecipients`)
- ✅ NEW: Omitted Optional+Computed (`TestAccBudget_OmittedOptionalComputed`)
- ✅ NEW: Update removing fields (`TestAccBudget_UpdateOmittedField`)
