### PR TITLE
test: skip support request acceptance tests

### DIFF
--- a/internal/provider/support_request_comments_data_source_test.go
+++ b/internal/provider/support_request_comments_data_source_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccSupportRequestCommentsDataSource_Basic(t *testing.T) {
+	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
 		PreCheck:                 testAccPreCheckFunc(t),

--- a/internal/provider/support_request_data_source_test.go
+++ b/internal/provider/support_request_data_source_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccSupportRequestDataSource_Basic(t *testing.T) {
+	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
 		PreCheck:                 testAccPreCheckFunc(t),

--- a/internal/provider/support_requests_data_source_test.go
+++ b/internal/provider/support_requests_data_source_test.go
@@ -97,6 +97,7 @@ data "doit_support_requests" "from_token" {
 
 // TestAccSupportRequestsDataSource_MaxResultsAndPageToken tests using both parameters together.
 func TestAccSupportRequestsDataSource_MaxResultsAndPageToken(t *testing.T) {
+	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	pageToken := getSupportRequestFirstPageToken(t, 1)
 	if pageToken == "" {
 		t.Skip("No page_token returned (need more than 1 support request)")
@@ -133,6 +134,7 @@ data "doit_support_requests" "paginated" {
 
 // TestAccSupportRequestsDataSource_AutoPagination tests that without max_results, all support requests are fetched.
 func TestAccSupportRequestsDataSource_AutoPagination(t *testing.T) {
+	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
 		PreCheck:                 testAccPreCheckFunc(t),


### PR DESCRIPTION
The support requests API is returning `400 'Failed to get tickets'`, causing 4 acceptance tests to fail:

- `TestAccSupportRequestsDataSource_MaxResultsAndPageToken`
- `TestAccSupportRequestsDataSource_AutoPagination`
- `TestAccSupportRequestDataSource_Basic`
- `TestAccSupportRequestCommentsDataSource_Basic`

Skip them until the API issue is resolved.

Ref: https://github.com/doitintl/terraform-provider-doit/actions/runs/24397755371/job/71259817552