### PR TITLE
refactor(annotation): adopt two-phase overlay pattern

### DIFF
--- a/internal/provider/annotation_resource.go
+++ b/internal/provider/annotation_resource.go
@@ -75,6 +75,46 @@ func (r *annotationResource) Schema(ctx context.Context, _ resource.SchemaReques
 	resp.Schema = s
 }
 
+// overlayAnnotationComputedFields uses the two-phase overlay pattern to reconcile
+// the Terraform plan with the API response after Create/Update.
+//
+// Phase 1 (Resolve): Build a fully-resolved state from the API response using
+// mapAnnotationToModel — the same mapping function used by Read.
+//
+// Phase 2 (Overlay): Walk the plan field-by-field. Known values are preserved.
+// Unknown values are replaced with the resolved counterpart.
+func overlayAnnotationComputedFields(ctx context.Context, apiResp *models.AnnotationListItem, plan *annotationResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Phase 1: Build fully-resolved state from API response.
+	resolved := *plan
+	diags.Append(mapAnnotationToModel(ctx, apiResp, &resolved)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Phase 2: Overlay known plan values on top of resolved state.
+
+	// ── Computed-only fields: always from resolved ──
+	plan.Id = resolved.Id
+	plan.CreateTime = resolved.CreateTime
+	plan.UpdateTime = resolved.UpdateTime
+
+	// ── Content, Timestamp: Required — never touch ──
+
+	// ── Labels: Optional+Computed list ──
+	if plan.Labels.IsUnknown() {
+		plan.Labels = resolved.Labels
+	}
+
+	// ── Reports: Optional+Computed list ──
+	if plan.Reports.IsUnknown() {
+		plan.Reports = resolved.Reports
+	}
+
+	return diags
+}
+
 func (r *annotationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan annotationResourceModel
 
@@ -148,9 +188,9 @@ func (r *annotationResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	// Map response to state
-	diags := mapAnnotationToModel(ctx, annotationResp.JSON201, &plan)
-	resp.Diagnostics.Append(diags...)
+	// Plan-first state pattern: keep all user-configured values from the plan
+	// exactly as-is, and only overlay Computed-only fields from the API response.
+	resp.Diagnostics.Append(overlayAnnotationComputedFields(ctx, annotationResp.JSON201, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -294,9 +334,10 @@ func (r *annotationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// Map response to state
-	diags := mapAnnotationToModel(ctx, updateResp.JSON200, &plan)
-	resp.Diagnostics.Append(diags...)
+	// Plan-first state pattern: keep all user-configured values from the plan
+	// exactly as-is, and only overlay Computed-only fields from the API response.
+	plan.Id = state.Id
+	resp.Diagnostics.Append(overlayAnnotationComputedFields(ctx, updateResp.JSON200, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/annotation_resource.go
+++ b/internal/provider/annotation_resource.go
@@ -188,8 +188,9 @@ func (r *annotationResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	// Plan-first state pattern: keep all user-configured values from the plan
-	// exactly as-is, and only overlay Computed-only fields from the API response.
+	// Plan-first state pattern: keep user-configured values from the plan
+	// as-is, and overlay API response values for Computed fields plus any
+	// Optional+Computed fields (labels, reports) that are still unknown.
 	resp.Diagnostics.Append(overlayAnnotationComputedFields(ctx, annotationResp.JSON201, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -334,9 +335,9 @@ func (r *annotationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// Plan-first state pattern: keep all user-configured values from the plan
-	// exactly as-is, and only overlay Computed-only fields from the API response.
-	plan.Id = state.Id
+	// Plan-first state pattern: keep user-configured values from the plan
+	// as-is, and overlay API response values for Computed fields plus any
+	// Optional+Computed fields (labels, reports) that are still unknown.
 	resp.Diagnostics.Append(overlayAnnotationComputedFields(ctx, updateResp.JSON200, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/annotation_resource_test.go
+++ b/internal/provider/annotation_resource_test.go
@@ -67,6 +67,15 @@ func TestAccAnnotation(t *testing.T) {
 						knownvalue.StringExact(fmt.Sprintf("Updated annotation content %d", n))),
 				},
 			},
+			// Step 3: Drift check — re-apply same updated config, expect no changes.
+			{
+				Config: testAccAnnotationUpdate(n, timestamp),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 		},
 	})
 }
@@ -87,6 +96,15 @@ func TestAccAnnotation_Import(t *testing.T) {
 				ResourceName:      "doit_annotation.this",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Step 3: Drift check — re-apply config after import, expect no changes.
+			{
+				Config: testAccAnnotation(n, timestamp),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Migrate the annotation resource to the **two-phase overlay pattern** used across all other resources (report, budget, allocation, alert).

### Two-Phase Pattern

**Phase 1 (Resolve):** Call `mapAnnotationToModel` on a copy of the plan to build a fully-resolved state from the API response.

**Phase 2 (Overlay):** Walk the plan field-by-field. Known values preserved, Unknown values resolved from API, Computed-only fields always from API.

### Changes

| File | Change |
|------|--------|
| `annotation_resource.go` | Add `overlayAnnotationComputedFields`; replace direct `mapAnnotationToModel` calls in Create/Update |
| `annotation_resource_test.go` | Add drift checks (`ExpectEmptyPlan`) after Update and Import |

### Field Classification

The annotation resource is simple (flat model, no nested objects):

| Field | Schema | Overlay behavior |
|-------|--------|-----------------|
| `content`, `timestamp` | Required | Never touch |
| `id`, `create_time`, `update_time` | Computed | Always from resolved |
| `labels`, `reports` | Optional+Computed | Resolve when Unknown |

### Testing

✅ All annotation resource tests pass locally (including two new drift checks)