### PR TITLE
refactor(label,datahub,asset): adopt two-phase overlay pattern

### DIFF
--- a/internal/provider/asset_resource.go
+++ b/internal/provider/asset_resource.go
@@ -248,7 +248,8 @@ func (r *assetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	// Plan-first state pattern: overlay Computed-only fields from API response.
+	// Plan-first state pattern: overlay Computed-only fields and resolve
+	// Optional+Computed fields (quantity) from the API when unknown.
 	resp.Diagnostics.Append(overlayAssetComputedFields(ctx, assetResp.JSON200, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/asset_resource.go
+++ b/internal/provider/asset_resource.go
@@ -173,7 +173,7 @@ func overlayAssetComputedFields(ctx context.Context, apiResp *models.AssetItemDe
 	}
 
 	// Phase 2: Overlay.
-	// Id: Required (user-specified for import-only) — never touch.
+	// Id: Computed-only, but safely preserved from the plan's prior state.
 	// Quantity: Optional+Computed — resolve when Unknown.
 	if plan.Quantity.IsUnknown() {
 		plan.Quantity = resolved.Quantity

--- a/internal/provider/asset_resource.go
+++ b/internal/provider/asset_resource.go
@@ -159,6 +159,36 @@ func (r *assetResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
+// overlayAssetComputedFields uses the two-phase overlay pattern to reconcile
+// the Terraform plan with the API response after Update.
+//
+// Asset is import-only (no Create). Only quantity is user-configurable;
+// all other fields are Computed-only.
+func overlayAssetComputedFields(ctx context.Context, apiResp *models.AssetItemDetailed, plan *assetResourceModel) diag.Diagnostics {
+	// Phase 1: Build fully-resolved state from API response.
+	resolved := *plan
+	diags := mapAssetToModel(ctx, apiResp, &resolved)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Phase 2: Overlay.
+	// Id: Required (user-specified for import-only) — never touch.
+	// Quantity: Optional+Computed — resolve when Unknown.
+	if plan.Quantity.IsUnknown() {
+		plan.Quantity = resolved.Quantity
+	}
+
+	// All other fields are Computed-only — always from resolved.
+	plan.Name = resolved.Name
+	plan.Type = resolved.Type
+	plan.Url = resolved.Url
+	plan.CreateTime = resolved.CreateTime
+	plan.Properties = resolved.Properties
+
+	return diags
+}
+
 func (r *assetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan assetResourceModel
 
@@ -218,7 +248,8 @@ func (r *assetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	resp.Diagnostics.Append(mapAssetToModel(ctx, assetResp.JSON200, &plan)...)
+	// Plan-first state pattern: overlay Computed-only fields from API response.
+	resp.Diagnostics.Append(overlayAssetComputedFields(ctx, assetResp.JSON200, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/datahub_dataset_resource.go
+++ b/internal/provider/datahub_dataset_resource.go
@@ -129,7 +129,8 @@ func (r *datahubDatasetResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	// Plan-first state pattern: overlay Computed-only fields from API response.
+	// Plan-first state pattern: overlay Computed-only fields and resolve
+	// Optional+Computed fields (description) from the API when unknown.
 	overlayDatahubDatasetComputedFields(createResp.JSON201.Name, createResp.JSON201.Description, createResp.JSON201.Records, createResp.JSON201.UpdatedBy, createResp.JSON201.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -223,7 +224,8 @@ func (r *datahubDatasetResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// Plan-first state pattern: overlay Computed-only fields from API response.
+	// Plan-first state pattern: overlay Computed-only fields and resolve
+	// Optional+Computed fields (description) from the API when unknown.
 	overlayDatahubDatasetComputedFields(updateResp.JSON200.Name, updateResp.JSON200.Description, updateResp.JSON200.Records, updateResp.JSON200.UpdatedBy, updateResp.JSON200.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/provider/datahub_dataset_resource.go
+++ b/internal/provider/datahub_dataset_resource.go
@@ -69,6 +69,26 @@ func (r *datahubDatasetResource) Schema(ctx context.Context, _ resource.SchemaRe
 	}
 }
 
+// overlayDatahubDatasetComputedFields uses the two-phase overlay pattern to
+// reconcile the Terraform plan with the API response after Create/Update.
+func overlayDatahubDatasetComputedFields(name, description *string, records *int64, updatedBy, lastUpdated *string, plan *datahubDatasetResourceModel) {
+	// Phase 1: Build fully-resolved state from API response.
+	resolved := *plan
+	mapDatahubDatasetToModel(name, description, records, updatedBy, lastUpdated, &resolved)
+
+	// Phase 2: Overlay.
+	// Name: Required — never touch.
+	// Records, UpdatedBy, LastUpdated: Computed-only — always from resolved.
+	plan.Records = resolved.Records
+	plan.UpdatedBy = resolved.UpdatedBy
+	plan.LastUpdated = resolved.LastUpdated
+
+	// Description: Optional+Computed — resolve when Unknown.
+	if plan.Description.IsUnknown() {
+		plan.Description = resolved.Description
+	}
+}
+
 func (r *datahubDatasetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan datahubDatasetResourceModel
 
@@ -109,7 +129,8 @@ func (r *datahubDatasetResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	mapDatahubDatasetToModel(createResp.JSON201.Name, createResp.JSON201.Description, createResp.JSON201.Records, createResp.JSON201.UpdatedBy, createResp.JSON201.LastUpdated, &plan)
+	// Plan-first state pattern: overlay Computed-only fields from API response.
+	overlayDatahubDatasetComputedFields(createResp.JSON201.Name, createResp.JSON201.Description, createResp.JSON201.Records, createResp.JSON201.UpdatedBy, createResp.JSON201.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -202,7 +223,8 @@ func (r *datahubDatasetResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	mapDatahubDatasetToModel(updateResp.JSON200.Name, updateResp.JSON200.Description, updateResp.JSON200.Records, updateResp.JSON200.UpdatedBy, updateResp.JSON200.LastUpdated, &plan)
+	// Plan-first state pattern: overlay Computed-only fields from API response.
+	overlayDatahubDatasetComputedFields(updateResp.JSON200.Name, updateResp.JSON200.Description, updateResp.JSON200.Records, updateResp.JSON200.UpdatedBy, updateResp.JSON200.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/label.go
+++ b/internal/provider/label.go
@@ -32,3 +32,23 @@ func mapLabelToModel(resp *models.LabelListItem, state *labelResourceModel) {
 		state.UpdateTime = types.StringNull()
 	}
 }
+
+// overlayLabelComputedFields uses the two-phase overlay pattern to reconcile
+// the Terraform plan with the API response after Create/Update.
+//
+// Label has no Optional+Computed fields — all non-Required fields are
+// Computed-only — so the overlay simply sets Computed fields from the
+// resolved model while preserving the plan's Required fields.
+func overlayLabelComputedFields(apiResp *models.LabelListItem, plan *labelResourceModel) {
+	// Phase 1: Build fully-resolved state from API response.
+	resolved := *plan
+	mapLabelToModel(apiResp, &resolved)
+
+	// Phase 2: Overlay Computed-only fields.
+	plan.Id = resolved.Id
+	plan.Type = resolved.Type
+	plan.CreateTime = resolved.CreateTime
+	plan.UpdateTime = resolved.UpdateTime
+
+	// Name, Color: Required — never touch.
+}

--- a/internal/provider/label_resource.go
+++ b/internal/provider/label_resource.go
@@ -214,7 +214,6 @@ func (r *labelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// Plan-first state pattern: overlay Computed-only fields from API response.
-	plan.Id = state.Id
 	overlayLabelComputedFields(updateResp.JSON200, &plan)
 
 	// Save updated data into Terraform state

--- a/internal/provider/label_resource.go
+++ b/internal/provider/label_resource.go
@@ -103,8 +103,8 @@ func (r *labelResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	// Map response to state
-	mapLabelToModel(labelResp.JSON201, &plan)
+	// Plan-first state pattern: overlay Computed-only fields from API response.
+	overlayLabelComputedFields(labelResp.JSON201, &plan)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -213,8 +213,9 @@ func (r *labelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	// Map response to state
-	mapLabelToModel(updateResp.JSON200, &plan)
+	// Plan-first state pattern: overlay Computed-only fields from API response.
+	plan.Id = state.Id
+	overlayLabelComputedFields(updateResp.JSON200, &plan)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/provider/label_resource_test.go
+++ b/internal/provider/label_resource_test.go
@@ -72,6 +72,15 @@ func TestAccLabel(t *testing.T) {
 						knownvalue.StringExact("mint")),
 				},
 			},
+			// Step 3: Drift check — re-apply same updated config, expect no changes.
+			{
+				Config: testAccLabelUpdate(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 		},
 	})
 }
@@ -91,6 +100,15 @@ func TestAccLabel_Import(t *testing.T) {
 				ResourceName:      "doit_label.this",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Step 3: Drift check — re-apply config after import, expect no changes.
+			{
+				Config: testAccLabel(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Migrate the **final three resources** to the two-phase overlay pattern for full consistency across the entire provider.

### Resources Changed

| Resource | Overlay Function | Optional+Computed Fields | Tests |
|----------|-----------------|-------------------------|-------|
| **label** | `overlayLabelComputedFields` | None (all Computed-only) | ✅ Added drift checks after Update + Import |
| **datahub_dataset** | `overlayDatahubDatasetComputedFields` | `description` | ✅ Existing drift checks pass |
| **asset** | `overlayAssetComputedFields` | `quantity` | ✅ Existing drift checks pass |

### Excluded

**`label_assignments`** — has no mapping function. All fields are Required; `id` is Computed but is just a copy of `label_id` set directly. No overlay needed.

### Two-Phase Pattern (for reference)

- **Phase 1 (Resolve):** Build fully-resolved state from API response using existing mapping function
- **Phase 2 (Overlay):** Walk plan field-by-field; Known values preserved, Unknown resolved from resolved model, Computed-only always from resolved

### Complete Overlay Coverage

After this PR, **every resource** in the provider uses the plan-first overlay pattern:

| Resource | PR |
|----------|-----|
| Report | Already on main |
| Budget | #156 |
| Allocation | #156 |
| Alert | #157 |
| Annotation | #158 |
| **Label** | **This PR** |
| **DataHub Dataset** | **This PR** |
| **Asset** | **This PR** |
| Label Assignments | N/A (no mapping) |

### Testing

All 19 affected tests pass locally (label, datahub_dataset, asset resources + data sources).