### PR TITLE
feat: add UseStateForUnknown to stable Computed-only fields

### DIFF
--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -8,6 +8,9 @@ import (
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_alert"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 // Ensure the implementation satisfies expected interfaces.
@@ -59,7 +62,20 @@ func (r *alertResource) ImportState(ctx context.Context, req resource.ImportStat
 }
 
 func (r *alertResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_alert.AlertResourceSchema(ctx)
+	s := resource_alert.AlertResourceSchema(ctx)
+
+	// Add UseStateForUnknown to stable Computed-only fields so they don't
+	// show as "(known after apply)" on every plan that modifies the resource.
+	if attr, ok := s.Attributes["id"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["id"] = attr
+	}
+	if attr, ok := s.Attributes["create_time"].(schema.Int64Attribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, int64planmodifier.UseStateForUnknown())
+		s.Attributes["create_time"] = attr
+	}
+
+	resp.Schema = s
 }
 
 func (r *alertResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {

--- a/internal/provider/allocation_resource.go
+++ b/internal/provider/allocation_resource.go
@@ -13,6 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 type (
@@ -95,6 +98,29 @@ func (r *allocationResource) Schema(ctx context.Context, _ resource.SchemaReques
 			}
 			s.Attributes["rule"] = singleAttr
 		}
+	}
+
+	// Add UseStateForUnknown to stable Computed-only fields so they don't
+	// show as "(known after apply)" on every plan that modifies the resource.
+	if attr, ok := s.Attributes["id"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["id"] = attr
+	}
+	if attr, ok := s.Attributes["create_time"].(schema.Int64Attribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, int64planmodifier.UseStateForUnknown())
+		s.Attributes["create_time"] = attr
+	}
+	if attr, ok := s.Attributes["allocation_type"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["allocation_type"] = attr
+	}
+	if attr, ok := s.Attributes["anomaly_detection"].(schema.BoolAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, boolplanmodifier.UseStateForUnknown())
+		s.Attributes["anomaly_detection"] = attr
+	}
+	if attr, ok := s.Attributes["type"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["type"] = attr
 	}
 
 	resp.Schema = s

--- a/internal/provider/annotation_resource.go
+++ b/internal/provider/annotation_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -70,6 +71,17 @@ func (r *annotationResource) Schema(ctx context.Context, _ resource.SchemaReques
 			strAttr.Validators = append(strAttr.Validators, rfc3339Validator{})
 			s.Attributes["timestamp"] = strAttr
 		}
+	}
+
+	// Add UseStateForUnknown to stable Computed-only fields so they don't
+	// show as "(known after apply)" on every plan that modifies the resource.
+	if attr, ok := s.Attributes["id"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["id"] = attr
+	}
+	if attr, ok := s.Attributes["create_time"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["create_time"] = attr
 	}
 
 	resp.Schema = s

--- a/internal/provider/budget_resource.go
+++ b/internal/provider/budget_resource.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 const budgetSchemaVersion = 1
@@ -74,6 +76,17 @@ func (r *budgetResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 			int64Attr.Validators = append(int64Attr.Validators, budgetEndPeriodValidator{})
 			s.Attributes["end_period"] = int64Attr
 		}
+	}
+
+	// Add UseStateForUnknown to stable Computed-only fields so they don't
+	// show as "(known after apply)" on every plan that modifies the resource.
+	if attr, ok := s.Attributes["id"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["id"] = attr
+	}
+	if attr, ok := s.Attributes["create_time"].(schema.Int64Attribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, int64planmodifier.UseStateForUnknown())
+		s.Attributes["create_time"] = attr
 	}
 
 	resp.Schema = s

--- a/internal/provider/label_resource.go
+++ b/internal/provider/label_resource.go
@@ -8,6 +8,8 @@ import (
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_label"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 type (
@@ -58,7 +60,24 @@ func (r *labelResource) ImportState(ctx context.Context, req resource.ImportStat
 }
 
 func (r *labelResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_label.LabelResourceSchema(ctx)
+	s := resource_label.LabelResourceSchema(ctx)
+
+	// Add UseStateForUnknown to stable Computed-only fields so they don't
+	// show as "(known after apply)" on every plan that modifies the resource.
+	if attr, ok := s.Attributes["id"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["id"] = attr
+	}
+	if attr, ok := s.Attributes["create_time"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["create_time"] = attr
+	}
+	if attr, ok := s.Attributes["type"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["type"] = attr
+	}
+
+	resp.Schema = s
 }
 
 func (r *labelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/report_resource.go
+++ b/internal/provider/report_resource.go
@@ -8,6 +8,8 @@ import (
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_report"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 var (
@@ -35,7 +37,20 @@ func (r *reportResource) Metadata(_ context.Context, req resource.MetadataReques
 }
 
 func (r *reportResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_report.ReportResourceSchema(ctx)
+	s := resource_report.ReportResourceSchema(ctx)
+
+	// Add UseStateForUnknown to stable Computed-only fields so they don't
+	// show as "(known after apply)" on every plan that modifies the resource.
+	if attr, ok := s.Attributes["id"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["id"] = attr
+	}
+	if attr, ok := s.Attributes["type"].(schema.StringAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+		s.Attributes["type"] = attr
+	}
+
+	resp.Schema = s
 }
 func (r *reportResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {


### PR DESCRIPTION
## Summary

Adds `UseStateForUnknown()` plan modifiers to Computed-only fields that are **stable after creation**, eliminating noisy `(known after apply)` lines in plans for values that never change.

### Before
```
~ resource "doit_budget" "example" {
    ~ id          = "abc123" -> (known after apply)
    ~ create_time = 1713000000 -> (known after apply)
    ~ update_time = 1713000000 -> (known after apply)
      name        = "My Budget"
      ...
  }
```

### After
```
~ resource "doit_budget" "example" {
      id          = "abc123"
      create_time = 1713000000
    ~ update_time = 1713000000 -> (known after apply)
      name        = "My Budget"
      ...
  }
```

`update_time` correctly stays as "(known after apply)" because it changes on update.

### Fields Modified

| Resource | Fields | Plan Modifier |
|----------|--------|---------------|
| **alert** | `id`, `create_time` | `stringplanmodifier`, `int64planmodifier` |
| **allocation** | `id`, `create_time`, `allocation_type`, `anomaly_detection`, `type` | `stringplanmodifier`, `int64planmodifier`, `boolplanmodifier` |
| **annotation** | `id`, `create_time` | `stringplanmodifier` |
| **budget** | `id`, `create_time` | `stringplanmodifier`, `int64planmodifier` |
| **label** | `id`, `create_time`, `type` | `stringplanmodifier` |
| **report** | `id`, `type` | `stringplanmodifier` |

### Intentionally Excluded

Fields that change on update or externally are **not** marked with UseStateForUnknown:
- `update_time` — changes on every update
- `last_alerted` — changes when alert fires
- `current_utilization`, `forecasted_utilization` — change as spending occurs
- `triggered` — changes when budget alert triggers
- `datahub_dataset` fields (`records`, `updated_by`, `last_updated`) — all change on data ingestion

### Already done (no changes needed)
- `asset`: `name`, `type`, `url`, `create_time`
- `label_assignments`: `id`

### Testing

All 6 acceptance tests pass: alert, allocation, annotation, budget, label, report.