### PR TITLE
Revert "test: skip support request acceptance tests (#155)"

### DIFF
--- a/internal/provider/support_request_comments_data_source_test.go
+++ b/internal/provider/support_request_comments_data_source_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestAccSupportRequestCommentsDataSource_Basic(t *testing.T) {
-	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
 		PreCheck:                 testAccPreCheckFunc(t),

--- a/internal/provider/support_request_data_source_test.go
+++ b/internal/provider/support_request_data_source_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestAccSupportRequestDataSource_Basic(t *testing.T) {
-	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
 		PreCheck:                 testAccPreCheckFunc(t),

--- a/internal/provider/support_requests_data_source_test.go
+++ b/internal/provider/support_requests_data_source_test.go
@@ -98,7 +98,6 @@ data "doit_support_requests" "from_token" {
 
 // TestAccSupportRequestsDataSource_MaxResultsAndPageToken tests using both parameters together.
 func TestAccSupportRequestsDataSource_MaxResultsAndPageToken(t *testing.T) {
-	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	pageToken := getSupportRequestFirstPageToken(t, 1)
 	if pageToken == "" {
 		t.Skip("No page_token returned (need more than 1 support request)")
@@ -135,7 +134,6 @@ data "doit_support_requests" "paginated" {
 
 // TestAccSupportRequestsDataSource_AutoPagination tests that without max_results, all support requests are fetched.
 func TestAccSupportRequestsDataSource_AutoPagination(t *testing.T) {
-	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
 		PreCheck:                 testAccPreCheckFunc(t),


### PR DESCRIPTION
The support requests API no longer returns `400 "Failed to get tickets"`. Re-enable the 4 tests that were skipped in #155:

- `TestAccSupportRequestDataSource_Basic`
- `TestAccSupportRequestCommentsDataSource_Basic`  
- `TestAccSupportRequestsDataSource_MaxResultsAndPageToken`
- `TestAccSupportRequestsDataSource_AutoPagination`

Verified locally:
- All 3 working tests pass ✅
- The 3 pagination-dependent tests (`MaxResultsOnly`, `PageTokenOnly`, `MaxResultsAndPageToken`) gracefully self-skip via their existing guards when `maxResults` is ignored by the API

Reverts doitintl/terraform-provider-doit#155