### PR TITLE
fix(makefile): quote TEST variable in testacc-run target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,7 +43,7 @@ testacc:
 # Run a specific acceptance test
 # Usage: make testacc-run TEST=TestAccBudget
 testacc-run:
-	@test -f .envrc.local && . ./.envrc.local; TF_ACC=1 go test -v -timeout 120m ./internal/provider/... -run $(TEST)
+	@test -f .envrc.local && . ./.envrc.local; TF_ACC=1 go test -v -timeout 120m ./internal/provider/... -run '$(TEST)'
 
 # Validate all examples against the provider schema
 validate-examples:


### PR DESCRIPTION
Wrap $(TEST) in single quotes so that regex metacharacters like | are passed literally to 'go test -run' instead of being interpreted by the shell as a pipe operator.

Before: make testacc-run TEST='TestA|TestB' would pipe go test output into a 'TestB' command.

After: the pipe is correctly treated as regex alternation, matching both TestA and TestB test functions.