### PR TITLE
feat: add labels (cost-allocation tags) to anomaly resource data

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -1301,6 +1301,38 @@
 														}
 													},
 													{
+														"name": "labels",
+														"list_nested": {
+															"computed_optional_required": "computed",
+															"nested_object": {
+																"attributes": [
+																	{
+																		"name": "cost",
+																		"float64": {
+																			"computed_optional_required": "computed",
+																			"description": "The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend."
+																		}
+																	},
+																	{
+																		"name": "key",
+																		"string": {
+																			"computed_optional_required": "computed",
+																			"description": "The label/tag key."
+																		}
+																	},
+																	{
+																		"name": "value",
+																		"string": {
+																			"computed_optional_required": "computed",
+																			"description": "The label/tag value."
+																		}
+																	}
+																]
+															},
+															"description": "Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.\nCloud providers use different names for the same concept; GCP uses \"labels\", AWS uses \"cost-allocation tags\", and Azure uses \"tags\". We refer to all of these as labels."
+														}
+													},
+													{
 														"name": "operation",
 														"string": {
 															"computed_optional_required": "computed",
@@ -1466,6 +1498,38 @@
 										"name": "cost",
 										"float64": {
 											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "labels",
+										"list_nested": {
+											"computed_optional_required": "computed",
+											"nested_object": {
+												"attributes": [
+													{
+														"name": "cost",
+														"float64": {
+															"computed_optional_required": "computed",
+															"description": "The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend."
+														}
+													},
+													{
+														"name": "key",
+														"string": {
+															"computed_optional_required": "computed",
+															"description": "The label/tag key."
+														}
+													},
+													{
+														"name": "value",
+														"string": {
+															"computed_optional_required": "computed",
+															"description": "The label/tag value."
+														}
+													}
+												]
+											},
+											"description": "Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.\nCloud providers use different names for the same concept; GCP uses \"labels\", AWS uses \"cost-allocation tags\", and Azure uses \"tags\". We refer to all of these as labels."
 										}
 									},
 									{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -4030,11 +4030,33 @@ components:
         operation:
           description: "For anomalies related to AWS S3"
           type: string
+        labels:
+          type: array
+          description: |-
+            Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.
+            Cloud providers use different names for the same concept; GCP uses "labels", AWS uses "cost-allocation tags", and Azure uses "tags". We refer to all of these as labels.
+          items:
+            $ref: "#/components/schemas/AnomalyResourceLabel"
     AnomalyResourceArray:
       type: array
       description: Array of resources contributing to an anomaly.
       items:
         $ref: "#/components/schemas/AnomalyResource"
+    AnomalyResourceLabel:
+      type: object
+      description: |-
+        A single label (a.k.a. cost-allocation tag) on the resource, paired with the resource's cost tagged with this key/value pair.
+      properties:
+        key:
+          type: string
+          description: The label/tag key.
+        value:
+          type: string
+          description: The label/tag value.
+        cost:
+          type: number
+          format: double
+          description: The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.
     AssetResponse:
       type: object
       description: Response returned after creating or updating an asset.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -3330,11 +3330,33 @@ components:
         operation:
           description: "For anomalies related to AWS S3"
           type: string
+        labels:
+          type: array
+          description: |-
+            Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.
+            Cloud providers use different names for the same concept; GCP uses "labels", AWS uses "cost-allocation tags", and Azure uses "tags". We refer to all of these as labels.
+          items:
+            $ref: "#/components/schemas/AnomalyResourceLabel"
     AnomalyResourceArray:
       type: array
       description: Array of resources contributing to an anomaly.
       items:
         $ref: "#/components/schemas/AnomalyResource"
+    AnomalyResourceLabel:
+      type: object
+      description: |-
+        A single label (a.k.a. cost-allocation tag) on the resource, paired with the resource's cost tagged with this key/value pair.
+      properties:
+        key:
+          type: string
+          description: The label/tag key.
+        value:
+          type: string
+          description: The label/tag value.
+        cost:
+          type: number
+          format: double
+          description: The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.
     AnomalySKU:
       type: object
       description: SKU-level information contributing to an anomaly.

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -131,9 +131,21 @@ Read-Only:
 Read-Only:
 
 - `cost` (Number)
+- `labels` (Attributes List) Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.
+Cloud providers use different names for the same concept; GCP uses "labels", AWS uses "cost-allocation tags", and Azure uses "tags". We refer to all of these as labels. (see [below for nested schema](#nestedatt--anomalies--resource_data--labels))
 - `operation` (String) For anomalies related to AWS S3
 - `resource_id` (String)
 - `sku_description` (String)
+
+<a id="nestedatt--anomalies--resource_data--labels"></a>
+### Nested Schema for `anomalies.resource_data.labels`
+
+Read-Only:
+
+- `cost` (Number) The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.
+- `key` (String) The label/tag key.
+- `value` (String) The label/tag value.
+
 
 
 <a id="nestedatt--anomalies--top3skus"></a>

--- a/docs/data-sources/anomaly.md
+++ b/docs/data-sources/anomaly.md
@@ -78,9 +78,21 @@ Optional:
 Read-Only:
 
 - `cost` (Number)
+- `labels` (Attributes List) Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.
+Cloud providers use different names for the same concept; GCP uses "labels", AWS uses "cost-allocation tags", and Azure uses "tags". We refer to all of these as labels. (see [below for nested schema](#nestedatt--resource_data--labels))
 - `operation` (String) For anomalies related to AWS S3
 - `resource_id` (String)
 - `sku_description` (String)
+
+<a id="nestedatt--resource_data--labels"></a>
+### Nested Schema for `resource_data.labels`
+
+Read-Only:
+
+- `cost` (Number) The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.
+- `key` (String) The label/tag key.
+- `value` (String) The label/tag value.
+
 
 
 <a id="nestedatt--top3skus"></a>

--- a/internal/provider/anomalies_data_source.go
+++ b/internal/provider/anomalies_data_source.go
@@ -247,10 +247,14 @@ func mapAnomalyResourceData(ctx context.Context, resourceData *models.AnomalyRes
 
 	vals := make([]datasource_anomalies.ResourceDataValue, 0, len(*resourceData))
 	for _, rd := range *resourceData {
+		// Map labels nested list for this resource
+		labelsList := mapAnomalyResourceLabels(ctx, rd.Labels, diagnostics)
+
 		rdVal, diags := datasource_anomalies.NewResourceDataValue(
 			datasource_anomalies.ResourceDataValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
 				"cost":            types.Float64PointerValue(rd.Cost),
+				"labels":          labelsList,
 				"operation":       types.StringPointerValue(rd.Operation),
 				"resource_id":     types.StringPointerValue(rd.ResourceId),
 				"sku_description": types.StringPointerValue(rd.SkuDescription),
@@ -261,6 +265,33 @@ func mapAnomalyResourceData(ctx context.Context, resourceData *models.AnomalyRes
 	}
 
 	list, diags := types.ListValueFrom(ctx, datasource_anomalies.ResourceDataValue{}.Type(ctx), vals)
+	diagnostics.Append(diags...)
+	return list
+}
+
+// mapAnomalyResourceLabels maps API AnomalyResourceLabel slice to Terraform list.
+func mapAnomalyResourceLabels(ctx context.Context, labels *[]models.AnomalyResourceLabel, diagnostics *diag.Diagnostics) types.List {
+	if labels == nil || len(*labels) == 0 {
+		emptyLabels, d := types.ListValueFrom(ctx, datasource_anomalies.LabelsValue{}.Type(ctx), []datasource_anomalies.LabelsValue{})
+		diagnostics.Append(d...)
+		return emptyLabels
+	}
+
+	vals := make([]datasource_anomalies.LabelsValue, 0, len(*labels))
+	for _, l := range *labels {
+		labelVal, diags := datasource_anomalies.NewLabelsValue(
+			datasource_anomalies.LabelsValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"cost":  types.Float64PointerValue(l.Cost),
+				"key":   types.StringPointerValue(l.Key),
+				"value": types.StringPointerValue(l.Value),
+			},
+		)
+		diagnostics.Append(diags...)
+		vals = append(vals, labelVal)
+	}
+
+	list, diags := types.ListValueFrom(ctx, datasource_anomalies.LabelsValue{}.Type(ctx), vals)
 	diagnostics.Append(diags...)
 	return list
 }

--- a/internal/provider/anomalies_data_source_test.go
+++ b/internal/provider/anomalies_data_source_test.go
@@ -155,6 +155,49 @@ data "doit_anomalies" "test" {
 `
 }
 
+// TestAccAnomaliesDataSource_ResourceDataLabels verifies that the labels nested
+// attribute inside resource_data is accessible on anomalies list items.
+func TestAccAnomaliesDataSource_ResourceDataLabels(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomaliesDataSourceLabelsConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.labels_test", "row_count"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceLabelsConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAnomaliesDataSourceLabelsConfig() string {
+	return `
+data "doit_anomalies" "labels_test" {
+  max_results = 1
+}
+
+output "anomaly_resource_labels" {
+  value = [
+    for a in data.doit_anomalies.labels_test.anomalies : [
+      for rd in a.resource_data : rd.labels
+    ]
+  ]
+}
+`
+}
+
 // Helper functions
 
 var (

--- a/internal/provider/anomaly_data_source.go
+++ b/internal/provider/anomaly_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -143,10 +144,14 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 	if anomaly.ResourceData != nil && len(*anomaly.ResourceData) > 0 {
 		resourceDataVals := make([]datasource_anomaly.ResourceDataValue, 0, len(*anomaly.ResourceData))
 		for _, rd := range *anomaly.ResourceData {
+			// Map labels nested list for this resource
+			labelsList := mapAnomalyResourceLabelsForAnomaly(ctx, rd.Labels, &resp.Diagnostics)
+
 			rdVal, d := datasource_anomaly.NewResourceDataValue(
 				datasource_anomaly.ResourceDataValue{}.AttributeTypes(ctx),
 				map[string]attr.Value{
 					"cost":            types.Float64PointerValue(rd.Cost),
+					"labels":          labelsList,
 					"operation":       types.StringPointerValue(rd.Operation),
 					"resource_id":     types.StringPointerValue(rd.ResourceId),
 					"sku_description": types.StringPointerValue(rd.SkuDescription),
@@ -188,4 +193,32 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// mapAnomalyResourceLabelsForAnomaly maps API AnomalyResourceLabel slice to Terraform list
+// for the singular anomaly data source.
+func mapAnomalyResourceLabelsForAnomaly(ctx context.Context, labels *[]models.AnomalyResourceLabel, diagnostics *diag.Diagnostics) types.List {
+	if labels == nil || len(*labels) == 0 {
+		emptyLabels, d := types.ListValueFrom(ctx, datasource_anomaly.LabelsValue{}.Type(ctx), []datasource_anomaly.LabelsValue{})
+		diagnostics.Append(d...)
+		return emptyLabels
+	}
+
+	vals := make([]datasource_anomaly.LabelsValue, 0, len(*labels))
+	for _, l := range *labels {
+		labelVal, diags := datasource_anomaly.NewLabelsValue(
+			datasource_anomaly.LabelsValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"cost":  types.Float64PointerValue(l.Cost),
+				"key":   types.StringPointerValue(l.Key),
+				"value": types.StringPointerValue(l.Value),
+			},
+		)
+		diagnostics.Append(diags...)
+		vals = append(vals, labelVal)
+	}
+
+	list, diags := types.ListValueFrom(ctx, datasource_anomaly.LabelsValue{}.Type(ctx), vals)
+	diagnostics.Append(diags...)
+	return list
 }

--- a/internal/provider/anomaly_data_source_test.go
+++ b/internal/provider/anomaly_data_source_test.go
@@ -26,6 +26,7 @@ func TestAccAnomalyDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.doit_anomaly.test", "id", anomalyID),
 					resource.TestCheckResourceAttrSet("data.doit_anomaly.test", "platform"),
 					resource.TestCheckResourceAttrSet("data.doit_anomaly.test", "service_name"),
+					resource.TestCheckResourceAttrSet("data.doit_anomaly.test", "resource_data.#"),
 				),
 			},
 			// Drift verification: re-apply the same config should produce an empty plan
@@ -41,10 +42,57 @@ func TestAccAnomalyDataSource_Basic(t *testing.T) {
 	})
 }
 
+// TestAccAnomalyDataSource_ResourceDataLabels verifies that the labels nested
+// attribute inside resource_data is populated correctly (may be empty list for
+// anomalies without cost-allocation tags).
+func TestAccAnomalyDataSource_ResourceDataLabels(t *testing.T) {
+	anomalyID := os.Getenv("TEST_ANOMALY_ID")
+	if anomalyID == "" {
+		t.Skip("TEST_ANOMALY_ID environment variable not set")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomalyDataSourceConfigWithLabelsOutput(anomalyID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.doit_anomaly.test", "id", anomalyID),
+					// Verify resource_data exists and each item has a labels attribute
+					resource.TestCheckResourceAttrSet("data.doit_anomaly.test", "resource_data.#"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomalyDataSourceConfigWithLabelsOutput(anomalyID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccAnomalyDataSourceConfig(id string) string {
 	return fmt.Sprintf(`
 data "doit_anomaly" "test" {
   id = %[1]q
+}
+`, id)
+}
+
+func testAccAnomalyDataSourceConfigWithLabelsOutput(id string) string {
+	return fmt.Sprintf(`
+data "doit_anomaly" "test" {
+  id = %[1]q
+}
+
+output "resource_labels" {
+  value = [for rd in data.doit_anomaly.test.resource_data : rd.labels]
 }
 `, id)
 }

--- a/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
+++ b/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
@@ -60,6 +60,35 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 									"cost": schema.Float64Attribute{
 										Computed: true,
 									},
+									"labels": schema.ListNestedAttribute{
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"cost": schema.Float64Attribute{
+													Computed:            true,
+													Description:         "The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.",
+													MarkdownDescription: "The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.",
+												},
+												"key": schema.StringAttribute{
+													Computed:            true,
+													Description:         "The label/tag key.",
+													MarkdownDescription: "The label/tag key.",
+												},
+												"value": schema.StringAttribute{
+													Computed:            true,
+													Description:         "The label/tag value.",
+													MarkdownDescription: "The label/tag value.",
+												},
+											},
+											CustomType: LabelsType{
+												ObjectType: types.ObjectType{
+													AttrTypes: LabelsValue{}.AttributeTypes(ctx),
+												},
+											},
+										},
+										Computed:            true,
+										Description:         "Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.\nCloud providers use different names for the same concept; GCP uses \"labels\", AWS uses \"cost-allocation tags\", and Azure uses \"tags\". We refer to all of these as labels.",
+										MarkdownDescription: "Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.\nCloud providers use different names for the same concept; GCP uses \"labels\", AWS uses \"cost-allocation tags\", and Azure uses \"tags\". We refer to all of these as labels.",
+									},
 									"operation": schema.StringAttribute{
 										Computed:            true,
 										Description:         "For anomalies related to AWS S3",
@@ -1349,6 +1378,24 @@ func (t ResourceDataType) ValueFromObject(ctx context.Context, in basetypes.Obje
 			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
 	}
 
+	labelsAttribute, ok := attributes["labels"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`labels is missing from object`)
+
+		return nil, diags
+	}
+
+	labelsVal, ok := labelsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`labels expected to be basetypes.ListValue, was: %T`, labelsAttribute))
+	}
+
 	operationAttribute, ok := attributes["operation"]
 
 	if !ok {
@@ -1409,6 +1456,7 @@ func (t ResourceDataType) ValueFromObject(ctx context.Context, in basetypes.Obje
 
 	return ResourceDataValue{
 		Cost:           costVal,
+		Labels:         labelsVal,
 		Operation:      operationVal,
 		ResourceId:     resourceIdVal,
 		SkuDescription: skuDescriptionVal,
@@ -1497,6 +1545,24 @@ func NewResourceDataValue(attributeTypes map[string]attr.Type, attributes map[st
 			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
 	}
 
+	labelsAttribute, ok := attributes["labels"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`labels is missing from object`)
+
+		return NewResourceDataValueUnknown(), diags
+	}
+
+	labelsVal, ok := labelsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`labels expected to be basetypes.ListValue, was: %T`, labelsAttribute))
+	}
+
 	operationAttribute, ok := attributes["operation"]
 
 	if !ok {
@@ -1557,6 +1623,7 @@ func NewResourceDataValue(attributeTypes map[string]attr.Type, attributes map[st
 
 	return ResourceDataValue{
 		Cost:           costVal,
+		Labels:         labelsVal,
 		Operation:      operationVal,
 		ResourceId:     resourceIdVal,
 		SkuDescription: skuDescriptionVal,
@@ -1633,6 +1700,7 @@ var _ basetypes.ObjectValuable = ResourceDataValue{}
 
 type ResourceDataValue struct {
 	Cost           basetypes.Float64Value `tfsdk:"cost"`
+	Labels         basetypes.ListValue    `tfsdk:"labels"`
 	Operation      basetypes.StringValue  `tfsdk:"operation"`
 	ResourceId     basetypes.StringValue  `tfsdk:"resource_id"`
 	SkuDescription basetypes.StringValue  `tfsdk:"sku_description"`
@@ -1640,12 +1708,15 @@ type ResourceDataValue struct {
 }
 
 func (v ResourceDataValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 4)
+	attrTypes := make(map[string]tftypes.Type, 5)
 
 	var val tftypes.Value
 	var err error
 
 	attrTypes["cost"] = basetypes.Float64Type{}.TerraformType(ctx)
+	attrTypes["labels"] = basetypes.ListType{
+		ElemType: LabelsValue{}.Type(ctx),
+	}.TerraformType(ctx)
 	attrTypes["operation"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["resource_id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["sku_description"] = basetypes.StringType{}.TerraformType(ctx)
@@ -1654,7 +1725,7 @@ func (v ResourceDataValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 4)
+		vals := make(map[string]tftypes.Value, 5)
 
 		val, err = v.Cost.ToTerraformValue(ctx)
 
@@ -1663,6 +1734,14 @@ func (v ResourceDataValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		}
 
 		vals["cost"] = val
+
+		val, err = v.Labels.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["labels"] = val
 
 		val, err = v.Operation.ToTerraformValue(ctx)
 
@@ -1717,8 +1796,17 @@ func (v ResourceDataValue) String() string {
 func (v ResourceDataValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	var labels attr.Value
+
+	{
+		labels = v.Labels
+	}
+
 	attributeTypes := map[string]attr.Type{
-		"cost":            basetypes.Float64Type{},
+		"cost": basetypes.Float64Type{},
+		"labels": basetypes.ListType{
+			ElemType: LabelsValue{}.Type(ctx),
+		},
 		"operation":       basetypes.StringType{},
 		"resource_id":     basetypes.StringType{},
 		"sku_description": basetypes.StringType{},
@@ -1736,6 +1824,7 @@ func (v ResourceDataValue) ToObjectValue(ctx context.Context) (basetypes.ObjectV
 		attributeTypes,
 		map[string]attr.Value{
 			"cost":            v.Cost,
+			"labels":          labels,
 			"operation":       v.Operation,
 			"resource_id":     v.ResourceId,
 			"sku_description": v.SkuDescription,
@@ -1760,6 +1849,10 @@ func (v ResourceDataValue) Equal(o attr.Value) bool {
 	}
 
 	if !v.Cost.Equal(other.Cost) {
+		return false
+	}
+
+	if !v.Labels.Equal(other.Labels) {
 		return false
 	}
 
@@ -1788,10 +1881,447 @@ func (v ResourceDataValue) Type(ctx context.Context) attr.Type {
 
 func (v ResourceDataValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"cost":            basetypes.Float64Type{},
+		"cost": basetypes.Float64Type{},
+		"labels": basetypes.ListType{
+			ElemType: LabelsValue{}.Type(ctx),
+		},
 		"operation":       basetypes.StringType{},
 		"resource_id":     basetypes.StringType{},
 		"sku_description": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = LabelsType{}
+
+type LabelsType struct {
+	basetypes.ObjectType
+}
+
+func (t LabelsType) Equal(o attr.Type) bool {
+	other, ok := o.(LabelsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t LabelsType) String() string {
+	return "LabelsType"
+}
+
+func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	costAttribute, ok := attributes["cost"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cost is missing from object`)
+
+		return nil, diags
+	}
+
+	costVal, ok := costAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return nil, diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return nil, diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return LabelsValue{
+		Cost:  costVal,
+		Key:   keyVal,
+		Value: valueVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelsValueNull() LabelsValue {
+	return LabelsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewLabelsValueUnknown() LabelsValue {
+	return LabelsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewLabelsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (LabelsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing LabelsValue Attribute Value",
+				"While creating a LabelsValue value, a missing attribute value was detected. "+
+					"A LabelsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid LabelsValue Attribute Type",
+				"While creating a LabelsValue value, an invalid attribute value was detected. "+
+					"A LabelsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("LabelsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra LabelsValue Attribute Value",
+				"While creating a LabelsValue value, an extra attribute value was detected. "+
+					"A LabelsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra LabelsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewLabelsValueUnknown(), diags
+	}
+
+	costAttribute, ok := attributes["cost"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cost is missing from object`)
+
+		return NewLabelsValueUnknown(), diags
+	}
+
+	costVal, ok := costAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return NewLabelsValueUnknown(), diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return NewLabelsValueUnknown(), diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return NewLabelsValueUnknown(), diags
+	}
+
+	return LabelsValue{
+		Cost:  costVal,
+		Key:   keyVal,
+		Value: valueVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) LabelsValue {
+	object, diags := NewLabelsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewLabelsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t LabelsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewLabelsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewLabelsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewLabelsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewLabelsValueMust(LabelsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t LabelsType) ValueType(ctx context.Context) attr.Value {
+	return LabelsValue{}
+}
+
+var _ basetypes.ObjectValuable = LabelsValue{}
+
+type LabelsValue struct {
+	Cost  basetypes.Float64Value `tfsdk:"cost"`
+	Key   basetypes.StringValue  `tfsdk:"key"`
+	Value basetypes.StringValue  `tfsdk:"value"`
+	state attr.ValueState
+}
+
+func (v LabelsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["cost"] = basetypes.Float64Type{}.TerraformType(ctx)
+	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["value"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Cost.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["cost"] = val
+
+		val, err = v.Key.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["key"] = val
+
+		val, err = v.Value.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["value"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v LabelsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v LabelsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v LabelsValue) String() string {
+	return "LabelsValue"
+}
+
+func (v LabelsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"cost":  basetypes.Float64Type{},
+		"key":   basetypes.StringType{},
+		"value": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"cost":  v.Cost,
+			"key":   v.Key,
+			"value": v.Value,
+		})
+
+	return objVal, diags
+}
+
+func (v LabelsValue) Equal(o attr.Value) bool {
+	other, ok := o.(LabelsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Cost.Equal(other.Cost) {
+		return false
+	}
+
+	if !v.Key.Equal(other.Key) {
+		return false
+	}
+
+	if !v.Value.Equal(other.Value) {
+		return false
+	}
+
+	return true
+}
+
+func (v LabelsValue) Type(ctx context.Context) attr.Type {
+	return LabelsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v LabelsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"cost":  basetypes.Float64Type{},
+		"key":   basetypes.StringType{},
+		"value": basetypes.StringType{},
 	}
 }
 

--- a/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
+++ b/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
@@ -59,6 +59,35 @@ func AnomalyDataSourceSchema(ctx context.Context) schema.Schema {
 						"cost": schema.Float64Attribute{
 							Computed: true,
 						},
+						"labels": schema.ListNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"cost": schema.Float64Attribute{
+										Computed:            true,
+										Description:         "The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.",
+										MarkdownDescription: "The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.",
+									},
+									"key": schema.StringAttribute{
+										Computed:            true,
+										Description:         "The label/tag key.",
+										MarkdownDescription: "The label/tag key.",
+									},
+									"value": schema.StringAttribute{
+										Computed:            true,
+										Description:         "The label/tag value.",
+										MarkdownDescription: "The label/tag value.",
+									},
+								},
+								CustomType: LabelsType{
+									ObjectType: types.ObjectType{
+										AttrTypes: LabelsValue{}.AttributeTypes(ctx),
+									},
+								},
+							},
+							Computed:            true,
+							Description:         "Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.\nCloud providers use different names for the same concept; GCP uses \"labels\", AWS uses \"cost-allocation tags\", and Azure uses \"tags\". We refer to all of these as labels.",
+							MarkdownDescription: "Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.\nCloud providers use different names for the same concept; GCP uses \"labels\", AWS uses \"cost-allocation tags\", and Azure uses \"tags\". We refer to all of these as labels.",
+						},
 						"operation": schema.StringAttribute{
 							Computed:            true,
 							Description:         "For anomalies related to AWS S3",
@@ -196,6 +225,24 @@ func (t ResourceDataType) ValueFromObject(ctx context.Context, in basetypes.Obje
 			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
 	}
 
+	labelsAttribute, ok := attributes["labels"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`labels is missing from object`)
+
+		return nil, diags
+	}
+
+	labelsVal, ok := labelsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`labels expected to be basetypes.ListValue, was: %T`, labelsAttribute))
+	}
+
 	operationAttribute, ok := attributes["operation"]
 
 	if !ok {
@@ -256,6 +303,7 @@ func (t ResourceDataType) ValueFromObject(ctx context.Context, in basetypes.Obje
 
 	return ResourceDataValue{
 		Cost:           costVal,
+		Labels:         labelsVal,
 		Operation:      operationVal,
 		ResourceId:     resourceIdVal,
 		SkuDescription: skuDescriptionVal,
@@ -344,6 +392,24 @@ func NewResourceDataValue(attributeTypes map[string]attr.Type, attributes map[st
 			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
 	}
 
+	labelsAttribute, ok := attributes["labels"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`labels is missing from object`)
+
+		return NewResourceDataValueUnknown(), diags
+	}
+
+	labelsVal, ok := labelsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`labels expected to be basetypes.ListValue, was: %T`, labelsAttribute))
+	}
+
 	operationAttribute, ok := attributes["operation"]
 
 	if !ok {
@@ -404,6 +470,7 @@ func NewResourceDataValue(attributeTypes map[string]attr.Type, attributes map[st
 
 	return ResourceDataValue{
 		Cost:           costVal,
+		Labels:         labelsVal,
 		Operation:      operationVal,
 		ResourceId:     resourceIdVal,
 		SkuDescription: skuDescriptionVal,
@@ -480,6 +547,7 @@ var _ basetypes.ObjectValuable = ResourceDataValue{}
 
 type ResourceDataValue struct {
 	Cost           basetypes.Float64Value `tfsdk:"cost"`
+	Labels         basetypes.ListValue    `tfsdk:"labels"`
 	Operation      basetypes.StringValue  `tfsdk:"operation"`
 	ResourceId     basetypes.StringValue  `tfsdk:"resource_id"`
 	SkuDescription basetypes.StringValue  `tfsdk:"sku_description"`
@@ -487,12 +555,15 @@ type ResourceDataValue struct {
 }
 
 func (v ResourceDataValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 4)
+	attrTypes := make(map[string]tftypes.Type, 5)
 
 	var val tftypes.Value
 	var err error
 
 	attrTypes["cost"] = basetypes.Float64Type{}.TerraformType(ctx)
+	attrTypes["labels"] = basetypes.ListType{
+		ElemType: LabelsValue{}.Type(ctx),
+	}.TerraformType(ctx)
 	attrTypes["operation"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["resource_id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["sku_description"] = basetypes.StringType{}.TerraformType(ctx)
@@ -501,7 +572,7 @@ func (v ResourceDataValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 4)
+		vals := make(map[string]tftypes.Value, 5)
 
 		val, err = v.Cost.ToTerraformValue(ctx)
 
@@ -510,6 +581,14 @@ func (v ResourceDataValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		}
 
 		vals["cost"] = val
+
+		val, err = v.Labels.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["labels"] = val
 
 		val, err = v.Operation.ToTerraformValue(ctx)
 
@@ -564,8 +643,17 @@ func (v ResourceDataValue) String() string {
 func (v ResourceDataValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	var labels attr.Value
+
+	{
+		labels = v.Labels
+	}
+
 	attributeTypes := map[string]attr.Type{
-		"cost":            basetypes.Float64Type{},
+		"cost": basetypes.Float64Type{},
+		"labels": basetypes.ListType{
+			ElemType: LabelsValue{}.Type(ctx),
+		},
 		"operation":       basetypes.StringType{},
 		"resource_id":     basetypes.StringType{},
 		"sku_description": basetypes.StringType{},
@@ -583,6 +671,7 @@ func (v ResourceDataValue) ToObjectValue(ctx context.Context) (basetypes.ObjectV
 		attributeTypes,
 		map[string]attr.Value{
 			"cost":            v.Cost,
+			"labels":          labels,
 			"operation":       v.Operation,
 			"resource_id":     v.ResourceId,
 			"sku_description": v.SkuDescription,
@@ -607,6 +696,10 @@ func (v ResourceDataValue) Equal(o attr.Value) bool {
 	}
 
 	if !v.Cost.Equal(other.Cost) {
+		return false
+	}
+
+	if !v.Labels.Equal(other.Labels) {
 		return false
 	}
 
@@ -635,10 +728,447 @@ func (v ResourceDataValue) Type(ctx context.Context) attr.Type {
 
 func (v ResourceDataValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"cost":            basetypes.Float64Type{},
+		"cost": basetypes.Float64Type{},
+		"labels": basetypes.ListType{
+			ElemType: LabelsValue{}.Type(ctx),
+		},
 		"operation":       basetypes.StringType{},
 		"resource_id":     basetypes.StringType{},
 		"sku_description": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = LabelsType{}
+
+type LabelsType struct {
+	basetypes.ObjectType
+}
+
+func (t LabelsType) Equal(o attr.Type) bool {
+	other, ok := o.(LabelsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t LabelsType) String() string {
+	return "LabelsType"
+}
+
+func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	costAttribute, ok := attributes["cost"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cost is missing from object`)
+
+		return nil, diags
+	}
+
+	costVal, ok := costAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return nil, diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return nil, diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return LabelsValue{
+		Cost:  costVal,
+		Key:   keyVal,
+		Value: valueVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelsValueNull() LabelsValue {
+	return LabelsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewLabelsValueUnknown() LabelsValue {
+	return LabelsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewLabelsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (LabelsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing LabelsValue Attribute Value",
+				"While creating a LabelsValue value, a missing attribute value was detected. "+
+					"A LabelsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid LabelsValue Attribute Type",
+				"While creating a LabelsValue value, an invalid attribute value was detected. "+
+					"A LabelsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LabelsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("LabelsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra LabelsValue Attribute Value",
+				"While creating a LabelsValue value, an extra attribute value was detected. "+
+					"A LabelsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra LabelsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewLabelsValueUnknown(), diags
+	}
+
+	costAttribute, ok := attributes["cost"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cost is missing from object`)
+
+		return NewLabelsValueUnknown(), diags
+	}
+
+	costVal, ok := costAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cost expected to be basetypes.Float64Value, was: %T`, costAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return NewLabelsValueUnknown(), diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return NewLabelsValueUnknown(), diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return NewLabelsValueUnknown(), diags
+	}
+
+	return LabelsValue{
+		Cost:  costVal,
+		Key:   keyVal,
+		Value: valueVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLabelsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) LabelsValue {
+	object, diags := NewLabelsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewLabelsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t LabelsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewLabelsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewLabelsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewLabelsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewLabelsValueMust(LabelsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t LabelsType) ValueType(ctx context.Context) attr.Value {
+	return LabelsValue{}
+}
+
+var _ basetypes.ObjectValuable = LabelsValue{}
+
+type LabelsValue struct {
+	Cost  basetypes.Float64Value `tfsdk:"cost"`
+	Key   basetypes.StringValue  `tfsdk:"key"`
+	Value basetypes.StringValue  `tfsdk:"value"`
+	state attr.ValueState
+}
+
+func (v LabelsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["cost"] = basetypes.Float64Type{}.TerraformType(ctx)
+	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["value"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Cost.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["cost"] = val
+
+		val, err = v.Key.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["key"] = val
+
+		val, err = v.Value.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["value"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v LabelsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v LabelsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v LabelsValue) String() string {
+	return "LabelsValue"
+}
+
+func (v LabelsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"cost":  basetypes.Float64Type{},
+		"key":   basetypes.StringType{},
+		"value": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"cost":  v.Cost,
+			"key":   v.Key,
+			"value": v.Value,
+		})
+
+	return objVal, diags
+}
+
+func (v LabelsValue) Equal(o attr.Value) bool {
+	other, ok := o.(LabelsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Cost.Equal(other.Cost) {
+		return false
+	}
+
+	if !v.Key.Equal(other.Key) {
+		return false
+	}
+
+	if !v.Value.Equal(other.Value) {
+		return false
+	}
+
+	return true
+}
+
+func (v LabelsValue) Type(ctx context.Context) attr.Type {
+	return LabelsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v LabelsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"cost":  basetypes.Float64Type{},
+		"key":   basetypes.StringType{},
+		"value": basetypes.StringType{},
 	}
 }
 

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -2623,6 +2623,10 @@ type AnomalyItemStatus string
 type AnomalyResource struct {
 	Cost *float64 `json:"cost,omitempty"`
 
+	// Labels Labels (also known as cost-allocation tags) present on this resource during the anomaly; each entry reports the label's key, its value, and the resource's cost tagged with that key/value pair.
+	// Cloud providers use different names for the same concept; GCP uses "labels", AWS uses "cost-allocation tags", and Azure uses "tags". We refer to all of these as labels.
+	Labels *[]AnomalyResourceLabel `json:"labels,omitempty"`
+
 	// Operation For anomalies related to AWS S3
 	Operation      *string `json:"operation,omitempty"`
 	ResourceId     *string `json:"resourceId,omitempty"`
@@ -2631,6 +2635,18 @@ type AnomalyResource struct {
 
 // AnomalyResourceArray Array of resources contributing to an anomaly.
 type AnomalyResourceArray = []AnomalyResource
+
+// AnomalyResourceLabel A single label (a.k.a. cost-allocation tag) on the resource, paired with the resource's cost tagged with this key/value pair.
+type AnomalyResourceLabel struct {
+	// Cost The resource's cost tagged with this key/value pair; typically equal to the resource's cost, since labels/tags usually cover all of its spend.
+	Cost *float64 `json:"cost,omitempty"`
+
+	// Key The label/tag key.
+	Key *string `json:"key,omitempty"`
+
+	// Value The label/tag value.
+	Value *string `json:"value,omitempty"`
+}
 
 // AnomalySKU SKU-level information contributing to an anomaly.
 type AnomalySKU struct {


### PR DESCRIPTION
## Summary

Add support for the new `labels` field on `AnomalyResource`, which exposes cost-allocation tags (GCP labels / AWS cost-allocation tags / Azure tags) present on resources contributing to anomalies.

Each label entry contains:
- `key`: the label/tag key
- `value`: the label/tag value
- `cost`: the resource's cost tagged with this key/value pair

## Changes

### OpenAPI spec
- Added `AnomalyResourceLabel` schema with `key`, `value`, `cost` properties
- Added `labels` array field to `AnomalyResource`

### Generated code (via `make generate`)
- Updated models (`AnomalyResource`, new `AnomalyResourceLabel` struct)
- Updated schema and constructors for both `datasource_anomaly` and `datasource_anomalies`

### Implementation
- **`anomaly_data_source.go`** — Added `mapAnomalyResourceLabelsForAnomaly()` helper; wired `labels` into `NewResourceDataValue` constructor
- **`anomalies_data_source.go`** — Added `mapAnomalyResourceLabels()` helper; wired `labels` into `mapAnomalyResourceData()`

### Tests
- **`anomaly_data_source_test.go`** — Added `TestAccAnomalyDataSource_ResourceDataLabels` with drift verification
- **`anomalies_data_source_test.go`** — Added `TestAccAnomaliesDataSource_ResourceDataLabels` with drift verification

Both new tests exercise the `labels` nested structure via Terraform output expressions to validate the schema works end-to-end.

### Documentation
- Regenerated via `make docs` — both `doit_anomaly` and `doit_anomalies` docs now include the `resource_data.labels` nested schema.

## Test Results

All 7 acceptance tests pass:
- `TestAccAnomalyDataSource_Basic` ✅
- `TestAccAnomalyDataSource_ResourceDataLabels` ✅ (new)
- `TestAccAnomaliesDataSource_MaxResultsOnly` ✅
- `TestAccAnomaliesDataSource_PageTokenOnly` ✅
- `TestAccAnomaliesDataSource_MaxResultsAndPageToken` ✅
- `TestAccAnomaliesDataSource_AutoPagination` ✅
- `TestAccAnomaliesDataSource_ResourceDataLabels` ✅ (new)