### PR TITLE
fix: prevent inverse_selection from silently overwriting inverse

### DIFF
--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -184,11 +184,22 @@ func (plan *allocationResourceModel) toUpdateRequest(ctx context.Context) (req m
 func convertComponentsToModels(ctx context.Context, components []resource_allocation.ComponentsValue) (result []models.AllocationComponent, diags diag.Diagnostics) {
 	result = make([]models.AllocationComponent, len(components))
 	for i := range components {
+		// Only send the deprecated inverse_selection when inverse is a known
+		// false value. The API's ToFilter() gives inverse_selection precedence
+		// over inverse, so sending both (e.g. inverse=true,
+		// inverse_selection=false) causes inverse to be silently overwritten.
+		// Guard against Unknown/Null defensively — schema defaults ensure
+		// inverse is always known during Apply, but the guard costs nothing.
+		var inverseSelection *bool
+		inverse := components[i].Inverse
+		if !inverse.IsUnknown() && !inverse.IsNull() && !inverse.ValueBool() {
+			inverseSelection = components[i].InverseSelection.ValueBoolPointer()
+		}
 		result[i] = models.AllocationComponent{
 			CaseInsensitive:  components[i].CaseInsensitive.ValueBoolPointer(),
 			IncludeNull:      components[i].IncludeNull.ValueBoolPointer(),
 			Inverse:          components[i].Inverse.ValueBoolPointer(),
-			InverseSelection: components[i].InverseSelection.ValueBoolPointer(),
+			InverseSelection: inverseSelection,
 			Key:              components[i].Key.ValueString(),
 			Mode:             models.AllocationComponentMode(components[i].Mode.ValueString()),
 			Type:             models.AllocationDimensionsTypes(components[i].ComponentsType.ValueString()),
@@ -366,12 +377,12 @@ func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *mod
 			"formula": types.StringValue(resp.Rule.Formula),
 		}
 		if resp.Rule.Components != nil {
-			// Preserve existing component values from state for alias-type normalization.
-			// Note: includeNull, inverse, and caseInsensitive ARE reliably echoed by the
-			// API. inverseSelection is a deprecated field superseded by inverse — the API
-			// accepts it on write but never returns it (the value is visible via inverse
-			// instead). We preserve all four from state as a defensive baseline, which
-			// also handles ImportState gracefully (falls back to API value).
+			// Preserve existing component values from state for alias-type normalization
+			// and deprecated field round-tripping.
+			// - includeNull, inverse, caseInsensitive: use API value (reliably echoed),
+			//   falling back to state only when API returns nil.
+			// - inverseSelection: MUST use state (API never returns this deprecated field).
+			// - type: use normalizeDimensionsType to preserve user's alias (e.g. allocation_rule).
 			var existingComponents []resource_allocation.ComponentsValue
 			if !state.Rule.IsNull() && !state.Rule.IsUnknown() &&
 				!state.Rule.Components.IsNull() && !state.Rule.Components.IsUnknown() {
@@ -542,27 +553,30 @@ func toAllocationRuleComponentsListValue(ctx context.Context, components []model
 			compType = normalizeDimensionsType(compType, existingComponents[i].ComponentsType.ValueString())
 		}
 
-		// Note on field echo behavior (verified via API probe):
+		// Field echo behavior (verified via API probe):
 		// - includeNull, inverse, caseInsensitive: echoed correctly by the API.
-		// - inverseSelection: DEPRECATED (superseded by inverse). The API accepts it
-		//   on write but never echoes it back; the equivalent value is visible in
-		//   inverse instead. We preserve all four from state so that:
-		//   a) deprecated inverseSelection round-trips without drift for existing configs, and
-		//   b) ImportState (no prior state) falls back cleanly to the API value.
+		//   We use the API value as the source of truth, falling back to state
+		//   only when the API returns nil (shouldn't happen, but defensive).
+		//   This ensures real drift (e.g. external modifications) is detected.
+		// - inverseSelection: DEPRECATED (superseded by inverse). The API accepts
+		//   it on write but never echoes it back. We MUST preserve it from state
+		//   so that existing configs using the deprecated field don't drift.
+		//   ImportState (no prior state) falls back to the API value (always nil → false).
 		caseInsensitiveVal := types.BoolValue(false)
-		if i < len(existingComponents) {
-			caseInsensitiveVal = types.BoolValue(existingComponents[i].CaseInsensitive.ValueBool())
-		} else if component.CaseInsensitive != nil {
+		if component.CaseInsensitive != nil {
 			caseInsensitiveVal = types.BoolValue(*component.CaseInsensitive)
+		} else if i < len(existingComponents) {
+			caseInsensitiveVal = types.BoolValue(existingComponents[i].CaseInsensitive.ValueBool())
 		}
 
 		includeNullVal := types.BoolValue(false)
-		if i < len(existingComponents) {
-			includeNullVal = types.BoolValue(existingComponents[i].IncludeNull.ValueBool())
-		} else if component.IncludeNull != nil {
+		if component.IncludeNull != nil {
 			includeNullVal = types.BoolValue(*component.IncludeNull)
+		} else if i < len(existingComponents) {
+			includeNullVal = types.BoolValue(existingComponents[i].IncludeNull.ValueBool())
 		}
 
+		// inverseSelection: state-first — API never returns this deprecated field.
 		inverseSelectionVal := types.BoolValue(false)
 		if i < len(existingComponents) {
 			inverseSelectionVal = types.BoolValue(existingComponents[i].InverseSelection.ValueBool())
@@ -571,10 +585,18 @@ func toAllocationRuleComponentsListValue(ctx context.Context, components []model
 		}
 
 		inverseVal := types.BoolValue(false)
-		if i < len(existingComponents) {
+		if i < len(existingComponents) && existingComponents[i].InverseSelection.ValueBool() {
+			// When the user uses the deprecated inverse_selection=true, the API
+			// stores inverse=true internally (via ToFilter's deprecated field
+			// override). The Read path would then see inverse=true from the API,
+			// but the user's config has inverse at its default (false). This would
+			// cause false drift. Preserve the state's inverse value so the
+			// deprecated workflow remains stable.
 			inverseVal = types.BoolValue(existingComponents[i].Inverse.ValueBool())
 		} else if component.Inverse != nil {
 			inverseVal = types.BoolValue(*component.Inverse)
+		} else if i < len(existingComponents) {
+			inverseVal = types.BoolValue(existingComponents[i].Inverse.ValueBool())
 		}
 
 		m := map[string]attr.Value{

--- a/internal/provider/allocation_components_validator.go
+++ b/internal/provider/allocation_components_validator.go
@@ -22,7 +22,7 @@ var _ validator.List = allocationComponentsValidator{}
 type allocationComponentsValidator struct{}
 
 func (v allocationComponentsValidator) Description(_ context.Context) string {
-	return "validates that allocation_rule components have key='allocation_rule' and mode is 'is' or 'contains'"
+	return "validates allocation rule component constraints: allocation_rule type restrictions and inverse/inverse_selection mutual exclusivity"
 }
 
 func (v allocationComponentsValidator) MarkdownDescription(ctx context.Context) string {
@@ -46,6 +46,22 @@ func (v allocationComponentsValidator) ValidateList(ctx context.Context, req val
 
 		if compVal.ComponentsType.IsNull() || compVal.ComponentsType.IsUnknown() {
 			continue
+		}
+
+		// Validate inverse and inverse_selection are not both true.
+		// inverse_selection is deprecated in favor of inverse. Setting both
+		// causes ambiguous behavior because the API gives inverse_selection
+		// precedence, silently overriding inverse.
+		if compVal.Inverse.ValueBool() && compVal.InverseSelection.ValueBool() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtListIndex(i).AtName("inverse"),
+				"Conflicting Inverse Attributes",
+				fmt.Sprintf(
+					"components[%d]: 'inverse' and 'inverse_selection' cannot both be true. "+
+						"Use 'inverse' only — 'inverse_selection' is deprecated.",
+					i,
+				),
+			)
 		}
 
 		if compVal.ComponentsType.ValueString() != "allocation_rule" {

--- a/internal/provider/allocation_components_validator_internal_test.go
+++ b/internal/provider/allocation_components_validator_internal_test.go
@@ -118,6 +118,96 @@ func TestAllocationComponentsValidator(t *testing.T) {
 	}
 }
 
+func TestAllocationComponentsValidator_InverseConflict(t *testing.T) {
+	ctx := context.Background()
+
+	makeComponentWithFlags := func(key, mode, compType string, inverse, inverseSelection bool) resource_allocation.ComponentsValue {
+		val, diags := resource_allocation.NewComponentsValue(
+			resource_allocation.ComponentsValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"key":               types.StringValue(key),
+				"mode":              types.StringValue(mode),
+				"type":              types.StringValue(compType),
+				"values":            types.ListValueMust(types.StringType, []attr.Value{types.StringValue("JP")}),
+				"case_insensitive":  types.BoolValue(false),
+				"include_null":      types.BoolValue(false),
+				"inverse":           types.BoolValue(inverse),
+				"inverse_selection": types.BoolValue(inverseSelection),
+			},
+		)
+		if diags.HasError() {
+			t.Fatalf("failed to create component value: %s", diags.Errors())
+		}
+		return val
+	}
+
+	makeList := func(components ...resource_allocation.ComponentsValue) basetypes.ListValue {
+		elems := make([]attr.Value, len(components))
+		for i, c := range components {
+			elems[i] = c
+		}
+		list, diags := types.ListValueFrom(ctx, resource_allocation.ComponentsValue{}.Type(ctx), elems)
+		if diags.HasError() {
+			t.Fatalf("failed to create list value: %s", diags.Errors())
+		}
+		return list
+	}
+
+	tests := []struct {
+		name        string
+		components  basetypes.ListValue
+		expectError bool
+	}{
+		{
+			name:        "valid - only inverse=true",
+			components:  makeList(makeComponentWithFlags("country", "is", "fixed", true, false)),
+			expectError: false,
+		},
+		{
+			name:        "valid - only inverse_selection=true",
+			components:  makeList(makeComponentWithFlags("country", "is", "fixed", false, true)),
+			expectError: false,
+		},
+		{
+			name:        "valid - both false",
+			components:  makeList(makeComponentWithFlags("country", "is", "fixed", false, false)),
+			expectError: false,
+		},
+		{
+			name:        "invalid - both inverse and inverse_selection true",
+			components:  makeList(makeComponentWithFlags("country", "is", "fixed", true, true)),
+			expectError: true,
+		},
+		{
+			name: "invalid - conflict in second component only",
+			components: makeList(
+				makeComponentWithFlags("country", "is", "fixed", true, false),   // ok
+				makeComponentWithFlags("project_id", "is", "fixed", true, true), // conflict
+			),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := allocationComponentsValidator{}
+			req := validator.ListRequest{
+				ConfigValue: tc.components,
+			}
+			resp := &validator.ListResponse{}
+
+			v.ValidateList(ctx, req, resp)
+
+			if tc.expectError && !resp.Diagnostics.HasError() {
+				t.Error("expected error but got none")
+			}
+			if !tc.expectError && resp.Diagnostics.HasError() {
+				t.Errorf("expected no error but got: %s", resp.Diagnostics.Errors())
+			}
+		})
+	}
+}
+
 func TestAllocationComponentsValidator_NullAndUnknown(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -151,6 +151,148 @@ func TestAccAllocation_Validation(t *testing.T) {
 	})
 }
 
+// TestAccAllocation_InverseConflict tests that setting both inverse=true and
+// inverse_selection=true on the same component is rejected at plan time.
+func TestAccAllocation_InverseConflict(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAllocationInverseConflict(rName),
+				ExpectError: regexp.MustCompile(`Conflicting Inverse Attributes`),
+			},
+		},
+	})
+}
+
+func testAccAllocationInverseConflict(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "inv_conflict" {
+    name        = "%s-inv-conflict"
+    description = "test allocation with conflicting inverse attributes"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key               = "country"
+           mode              = "is"
+           type              = "fixed"
+           values            = ["JP"]
+           inverse           = true
+           inverse_selection = true
+         }
+       ]
+    }
+}
+`, rName)
+}
+
+// TestAccAllocation_InverseConflict_Rules verifies that the conflict validator
+// also fires on the rules[] (group allocation) path, not just rule.
+func TestAccAllocation_InverseConflict_Rules(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAllocationInverseConflictRules(rName),
+				ExpectError: regexp.MustCompile(`Conflicting Inverse Attributes`),
+			},
+		},
+	})
+}
+
+func testAccAllocationInverseConflictRules(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "inv_conflict_rules" {
+    name              = "%s-inv-conflict-rules"
+    description       = "test allocation group with conflicting inverse attributes"
+    unallocated_costs = "%s-other"
+    rules = [
+        {
+            action  = "create"
+            name    = "%s-conflict-rule"
+            formula = "A"
+            components = [
+                {
+                    key               = "country"
+                    mode              = "is"
+                    type              = "fixed"
+                    values            = ["JP"]
+                    inverse           = true
+                    inverse_selection = true
+                }
+            ]
+        }
+    ]
+}
+`, rName, rName, rName)
+}
+
+// TestAccAllocation_InverseRulesPath tests that inverse=true works correctly
+// through the rules[] (group allocation) path, not just the rule path.
+func TestAccAllocation_InverseRulesPath(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with inverse=true via rules[]
+			{
+				Config: testAccAllocationInverseRulesPath(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("doit_allocation.inv_rules", "id"),
+					resource.TestCheckResourceAttr("doit_allocation.inv_rules", "rules.0.components.0.inverse", "true"),
+				),
+			},
+			// Step 2: Drift check — plan should be empty
+			{
+				Config: testAccAllocationInverseRulesPath(rName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationInverseRulesPath(rName string, inverse bool) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "inv_rules" {
+    name              = "%s-inv-rules"
+    description       = "test allocation group with inverse via rules path"
+    unallocated_costs = "%s-other"
+    rules = [
+        {
+            action  = "create"
+            name    = "%s-inv-rule"
+            formula = "A"
+            components = [
+                {
+                    key     = "country"
+                    mode    = "is"
+                    type    = "fixed"
+                    values  = ["JP"]
+                    inverse = %t
+                }
+            ]
+        }
+    ]
+}
+`, rName, rName, rName, inverse)
+}
+
 func TestAccAllocation_Group_Select(t *testing.T) {
 	rName := acctest.RandomWithPrefix(testAllocPrefix)
 
@@ -605,10 +747,14 @@ resource "doit_allocation" "ci" {
 `, rName, rName, rName)
 }
 
-// TestAccAllocation_InverseField tests the new "inverse" attribute on allocation
-// rule components. This is separate from TestAccAllocation_ComponentFlags which
-// tests the legacy "inverse_selection" attribute for backward compatibility.
-func TestAccAllocation_InverseField(t *testing.T) {
+// TestAccAllocation_InverseLifecycle comprehensively tests the "inverse" attribute
+// through its full lifecycle: create with true, drift check, toggle to false, toggle
+// back to true, and import + drift check. This verifies that:
+//   - The provider correctly sends inverse=true to the API without interference
+//     from the deprecated inverse_selection field.
+//   - The Read path detects real API values (no masking from prior state).
+//   - No "Provider produced inconsistent result" errors occur in any transition.
+func TestAccAllocation_InverseLifecycle(t *testing.T) {
 	rName := acctest.RandomWithPrefix(testAllocPrefix)
 	resource.ParallelTest(t, resource.TestCase{
 		CheckDestroy:             testAccCheckAllocationDestroy(t),
@@ -616,16 +762,111 @@ func TestAccAllocation_InverseField(t *testing.T) {
 		PreCheck:                 testAccPreCheckFunc(t),
 		TerraformVersionChecks:   testAccTFVersionChecks,
 		Steps: []resource.TestStep{
+			// Step 1: Create with inverse=true.
 			{
-				Config: testAccAllocationInverseField(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("doit_allocation.inverse", "id"),
-					resource.TestCheckResourceAttr("doit_allocation.inverse", "rules.0.components.0.inverse", "true"),
-				),
+				Config: testAccAllocationInverseLifecycle(rName, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.inv_lifecycle",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"inverse":           knownvalue.Bool(true),
+								"inverse_selection": knownvalue.Bool(false),
+							}),
+						}),
+					),
+				},
 			},
-			// Verify no drift on re-apply
+			// Step 2: Drift check — re-apply same config, expect no changes.
 			{
-				Config: testAccAllocationInverseField(rName),
+				Config: testAccAllocationInverseLifecycle(rName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Update to inverse=false.
+			{
+				Config: testAccAllocationInverseLifecycle(rName, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_allocation.inv_lifecycle",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.inv_lifecycle",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"inverse":           knownvalue.Bool(false),
+								"inverse_selection": knownvalue.Bool(false),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 4: Drift check after update to false.
+			{
+				Config: testAccAllocationInverseLifecycle(rName, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 5: Update back to inverse=true.
+			{
+				Config: testAccAllocationInverseLifecycle(rName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_allocation.inv_lifecycle",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.inv_lifecycle",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"inverse":           knownvalue.Bool(true),
+								"inverse_selection": knownvalue.Bool(false),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 6: Drift check after update to true.
+			{
+				Config: testAccAllocationInverseLifecycle(rName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 7: Import + verify state.
+			{
+				ResourceName:      "doit_allocation.inv_lifecycle",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"update_time", // Computed field that changes on each modification
+				},
+			},
+			// Step 8: Drift check after import.
+			{
+				Config: testAccAllocationInverseLifecycle(rName, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -636,30 +877,25 @@ func TestAccAllocation_InverseField(t *testing.T) {
 	})
 }
 
-func testAccAllocationInverseField(rName string) string {
+func testAccAllocationInverseLifecycle(rName string, inverse bool) string {
 	return fmt.Sprintf(`
-resource "doit_allocation" "inverse" {
-    name = "%s-inverse"
-    description = "Test allocation with inverse field"
-    unallocated_costs = "%s-other"
-    rules = [
+resource "doit_allocation" "inv_lifecycle" {
+    name        = "%s-inv-lifecycle"
+    description = "Test allocation inverse lifecycle"
+    rule = {
+       formula = "A"
+       components = [
         {
-            action = "create"
-            name   = "%s-inverse-rule"
-            formula = "A"
-            components = [
-                {
-                    key     = "country"
-                    mode    = "is"
-                    type    = "fixed"
-                    values  = ["JP"]
-                    inverse = true
-                }
-            ]
-        }
-    ]
+           key     = "country"
+           mode    = "is"
+           type    = "fixed"
+           values  = ["JP"]
+           inverse = %t
+         }
+       ]
+    }
 }
-`, rName, rName, rName)
+`, rName, inverse)
 }
 
 // TestAccAllocation_Disappears verifies that Terraform correctly handles
@@ -954,7 +1190,7 @@ resource "doit_allocation" "invalid_nested" {
 
 // TestAccAllocation_InverseMigration tests that migrating a single allocation
 // from the deprecated "inverse_selection" attribute to the new "inverse"
-// attribute does not produce "inconsistent result" errors.
+// attribute (and back) does not produce "inconsistent result" errors.
 //
 // The API internally maps "inverse" back to "inverse_selection" in the response,
 // so the response always has inverse_selection=true and inverse=false. The
@@ -972,10 +1208,28 @@ func TestAccAllocation_InverseMigration(t *testing.T) {
 			// Step 1: Create with the legacy inverse_selection = true.
 			{
 				Config: testAccAllocationInverseSelectionLegacy(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.inv_migrate",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"inverse_selection": knownvalue.Bool(true),
+							}),
+						}),
+					),
+				},
 			},
-			// Step 2: Migrate to inverse = true (remove inverse_selection).
-			// On v1.3.3, this crashes with "inconsistent result" because
-			// the API maps inverse back to inverse_selection.
+			// Step 2: Drift check for legacy config.
+			{
+				Config: testAccAllocationInverseSelectionLegacy(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Migrate to inverse = true (remove inverse_selection).
 			{
 				Config: testAccAllocationInverseMigrated(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -990,9 +1244,33 @@ func TestAccAllocation_InverseMigration(t *testing.T) {
 					),
 				},
 			},
-			// Step 3: Re-apply — verify no drift.
+			// Step 4: Drift check after migration to inverse.
 			{
 				Config: testAccAllocationInverseMigrated(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 5: Migrate back to inverse_selection = true (remove inverse).
+			{
+				Config: testAccAllocationInverseSelectionLegacy(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.inv_migrate",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"inverse_selection": knownvalue.Bool(true),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 6: Drift check after migrating back.
+			{
+				Config: testAccAllocationInverseSelectionLegacy(rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -1043,6 +1321,98 @@ resource "doit_allocation" "inv_migrate" {
     }
 }
 `, rName)
+}
+
+// TestAccAllocation_InverseWithMultipleComponents tests an allocation with
+// multiple components using different combinations of inverse and inverse_selection.
+// This verifies that the write path correctly handles each component independently
+// and that the read path doesn't cross-contaminate values between components.
+func TestAccAllocation_InverseWithMultipleComponents(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with 3 components:
+			//   A: no inverse (default false)
+			//   B: inverse = true
+			//   C: inverse_selection = true (deprecated)
+			{
+				Config: testAccAllocationInverseMultiComponent(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.inv_multi",
+						tfjsonpath.New("rule").AtMapKey("components"),
+						knownvalue.ListExact([]knownvalue.Check{
+							// A: default inverse=false
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"key":               knownvalue.StringExact("country"),
+								"inverse":           knownvalue.Bool(false),
+								"inverse_selection": knownvalue.Bool(false),
+							}),
+							// B: inverse=true
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"key":               knownvalue.StringExact("service_description"),
+								"inverse":           knownvalue.Bool(true),
+								"inverse_selection": knownvalue.Bool(false),
+							}),
+							// C: inverse_selection=true (deprecated)
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"key":               knownvalue.StringExact("project_id"),
+								"inverse_selection": knownvalue.Bool(true),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 2: Drift check.
+			{
+				Config: testAccAllocationInverseMultiComponent(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationInverseMultiComponent(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "inv_multi" {
+    name        = "%s-inv-multi"
+    description = "Test allocation with mixed inverse/inverse_selection components"
+    rule = {
+       formula = "A AND B AND C"
+       components = [
+        {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+        },
+        {
+           key     = "service_description"
+           mode    = "is"
+           type    = "fixed"
+           values  = ["AmazonCloudWatch"]
+           inverse = true
+        },
+        {
+           key               = "project_id"
+           mode              = "is"
+           type              = "fixed"
+           values            = ["%s"]
+           inverse_selection = true
+        }
+       ]
+    }
+}
+`, rName, testProject())
 }
 
 // TestAccAllocation_SentinelRestore tests that a single allocation with a


### PR DESCRIPTION
## Problem

When a user sets `inverse = true` on an allocation component, the provider also sends `inverse_selection = false` (from the schema default). The API's `ToFilter()` gives the deprecated `inverse_selection` field precedence, silently overwriting `inverse` from `true` to `false`. The Read path masked this by always using prior state values, so no drift was ever detected — but allocations produced wrong results.

## Root Cause

1. **Write path**: `convertComponentsToModels` always sent both fields. `ValueBoolPointer()` on the defaulted `inverse_selection = false` returns `*false` (non-nil), which the API treats as "user explicitly set this".
2. **Read path**: `toAllocationRuleComponentsListValue` always preferred prior state for `inverse`, `includeNull`, and `caseInsensitive` — masking real API discrepancies.

## Fix

### Write path (`convertComponentsToModels`)
- Omit `inverse_selection` from the API request when `inverse = true`. This prevents the API's deprecated-field-takes-precedence logic from overwriting the user's value.

### Read path (`toAllocationRuleComponentsListValue`)
- **API-first** for `inverse`, `includeNull`, `caseInsensitive` (reliably echoed by the API), with state fallback.
- **State-first** for `inverseSelection` only (API never returns this deprecated field).
- Special case: when `inverse_selection = true` in state, preserve the state's `inverse` value to avoid false drift (the API derives `inverse` from `inverse_selection`).

### Validator (`allocationComponentsValidator`)
- Reject components where both `inverse = true` and `inverse_selection = true` at plan time. Error message guides users to use `inverse` only.

## Tests

| Test | Steps | What it verifies |
|---|---|---|
| `InverseLifecycle` | 8 | Create→drift→toggle false→drift→toggle true→drift→import→drift |
| `InverseMigration` | 6 | legacy→drift→migrate→drift→migrate back→drift |
| `InverseWithMultipleComponents` | 2 | Mixed default/inverse/inverse_selection in same allocation |
| `InverseConflict` | 1 | Both true rejected at plan time |
| `InverseConflict` (unit) | 5 | Validator unit tests for all true/false combinations |

All 37 allocation acceptance tests pass. Zero regressions.