### PR TITLE
fix(support): align spec with CMP-40423 pagination fix

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -5013,7 +5013,7 @@
 												"path": "github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 											}
 										],
-										"schema_definition": "int64validator.AtLeast(1)"
+										"schema_definition": "int64validator.Between(1, 100)"
 									}
 								}
 							]

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -2973,9 +2973,10 @@ paths:
           description: The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
           schema:
             minimum: 1
+            maximum: 100
             type: integer
             format: int64
-            default: 50
+            default: 100
         - $ref: "#/components/parameters/pageToken"
         - name: filter
           in: query

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -2420,9 +2420,10 @@ paths:
           description: The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
           schema:
             minimum: 1
+            maximum: 100
             type: integer
             format: int64
-            default: 50
+            default: 100
         - $ref: "#/components/parameters/pageToken"
         - name: filter
           in: query

--- a/internal/provider/datasource_support_requests/support_requests_data_source_gen.go
+++ b/internal/provider/datasource_support_requests/support_requests_data_source_gen.go
@@ -38,7 +38,7 @@ func SupportRequestsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.",
 				MarkdownDescription: "The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.",
 				Validators: []validator.Int64{
-					int64validator.AtLeast(1),
+					int64validator.Between(1, 100),
 				},
 			},
 			"min_creation_time": schema.StringAttribute{

--- a/internal/provider/support_requests_data_source_test.go
+++ b/internal/provider/support_requests_data_source_test.go
@@ -13,9 +13,6 @@ import (
 
 // TestAccSupportRequestsDataSource_MaxResultsOnly tests that setting max_results limits results.
 func TestAccSupportRequestsDataSource_MaxResultsOnly(t *testing.T) {
-	// TODO(CMP-40423): The support requests API ignores maxResults and pageToken entirely,
-	// returning all results regardless of pagination parameters.
-	t.Skip("Skipped: support requests API ignores maxResults entirely (CMP-40423)")
 	ticketCount := getSupportRequestCount(t)
 	if ticketCount < 3 {
 		t.Skipf("Need at least 3 support requests to test pagination, got %d", ticketCount)
@@ -61,7 +58,7 @@ data "doit_support_requests" "limited" {
 // TestAccSupportRequestsDataSource_PageTokenOnly tests that setting only page_token (without max_results)
 // auto-paginates starting from the token, returning fewer results than a full run.
 func TestAccSupportRequestsDataSource_PageTokenOnly(t *testing.T) {
-	t.Skip("Skipped: support requests API returns 400 'Failed to get tickets'")
+
 	totalRequests := getSupportRequestCount(t)
 	if totalRequests < 2 {
 		t.Skipf("Need at least 2 support requests to test page_token-only, got %d", totalRequests)


### PR DESCRIPTION
## Summary

Syncs the downstream OpenAPI spec with the upstream CMP-40423 pagination fix ([doiteng/omni#53093](https://github.com/doiteng/omni/pull/53093)) and re-enables the previously skipped acceptance tests.

## Changes

- **OpenAPI spec**: `maxResults` default `50→100`, added `maximum: 100` constraint
- **Generated schema**: Now enforces `Between(1, 100)` validation at plan time
- **Tests**: Removed `t.Skip` from `MaxResultsOnly` and `PageTokenOnly` tests — both now pass against prod

## Context

The upstream fix resolved a regression where the support API ignored `maxResults` and `pageToken` for non-employee tokens. With the fix deployed to prod, all 4 support request data source tests pass:

| Test | Result |
|---|---|
| `MaxResultsOnly` | ✅ PASS (was skipped) |
| `PageTokenOnly` | ✅ PASS (was skipped) |
| `MaxResultsAndPageToken` | ✅ PASS |
| `AutoPagination` | ✅ PASS |