### PR TITLE
feat(report,allocation): add folder_id support

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -578,6 +578,13 @@
 						}
 					},
 					{
+						"name": "folder_id",
+						"string": {
+							"computed_optional_required": "computed",
+							"description": "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder)."
+						}
+					},
+					{
 						"name": "name",
 						"string": {
 							"computed_optional_required": "computed",
@@ -835,7 +842,7 @@
 						"name": "filter",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**."
+							"description": "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**, **folderId**."
 						}
 					},
 					{
@@ -901,6 +908,13 @@
 										"string": {
 											"computed_optional_required": "computed",
 											"description": "Allocation description."
+										}
+									},
+									{
+										"name": "folder_id",
+										"string": {
+											"computed_optional_required": "computed",
+											"description": "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder)."
 										}
 									},
 									{
@@ -4727,6 +4741,13 @@
 						}
 					},
 					{
+						"name": "folder_id",
+						"string": {
+							"computed_optional_required": "computed",
+							"description": "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder)."
+						}
+					},
+					{
 						"name": "labels",
 						"list": {
 							"computed_optional_required": "computed",
@@ -4777,7 +4798,7 @@
 						"name": "filter",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "An expression for filtering the results.\nThe syntax is `key:[\u003cvalue\u003e]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nPossible filter keys: **reportName**, **owner**, **type**, **updateTime**"
+							"description": "An expression for filtering the results.\nThe syntax is `key:[\u003cvalue\u003e]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nPossible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**"
 						}
 					},
 					{

--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -290,6 +290,13 @@
 						}
 					},
 					{
+						"name": "folder_id",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder)."
+						}
+					},
+					{
 						"name": "name",
 						"string": {
 							"computed_optional_required": "required",
@@ -2531,6 +2538,13 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "Report description."
+						}
+					},
+					{
+						"name": "folder_id",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder)."
 						}
 					},
 					{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -264,7 +264,7 @@ paths:
           in: query
           description: |-
             An expression for filtering the results.
-            Valid fields: **type**, **owner**, **name**.
+            Valid fields: **type**, **owner**, **name**, **folderId**.
           example: type:custom
           schema:
             type: string
@@ -447,172 +447,6 @@ paths:
         "404":
           $ref: "#/components/responses/404"
       x-codegen-request-body-name: Body
-  /analytics/v1/folders:
-    get:
-      tags:
-        - Folders
-      summary: List folders
-      description: |-
-        Returns Cloud Analytics folders the current customer has access to.
-        Folders are returned in id-ascending order.
-      operationId: listFolders
-      parameters:
-        - $ref: "#/components/parameters/maxResults"
-        - $ref: "#/components/parameters/pageToken"
-      responses:
-        "200":
-          description: OK - The request succeeded.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  pageToken:
-                    type: string
-                    description: Page token, returned by a previous call, to request the next page of results.
-                  rowCount:
-                    type: integer
-                    description: Number of folders returned in this page.
-                  folders:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Folder"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
-    post:
-      tags:
-        - Folders
-      summary: Create a folder
-      description: Creates a new Cloud Analytics folder.
-      operationId: createFolder
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateFolderRequest"
-      responses:
-        "201":
-          description: Created - The folder was created.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Folder"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
-      x-codegen-request-body-name: Body
-  "/analytics/v1/folders/{id}":
-    get:
-      tags:
-        - Folders
-      summary: Get a folder
-      description: Returns the specified Cloud Analytics folder.
-      operationId: getFolder
-      parameters:
-        - name: id
-          in: path
-          description: Folder ID.
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK - Folder returned.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Folder"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-    patch:
-      tags:
-        - Folders
-      summary: Update a folder
-      description: |-
-        Updates the specified folder. All fields are optional.
-        To reparent the folder, set `parentFolderId` to the target folder ID
-        (use "root" for the top level). If a sibling at the target has the same
-        name, the folder is auto-renamed.
-        To move reports or allocations into or out of a folder, update the item's
-        `folderId` field via the report or allocation PATCH endpoint.
-      operationId: updateFolder
-      parameters:
-        - name: id
-          in: path
-          description: Folder ID.
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UpdateFolderRequest"
-      responses:
-        "200":
-          description: OK - Folder updated.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Folder"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-      x-codegen-request-body-name: Body
-    delete:
-      tags:
-        - Folders
-      summary: Delete a folder
-      description: >-
-        Deletes the specified folder. The folder must be empty; if it still
-        contains reports or allocations, the request fails with `400 Bad Request`.
-      operationId: deleteFolder
-      parameters:
-        - name: id
-          in: path
-          description: Folder ID.
-          required: true
-          schema:
-            type: string
-      responses:
-        "204":
-          description: No Content - Folder deleted.
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
   /analytics/v1/annotations:
     get:
       tags:
@@ -1315,6 +1149,185 @@ paths:
           $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
+  /analytics/v1/folders:
+    get:
+      tags:
+        - Folders
+      summary: List folders
+      description: |-
+        Returns Cloud Analytics folders the current customer has access to.
+        Folders are returned in id-ascending order.
+      operationId: listFolders
+      parameters:
+        - $ref: "#/components/parameters/maxResults"
+        - $ref: "#/components/parameters/pageToken"
+      responses:
+        "200":
+          description: OK - The request succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pageToken:
+                    type: string
+                    description: Page token, returned by a previous call, to request the next page of results.
+                  rowCount:
+                    type: integer
+                    description: Number of folders returned in this page.
+                  folders:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Folder"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+    post:
+      tags:
+        - Folders
+      summary: Create a folder
+      description: Creates a new Cloud Analytics folder.
+      operationId: createFolder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFolderRequest"
+      responses:
+        "201":
+          description: Created - The folder was created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+          links:
+            getFolder:
+              operationId: getFolder
+              parameters:
+                id: $response.body#/id
+            updateFolder:
+              operationId: updateFolder
+              parameters:
+                id: $response.body#/id
+            deleteFolder:
+              operationId: deleteFolder
+              parameters:
+                id: $response.body#/id
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+      x-codegen-request-body-name: Body
+  "/analytics/v1/folders/{id}":
+    get:
+      tags:
+        - Folders
+      summary: Get a folder
+      description: Returns the specified Cloud Analytics folder.
+      operationId: getFolder
+      parameters:
+        - name: id
+          in: path
+          description: Folder ID.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK - Folder returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+    patch:
+      tags:
+        - Folders
+      summary: Update a folder
+      description: |-
+        Updates the specified folder. All fields are optional.
+        To reparent the folder, set `parentFolderId` to the target folder ID
+        (use "root" for the top level). If a sibling at the target has the same
+        name, the folder is auto-renamed.
+        To move reports or allocations into or out of a folder, update the item's
+        `folderId` field via the report or allocation PATCH endpoint.
+      operationId: updateFolder
+      parameters:
+        - name: id
+          in: path
+          description: Folder ID.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFolderRequest"
+      responses:
+        "200":
+          description: OK - Folder updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+      x-codegen-request-body-name: Body
+    delete:
+      tags:
+        - Folders
+      summary: Delete a folder
+      description: >-
+        Deletes the specified folder. All nested folders will be deleted.
+        Any reports or allocations contained in the folder are moved to the root.
+      operationId: deleteFolder
+      parameters:
+        - name: id
+          in: path
+          description: Folder ID.
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content - Folder deleted.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
   /analytics/v1/dimensions:
     get:
       tags:
@@ -1377,7 +1390,7 @@ paths:
 
             The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 
-            Possible filter keys: **reportName**, **owner**, **type**, **updateTime**
+            Possible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**
           example: "reportName:This Month vs. Last"
           schema:
             type: string
@@ -1438,6 +1451,10 @@ paths:
                   items:
                     type: string
                   description: Array of label IDs assigned to the report
+                folderId:
+                  type: string
+                  description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+                  example: root
             example:
               name: schemathesis-stateful-report
               description: Schemathesis stateful test report
@@ -4301,6 +4318,10 @@ components:
           type: string
           description: Custom label for values that do not fit into allocation (required for group type allocation).
           nullable: true
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     UpdateAllocationRequest:
       type: object
       description: Request body for updating an allocation.
@@ -4323,6 +4344,10 @@ components:
           type: string
           description: Custom label for values that do not fit into allocation (required for group type allocation).
           nullable: true
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     AllocationListItem:
       type: object
       description: Summary information for an allocation.
@@ -4359,6 +4384,10 @@ components:
         urlUI:
           type: string
           description: URL to view the allocation in the DoiT console.
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     AllocationRule:
       required:
         - components
@@ -5692,6 +5721,58 @@ components:
         - table_col_heatmap
         - csv_export
         - sheets_export
+    Folder:
+      type: object
+      description: A Cloud Analytics folder.
+      properties:
+        id:
+          type: string
+          description: Folder ID.
+        name:
+          type: string
+          description: Folder name.
+        description:
+          type: string
+          description: Folder description.
+        parentFolderId:
+          type: string
+          description: Identifier of the parent folder. Set to "root" if the folder is at the top level.
+          example: root
+    CreateFolderRequest:
+      required:
+        - name
+      type: object
+      description: Request body for creating a folder.
+      properties:
+        name:
+          type: string
+          description: Folder name.
+        description:
+          type: string
+          description: Folder description.
+        parentFolderId:
+          type: string
+          description: Identifier of the parent folder. Use "root" or omit to place the folder at the top level.
+          example: root
+    UpdateFolderRequest:
+      type: object
+      description: |-
+        Request body for updating a folder. All fields are optional; only fields
+        the caller wants to change should be set.
+      properties:
+        name:
+          type: string
+          description: Folder name.
+        description:
+          type: string
+          description: Folder description.
+        parentFolderId:
+          type: string
+          description: >-
+            Identifier of the new parent folder. Use "root" to move the folder
+            to the top level. If a sibling at the new parent has the same name,
+            the folder is auto-renamed (e.g. "Foo" → "Foo (1)").
+          example: root
     ExternalReport:
       required:
         - name
@@ -5721,6 +5802,10 @@ components:
           items:
             type: string
           description: Array of label IDs assigned to the report
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          example: root
     ExternalSplit:
       type: object
       description: Specification of how to split costs.
@@ -5809,6 +5894,10 @@ components:
           items:
             type: string
           description: Array of label IDs assigned to the report
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          example: root
       example:
         config:
           timeRange:
@@ -5819,58 +5908,6 @@ components:
           timeInterval: week
         description: An update via API
         name: A new name
-    Folder:
-      type: object
-      description: A Cloud Analytics folder.
-      properties:
-        id:
-          type: string
-          description: Folder ID.
-        name:
-          type: string
-          description: Folder name.
-        description:
-          type: string
-          description: Folder description.
-        parentFolderId:
-          type: string
-          description: Identifier of the parent folder. Set to "root" if the folder is at the top level.
-          example: root
-    CreateFolderRequest:
-      required:
-        - name
-      type: object
-      description: Request body for creating a folder.
-      properties:
-        name:
-          type: string
-          description: Folder name.
-        description:
-          type: string
-          description: Folder description.
-        parentFolderId:
-          type: string
-          description: Identifier of the parent folder. Use "root" or omit to place the folder at the top level.
-          example: root
-    UpdateFolderRequest:
-      type: object
-      description: |-
-        Request body for updating a folder. All fields are optional; only fields
-        the caller wants to change should be set.
-      properties:
-        name:
-          type: string
-          description: Folder name.
-        description:
-          type: string
-          description: Folder description.
-        parentFolderId:
-          type: string
-          description: >-
-            Identifier of the new parent folder. Use "root" to move the folder
-            to the top level. If a sibling at the new parent has the same name,
-            the folder is auto-renamed (e.g. "Foo" → "Foo (1)").
-          example: root
     Allocation:
       type: object
       description: Allocation object, including rules and metadata.
@@ -5915,6 +5952,10 @@ components:
           type: string
           description: Custom label for values that do not fit into allocation (required for group type allocation).
           nullable: true
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     GroupAllocationRule:
       required:
         - action

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -263,7 +263,7 @@ paths:
           in: query
           description: |-
             An expression for filtering the results.
-            Valid fields: **type**, **owner**, **name**.
+            Valid fields: **type**, **owner**, **name**, **folderId**.
           example: type:custom
           schema:
             type: string
@@ -435,160 +435,6 @@ paths:
         "404":
           $ref: "#/components/responses/404"
       x-codegen-request-body-name: Body
-  /analytics/v1/folders:
-    get:
-      tags:
-        - Folders
-      summary: List folders
-      description: |-
-        Returns Cloud Analytics folders the current customer has access to.
-        Folders are returned in id-ascending order.
-      operationId: listFolders
-      parameters:
-        - $ref: "#/components/parameters/maxResults"
-        - $ref: "#/components/parameters/pageToken"
-      responses:
-        "200":
-          description: OK - The request succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListFolders200Response'
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
-    post:
-      tags:
-        - Folders
-      summary: Create a folder
-      description: Creates a new Cloud Analytics folder.
-      operationId: createFolder
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateFolderRequest"
-      responses:
-        "201":
-          description: Created - The folder was created.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Folder"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
-      x-codegen-request-body-name: Body
-  "/analytics/v1/folders/{id}":
-    get:
-      tags:
-        - Folders
-      summary: Get a folder
-      description: Returns the specified Cloud Analytics folder.
-      operationId: getFolder
-      parameters:
-        - name: id
-          in: path
-          description: Folder ID.
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: OK - Folder returned.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Folder"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-    patch:
-      tags:
-        - Folders
-      summary: Update a folder
-      description: |-
-        Updates the specified folder. All fields are optional.
-        To reparent the folder, set `parentFolderId` to the target folder ID
-        (use "root" for the top level). If a sibling at the target has the same
-        name, the folder is auto-renamed.
-        To move reports or allocations into or out of a folder, update the item's
-        `folderId` field via the report or allocation PATCH endpoint.
-      operationId: updateFolder
-      parameters:
-        - name: id
-          in: path
-          description: Folder ID.
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UpdateFolderRequest"
-      responses:
-        "200":
-          description: OK - Folder updated.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Folder"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-      x-codegen-request-body-name: Body
-    delete:
-      tags:
-        - Folders
-      summary: Delete a folder
-      description: >-
-        Deletes the specified folder. The folder must be empty; if it still contains reports or allocations, the request fails with `400 Bad Request`.
-      operationId: deleteFolder
-      parameters:
-        - name: id
-          in: path
-          description: Folder ID.
-          required: true
-          schema:
-            type: string
-      responses:
-        "204":
-          description: No Content - Folder deleted.
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
   /analytics/v1/annotations:
     get:
       tags:
@@ -1263,6 +1109,173 @@ paths:
           $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
+  /analytics/v1/folders:
+    get:
+      tags:
+        - Folders
+      summary: List folders
+      description: |-
+        Returns Cloud Analytics folders the current customer has access to.
+        Folders are returned in id-ascending order.
+      operationId: listFolders
+      parameters:
+        - $ref: "#/components/parameters/maxResults"
+        - $ref: "#/components/parameters/pageToken"
+      responses:
+        "200":
+          description: OK - The request succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListFolders200Response'
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+    post:
+      tags:
+        - Folders
+      summary: Create a folder
+      description: Creates a new Cloud Analytics folder.
+      operationId: createFolder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFolderRequest"
+      responses:
+        "201":
+          description: Created - The folder was created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+          links:
+            getFolder:
+              operationId: getFolder
+              parameters:
+                id: $response.body#/id
+            updateFolder:
+              operationId: updateFolder
+              parameters:
+                id: $response.body#/id
+            deleteFolder:
+              operationId: deleteFolder
+              parameters:
+                id: $response.body#/id
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+      x-codegen-request-body-name: Body
+  "/analytics/v1/folders/{id}":
+    get:
+      tags:
+        - Folders
+      summary: Get a folder
+      description: Returns the specified Cloud Analytics folder.
+      operationId: getFolder
+      parameters:
+        - name: id
+          in: path
+          description: Folder ID.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK - Folder returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+    patch:
+      tags:
+        - Folders
+      summary: Update a folder
+      description: |-
+        Updates the specified folder. All fields are optional.
+        To reparent the folder, set `parentFolderId` to the target folder ID
+        (use "root" for the top level). If a sibling at the target has the same
+        name, the folder is auto-renamed.
+        To move reports or allocations into or out of a folder, update the item's
+        `folderId` field via the report or allocation PATCH endpoint.
+      operationId: updateFolder
+      parameters:
+        - name: id
+          in: path
+          description: Folder ID.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFolderRequest"
+      responses:
+        "200":
+          description: OK - Folder updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+      x-codegen-request-body-name: Body
+    delete:
+      tags:
+        - Folders
+      summary: Delete a folder
+      description: >-
+        Deletes the specified folder. All nested folders will be deleted. Any reports or allocations contained in the folder are moved to the root.
+      operationId: deleteFolder
+      parameters:
+        - name: id
+          in: path
+          description: Folder ID.
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content - Folder deleted.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
   /analytics/v1/dimensions:
     get:
       tags:
@@ -1325,7 +1338,7 @@ paths:
 
             The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 
-            Possible filter keys: **reportName**, **owner**, **type**, **updateTime**
+            Possible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**
           example: "reportName:This Month vs. Last"
           schema:
             type: string
@@ -3486,6 +3499,10 @@ components:
           type: string
           description: Custom label for values that do not fit into allocation (required for group type allocation).
           nullable: true
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     AllocationComponent:
       required:
         - key
@@ -3609,6 +3626,10 @@ components:
         urlUI:
           type: string
           description: URL to view the allocation in the DoiT console.
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     AllocationRule:
       required:
         - components
@@ -5484,6 +5505,10 @@ components:
           type: string
           description: Custom label for values that do not fit into allocation (required for group type allocation).
           nullable: true
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     CreateAnnotationRequest:
       required:
         - content
@@ -5619,6 +5644,10 @@ components:
           items:
             type: string
           description: Array of label IDs assigned to the report
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          example: root
     Currency:
       description: Currency code for monetary values.
       type: string
@@ -6299,6 +6328,10 @@ components:
           items:
             type: string
           description: Array of label IDs assigned to the report
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          example: root
     ExternalSplit:
       type: object
       description: Specification of how to split costs.
@@ -6386,6 +6419,10 @@ components:
           items:
             type: string
           description: Array of label IDs assigned to the report
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          example: root
       example:
         config:
           timeRange:
@@ -7857,6 +7894,10 @@ components:
           type: string
           description: Custom label for values that do not fit into allocation (required for group type allocation).
           nullable: true
+        folderId:
+          type: string
+          description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          example: root
     UpdateAnnotationRequest:
       type: object
       description: Request body for updating an annotation.

--- a/docs/data-sources/allocation.md
+++ b/docs/data-sources/allocation.md
@@ -49,6 +49,7 @@ output "allocation_description" {
 - `anomaly_detection` (Boolean) Whether anomaly detection is enabled for this allocation.
 - `create_time` (Number) The time when the allocation was created (in UNIX timestamp).
 - `description` (String) Allocation description.
+- `folder_id` (String) Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
 - `name` (String) Allocation name.
 - `rule` (Attributes) Single allocation rule. Components can reference other existing allocation rules by using the "allocation_rule" dimension type. (see [below for nested schema](#nestedatt--rule))
 - `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))

--- a/docs/data-sources/allocations.md
+++ b/docs/data-sources/allocations.md
@@ -38,7 +38,7 @@ output "allocation_names" {
 ### Optional
 
 - `filter` (String) An expression for filtering the results.
-Valid fields: **type**, **owner**, **name**.
+Valid fields: **type**, **owner**, **name**, **folderId**.
 - `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
@@ -68,6 +68,7 @@ Read-Only:
 - `allocation_type` (String) Composition type of allocation (single or group).
 - `create_time` (Number) The time when the allocation was created (in UNIX timestamp).
 - `description` (String) Allocation description.
+- `folder_id` (String) Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
 - `id` (String) Allocation ID.
 - `name` (String) Allocation name.
 - `owner` (String) Allocation owner.

--- a/docs/data-sources/report.md
+++ b/docs/data-sources/report.md
@@ -56,6 +56,7 @@ output "report_labels" {
 
 - `config` (Attributes) Report configuration. (see [below for nested schema](#nestedatt--config))
 - `description` (String) Report description.
+- `folder_id` (String) Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
 - `labels` (List of String) Array of label IDs assigned to the report
 - `name` (String) Report name.
 - `type` (String) Report type.

--- a/docs/data-sources/reports.md
+++ b/docs/data-sources/reports.md
@@ -59,7 +59,7 @@ output "reports_with_labels" {
 
 - `filter` (String) An expression for filtering the results.
 The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
-Possible filter keys: **reportName**, **owner**, **type**, **updateTime**
+Possible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**
 - `max_creation_time` (String) Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.
 - `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `min_creation_time` (String) Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.

--- a/docs/resources/allocation.md
+++ b/docs/resources/allocation.md
@@ -88,6 +88,30 @@ resource "doit_allocation" "allocation_by_region" {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Organizing allocations in folders
+# ─────────────────────────────────────────────────────────────────────────────
+# Use folder_id to place an allocation inside a Cloud Analytics folder.
+
+resource "doit_folder" "cost_allocations" {
+  name = "Cost Allocations"
+}
+
+resource "doit_allocation" "in_folder" {
+  name        = "Production"
+  description = "Production environment costs"
+  folder_id   = doit_folder.cost_allocations.id
+  rule = {
+    formula = "A"
+    components = [{
+      mode   = "is"
+      type   = "project_label"
+      key    = "env"
+      values = ["prod"]
+    }]
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Discovering valid component values using data sources
 # ─────────────────────────────────────────────────────────────────────────────
 # Allocation components use `type` and `key` fields that correspond to dimension
@@ -223,6 +247,7 @@ resource "doit_allocation" "dynamic_countries" {
 
 ### Optional
 
+- `folder_id` (String) Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
 - `rule` (Attributes) Single allocation rule. Components can reference other existing allocation rules by using the "allocation_rule" dimension type. (see [below for nested schema](#nestedatt--rule))
 - `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -83,6 +83,45 @@ resource "doit_report" "my_report" {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Organizing reports in folders
+# ─────────────────────────────────────────────────────────────────────────────
+# Use folder_id to place a report inside a Cloud Analytics folder.
+# Create a folder first, then reference its ID in the report.
+
+resource "doit_folder" "cost_reports" {
+  name = "Cost Reports"
+}
+
+resource "doit_report" "in_folder" {
+  name        = "AWS Monthly Costs"
+  description = "Monthly cost breakdown for AWS services"
+  folder_id   = doit_folder.cost_reports.id
+  config = {
+    metrics        = [{ type = "basic", value = "cost" }]
+    aggregation    = "total"
+    data_source    = "billing"
+    time_interval  = "month"
+    display_values = "actuals_only"
+    time_range = {
+      mode            = "last"
+      amount          = 3
+      include_current = true
+      unit            = "month"
+    }
+    filters = [
+      {
+        id     = "cloud_provider"
+        type   = "fixed"
+        mode   = "is"
+        values = ["amazon-web-services"]
+      }
+    ]
+    layout   = "table"
+    currency = "USD"
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Assigning labels to a report
 # ─────────────────────────────────────────────────────────────────────────────
 # Labels help categorize and filter reports in the DoiT console.
@@ -279,6 +318,7 @@ resource "doit_report" "multi_cloud_costs" {
 
 - `config` (Attributes) Report configuration. (see [below for nested schema](#nestedatt--config))
 - `description` (String) Report description.
+- `folder_id` (String) Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
 - `labels` (List of String) Array of label IDs assigned to the report
 - `name` (String) Report name.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/examples/resources/doit_allocation/resource.tf
+++ b/examples/resources/doit_allocation/resource.tf
@@ -73,6 +73,30 @@ resource "doit_allocation" "allocation_by_region" {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Organizing allocations in folders
+# ─────────────────────────────────────────────────────────────────────────────
+# Use folder_id to place an allocation inside a Cloud Analytics folder.
+
+resource "doit_folder" "cost_allocations" {
+  name = "Cost Allocations"
+}
+
+resource "doit_allocation" "in_folder" {
+  name        = "Production"
+  description = "Production environment costs"
+  folder_id   = doit_folder.cost_allocations.id
+  rule = {
+    formula = "A"
+    components = [{
+      mode   = "is"
+      type   = "project_label"
+      key    = "env"
+      values = ["prod"]
+    }]
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Discovering valid component values using data sources
 # ─────────────────────────────────────────────────────────────────────────────
 # Allocation components use `type` and `key` fields that correspond to dimension

--- a/examples/resources/doit_report/resource.tf
+++ b/examples/resources/doit_report/resource.tf
@@ -68,6 +68,45 @@ resource "doit_report" "my_report" {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Organizing reports in folders
+# ─────────────────────────────────────────────────────────────────────────────
+# Use folder_id to place a report inside a Cloud Analytics folder.
+# Create a folder first, then reference its ID in the report.
+
+resource "doit_folder" "cost_reports" {
+  name = "Cost Reports"
+}
+
+resource "doit_report" "in_folder" {
+  name        = "AWS Monthly Costs"
+  description = "Monthly cost breakdown for AWS services"
+  folder_id   = doit_folder.cost_reports.id
+  config = {
+    metrics        = [{ type = "basic", value = "cost" }]
+    aggregation    = "total"
+    data_source    = "billing"
+    time_interval  = "month"
+    display_values = "actuals_only"
+    time_range = {
+      mode            = "last"
+      amount          = 3
+      include_current = true
+      unit            = "month"
+    }
+    filters = [
+      {
+        id     = "cloud_provider"
+        type   = "fixed"
+        mode   = "is"
+        values = ["amazon-web-services"]
+      }
+    ]
+    layout   = "table"
+    currency = "USD"
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Assigning labels to a report
 # ─────────────────────────────────────────────────────────────────────────────
 # Labels help categorize and filter reports in the DoiT console.

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -64,6 +64,9 @@ func (r *allocationResource) overlayComputedFields(ctx context.Context, apiResp 
 	if plan.UnallocatedCosts.IsUnknown() {
 		plan.UnallocatedCosts = resolved.UnallocatedCosts
 	}
+	if plan.FolderId.IsUnknown() {
+		plan.FolderId = resolved.FolderId
+	}
 
 	// ── Rule (single nested object): use resolved when Unknown, overlay subfields when Known ──
 	if plan.Rule.IsUnknown() {
@@ -168,6 +171,7 @@ func (plan *allocationResourceModel) toCreateRequest(ctx context.Context) (req m
 		req.Name = *common.Name
 	}
 	req.UnallocatedCosts = common.UnallocatedCosts
+	req.FolderId = common.FolderId
 	req.Rule = common.Rule
 	req.Rules = common.Rules
 
@@ -217,6 +221,7 @@ func convertComponentsToModels(ctx context.Context, components []resource_alloca
 func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, req *models.UpdateAllocationRequest) (diags diag.Diagnostics) {
 	req.Description = plan.Description.ValueStringPointer()
 	req.Name = plan.Name.ValueStringPointer()
+	req.FolderId = plan.FolderId.ValueStringPointer()
 	// UnallocatedCosts is only sent if not empty because it is invalid for "single" allocations.
 	if v := plan.UnallocatedCosts.ValueString(); v != "" {
 		req.UnallocatedCosts = &v
@@ -365,6 +370,7 @@ func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *mod
 	state.UpdateTime = types.Int64PointerValue(resp.UpdateTime)
 	state.Name = types.StringPointerValue(resp.Name)
 	state.UnallocatedCosts = types.StringPointerValue(resp.UnallocatedCosts)
+	state.FolderId = types.StringPointerValue(resp.FolderId)
 
 	if resp.AllocationType != nil {
 		state.AllocationType = types.StringValue(string(*resp.AllocationType))

--- a/internal/provider/allocation_data_source.go
+++ b/internal/provider/allocation_data_source.go
@@ -82,6 +82,7 @@ func (ds *allocationDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if data.Id.IsUnknown() {
 		data.Name = types.StringUnknown()
 		data.Description = types.StringUnknown()
+		data.FolderId = types.StringUnknown()
 		data.Type = types.StringUnknown()
 		data.AllocationType = types.StringUnknown()
 		data.AnomalyDetection = types.BoolUnknown()
@@ -142,6 +143,7 @@ func (ds *allocationDataSource) mapAllocationToModel(ctx context.Context, alloca
 	data.CreateTime = types.Int64PointerValue(allocation.CreateTime)
 	data.UpdateTime = types.Int64PointerValue(allocation.UpdateTime)
 	data.UnallocatedCosts = types.StringPointerValue(allocation.UnallocatedCosts)
+	data.FolderId = types.StringPointerValue(allocation.FolderId)
 
 	if allocation.AllocationType != nil {
 		data.AllocationType = types.StringValue(string(*allocation.AllocationType))

--- a/internal/provider/allocation_data_source_test.go
+++ b/internal/provider/allocation_data_source_test.go
@@ -155,3 +155,54 @@ data "doit_allocation" "test" {
 }
 `
 }
+
+// TestAccAllocationDataSource_FolderId verifies that the data source returns the
+// correct folder_id when an allocation is created inside a folder.
+func TestAccAllocationDataSource_FolderId(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-alloc-ds-f")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllocationDataSourceFolderIdConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.doit_allocation.test", "folder_id",
+						"doit_folder.ds_alloc_test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAllocationDataSourceFolderIdConfig(name string) string {
+	return fmt.Sprintf(`
+resource "doit_folder" "ds_alloc_test" {
+    name = "%s-folder"
+}
+
+resource "doit_allocation" "test" {
+    name        = %q
+    description = "Folder DS test allocation"
+    folder_id   = doit_folder.ds_alloc_test.id
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "project_id"
+           mode   = "is"
+           type   = "fixed"
+           values = ["%s"]
+         }
+       ]
+    }
+}
+
+data "doit_allocation" "test" {
+    id = doit_allocation.test.id
+}
+`, name, name, testProject())
+}

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -2347,3 +2347,120 @@ func TestAccAllocation_GroupImportActionPreservation(t *testing.T) {
 		},
 	})
 }
+
+// TestAccAllocation_FolderId verifies that allocations can be created inside a
+// folder, the folder_id is persisted in state, the allocation can be moved to
+// root, and that re-applying produces no drift.
+func TestAccAllocation_FolderId(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create allocation inside a folder
+			{
+				Config: testAccAllocationInFolder(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_allocation.folder_test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"doit_allocation.folder_test", "folder_id",
+						"doit_folder.alloc_test", "id"),
+				),
+			},
+			// Step 2: Drift check — re-apply same config, expect no changes
+			{
+				Config: testAccAllocationInFolder(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Move allocation to root (folder_id = "root")
+			{
+				Config: testAccAllocationInRoot(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_allocation.folder_test",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.folder_test",
+						tfjsonpath.New("folder_id"),
+						knownvalue.StringExact("root")),
+				},
+			},
+			// Step 4: Drift check after move
+			{
+				Config: testAccAllocationInRoot(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationInFolder(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_folder" "alloc_test" {
+    name = "%s-alloc-folder"
+}
+
+resource "doit_allocation" "folder_test" {
+    name        = "%s-in-folder"
+    description = "Folder test allocation"
+    folder_id   = doit_folder.alloc_test.id
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "project_id"
+           mode   = "is"
+           type   = "fixed"
+           values = ["%s"]
+         }
+       ]
+    }
+}
+`, rName, rName, testProject())
+}
+
+func testAccAllocationInRoot(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "folder_test" {
+    name        = "%s-in-folder"
+    description = "Folder test allocation"
+    folder_id   = "root"
+    rule = {
+       formula = "A"
+       components = [
+        {
+           key    = "project_id"
+           mode   = "is"
+           type   = "fixed"
+           values = ["%s"]
+         }
+       ]
+    }
+}
+`, rName, testProject())
+}

--- a/internal/provider/allocations_data_source.go
+++ b/internal/provider/allocations_data_source.go
@@ -186,6 +186,7 @@ func (d *allocationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 					"id":              types.StringPointerValue(alloc.Id),
 					"name":            types.StringPointerValue(alloc.Name),
 					"description":     types.StringPointerValue(alloc.Description),
+					"folder_id":       types.StringPointerValue(alloc.FolderId),
 					"owner":           types.StringPointerValue(alloc.Owner),
 					"type":            types.StringPointerValue(alloc.Type),
 					"allocation_type": allocTypeVal,

--- a/internal/provider/datasource_allocation/allocation_data_source_gen.go
+++ b/internal/provider/datasource_allocation/allocation_data_source_gen.go
@@ -38,6 +38,11 @@ func AllocationDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Allocation description.",
 				MarkdownDescription: "Allocation description.",
 			},
+			"folder_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
+				MarkdownDescription: "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
+			},
 			"id": schema.StringAttribute{
 				Required:            true,
 				Description:         "Allocation ID",
@@ -240,6 +245,7 @@ type AllocationModel struct {
 	AnomalyDetection types.Bool   `tfsdk:"anomaly_detection"`
 	CreateTime       types.Int64  `tfsdk:"create_time"`
 	Description      types.String `tfsdk:"description"`
+	FolderId         types.String `tfsdk:"folder_id"`
 	Id               types.String `tfsdk:"id"`
 	Name             types.String `tfsdk:"name"`
 	Rule             RuleValue    `tfsdk:"rule"`

--- a/internal/provider/datasource_allocations/allocations_data_source_gen.go
+++ b/internal/provider/datasource_allocations/allocations_data_source_gen.go
@@ -38,6 +38,11 @@ func AllocationsDataSourceSchema(ctx context.Context) schema.Schema {
 							Description:         "Allocation description.",
 							MarkdownDescription: "Allocation description.",
 						},
+						"folder_id": schema.StringAttribute{
+							Computed:            true,
+							Description:         "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
+							MarkdownDescription: "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
+						},
 						"id": schema.StringAttribute{
 							Computed:            true,
 							Description:         "Allocation ID.",
@@ -80,8 +85,8 @@ func AllocationsDataSourceSchema(ctx context.Context) schema.Schema {
 			"filter": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**.",
-				MarkdownDescription: "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**.",
+				Description:         "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**, **folderId**.",
+				MarkdownDescription: "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**, **folderId**.",
 			},
 			"max_results": schema.StringAttribute{
 				Optional:            true,
@@ -224,6 +229,24 @@ func (t AllocationsType) ValueFromObject(ctx context.Context, in basetypes.Objec
 			fmt.Sprintf(`description expected to be basetypes.StringValue, was: %T`, descriptionAttribute))
 	}
 
+	folderIdAttribute, ok := attributes["folder_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`folder_id is missing from object`)
+
+		return nil, diags
+	}
+
+	folderIdVal, ok := folderIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`folder_id expected to be basetypes.StringValue, was: %T`, folderIdAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -340,6 +363,7 @@ func (t AllocationsType) ValueFromObject(ctx context.Context, in basetypes.Objec
 		AllocationType:  allocationTypeVal,
 		CreateTime:      createTimeVal,
 		Description:     descriptionVal,
+		FolderId:        folderIdVal,
 		Id:              idVal,
 		Name:            nameVal,
 		Owner:           ownerVal,
@@ -467,6 +491,24 @@ func NewAllocationsValue(attributeTypes map[string]attr.Type, attributes map[str
 			fmt.Sprintf(`description expected to be basetypes.StringValue, was: %T`, descriptionAttribute))
 	}
 
+	folderIdAttribute, ok := attributes["folder_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`folder_id is missing from object`)
+
+		return NewAllocationsValueUnknown(), diags
+	}
+
+	folderIdVal, ok := folderIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`folder_id expected to be basetypes.StringValue, was: %T`, folderIdAttribute))
+	}
+
 	idAttribute, ok := attributes["id"]
 
 	if !ok {
@@ -583,6 +625,7 @@ func NewAllocationsValue(attributeTypes map[string]attr.Type, attributes map[str
 		AllocationType:  allocationTypeVal,
 		CreateTime:      createTimeVal,
 		Description:     descriptionVal,
+		FolderId:        folderIdVal,
 		Id:              idVal,
 		Name:            nameVal,
 		Owner:           ownerVal,
@@ -664,6 +707,7 @@ type AllocationsValue struct {
 	AllocationType  basetypes.StringValue `tfsdk:"allocation_type"`
 	CreateTime      basetypes.Int64Value  `tfsdk:"create_time"`
 	Description     basetypes.StringValue `tfsdk:"description"`
+	FolderId        basetypes.StringValue `tfsdk:"folder_id"`
 	Id              basetypes.StringValue `tfsdk:"id"`
 	Name            basetypes.StringValue `tfsdk:"name"`
 	Owner           basetypes.StringValue `tfsdk:"owner"`
@@ -674,7 +718,7 @@ type AllocationsValue struct {
 }
 
 func (v AllocationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 9)
+	attrTypes := make(map[string]tftypes.Type, 10)
 
 	var val tftypes.Value
 	var err error
@@ -682,6 +726,7 @@ func (v AllocationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 	attrTypes["allocation_type"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["create_time"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["description"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["folder_id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["owner"] = basetypes.StringType{}.TerraformType(ctx)
@@ -693,7 +738,7 @@ func (v AllocationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 9)
+		vals := make(map[string]tftypes.Value, 10)
 
 		val, err = v.AllocationType.ToTerraformValue(ctx)
 
@@ -718,6 +763,14 @@ func (v AllocationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		}
 
 		vals["description"] = val
+
+		val, err = v.FolderId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["folder_id"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
 
@@ -800,6 +853,7 @@ func (v AllocationsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 		"allocation_type": basetypes.StringType{},
 		"create_time":     basetypes.Int64Type{},
 		"description":     basetypes.StringType{},
+		"folder_id":       basetypes.StringType{},
 		"id":              basetypes.StringType{},
 		"name":            basetypes.StringType{},
 		"owner":           basetypes.StringType{},
@@ -822,6 +876,7 @@ func (v AllocationsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 			"allocation_type": v.AllocationType,
 			"create_time":     v.CreateTime,
 			"description":     v.Description,
+			"folder_id":       v.FolderId,
 			"id":              v.Id,
 			"name":            v.Name,
 			"owner":           v.Owner,
@@ -857,6 +912,10 @@ func (v AllocationsValue) Equal(o attr.Value) bool {
 	}
 
 	if !v.Description.Equal(other.Description) {
+		return false
+	}
+
+	if !v.FolderId.Equal(other.FolderId) {
 		return false
 	}
 
@@ -900,6 +959,7 @@ func (v AllocationsValue) AttributeTypes(ctx context.Context) map[string]attr.Ty
 		"allocation_type": basetypes.StringType{},
 		"create_time":     basetypes.Int64Type{},
 		"description":     basetypes.StringType{},
+		"folder_id":       basetypes.StringType{},
 		"id":              basetypes.StringType{},
 		"name":            basetypes.StringType{},
 		"owner":           basetypes.StringType{},

--- a/internal/provider/datasource_report/report_data_source_gen.go
+++ b/internal/provider/datasource_report/report_data_source_gen.go
@@ -526,6 +526,11 @@ func ReportDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Report description.",
 				MarkdownDescription: "Report description.",
 			},
+			"folder_id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder).",
+				MarkdownDescription: "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder).",
+			},
 			"id": schema.StringAttribute{
 				Required:            true,
 				Description:         "Report ID. See [Resource IDs](https://developer.doit.com/docs/resource-ids).",
@@ -556,6 +561,7 @@ func ReportDataSourceSchema(ctx context.Context) schema.Schema {
 type ReportModel struct {
 	Config      ConfigValue  `tfsdk:"config"`
 	Description types.String `tfsdk:"description"`
+	FolderId    types.String `tfsdk:"folder_id"`
 	Id          types.String `tfsdk:"id"`
 	Labels      types.List   `tfsdk:"labels"`
 	Name        types.String `tfsdk:"name"`

--- a/internal/provider/datasource_reports/reports_data_source_gen.go
+++ b/internal/provider/datasource_reports/reports_data_source_gen.go
@@ -21,8 +21,8 @@ func ReportsDataSourceSchema(ctx context.Context) schema.Schema {
 			"filter": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "An expression for filtering the results.\nThe syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nPossible filter keys: **reportName**, **owner**, **type**, **updateTime**",
-				MarkdownDescription: "An expression for filtering the results.\nThe syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nPossible filter keys: **reportName**, **owner**, **type**, **updateTime**",
+				Description:         "An expression for filtering the results.\nThe syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nPossible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**",
+				MarkdownDescription: "An expression for filtering the results.\nThe syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nPossible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**",
 			},
 			"max_creation_time": schema.StringAttribute{
 				Optional:            true,

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3108,6 +3108,9 @@ type Allocation struct {
 	// Description Allocation description.
 	Description *string `json:"description,omitempty"`
 
+	// FolderId Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+	FolderId *string `json:"folderId,omitempty"`
+
 	// Id Allocation ID.
 	Id *string `json:"id,omitempty"`
 
@@ -3196,6 +3199,9 @@ type AllocationListItem struct {
 
 	// Description Allocation description.
 	Description *string `json:"description,omitempty"`
+
+	// FolderId Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+	FolderId *string `json:"folderId,omitempty"`
 
 	// Id Allocation ID.
 	Id *string `json:"id,omitempty"`
@@ -4586,6 +4592,9 @@ type CreateAllocationRequest struct {
 	// Description Allocation description.
 	Description string `json:"description"`
 
+	// FolderId Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+	FolderId *string `json:"folderId,omitempty"`
+
 	// Name Allocation name.
 	Name string `json:"name"`
 
@@ -4679,6 +4688,9 @@ type CreateReportRequestBody struct {
 
 	// Description Report description.
 	Description *string `json:"description,omitempty"`
+
+	// FolderId Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+	FolderId *string `json:"folderId,omitempty"`
 
 	// Labels Array of label IDs assigned to the report
 	Labels *[]string `json:"labels,omitempty"`
@@ -5069,6 +5081,9 @@ type ExternalReport struct {
 	// Description Report description.
 	Description *string `json:"description,omitempty"`
 
+	// FolderId Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+	FolderId *string `json:"folderId,omitempty"`
+
 	// Id Report ID.
 	Id *string `json:"id,omitempty"`
 
@@ -5136,6 +5151,9 @@ type ExternalUpdateReport struct {
 
 	// Description Report description
 	Description *string `json:"description,omitempty"`
+
+	// FolderId Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+	FolderId *string `json:"folderId,omitempty"`
 
 	// Labels Array of label IDs assigned to the report
 	Labels *[]string `json:"labels,omitempty"`
@@ -6231,6 +6249,9 @@ type UpdateAllocationRequest struct {
 	// Description Allocation description
 	Description *string `json:"description,omitempty"`
 
+	// FolderId Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+	FolderId *string `json:"folderId,omitempty"`
+
 	// Name Allocation name
 	Name *string `json:"name,omitempty"`
 
@@ -6546,7 +6567,7 @@ type ListAllocationsParams struct {
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 
 	// Filter An expression for filtering the results.
-	// Valid fields: **type**, **owner**, **name**.
+	// Valid fields: **type**, **owner**, **name**, **folderId**.
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
 
 	// SortBy A field by which the results will be sorted.
@@ -6709,7 +6730,7 @@ type ListReportsParams struct {
 
 	// Filter An expression for filtering the results.
 	// The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
-	// Possible filter keys: **reportName**, **owner**, **type**, **updateTime**
+	// Possible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
 
 	// MinCreationTime Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -69,6 +69,11 @@ func (r *reportResource) overlayReportComputedFields(ctx context.Context, apiRes
 		plan.Labels = resolved.Labels
 	}
 
+	// folder_id: use plan if known, otherwise resolved
+	if plan.FolderId.IsUnknown() {
+		plan.FolderId = resolved.FolderId
+	}
+
 	// ── Config block ──
 	// Walk each field: if the plan value is Known, keep it (user's source of truth).
 	// If Unknown, use the API-resolved value.
@@ -618,6 +623,7 @@ func (r *reportResource) populateStateFromAPI(ctx context.Context, id string, st
 func (plan *reportResourceModel) toCreateRequest(ctx context.Context) (req models.CreateReportJSONRequestBody, diags diag.Diagnostics) {
 	req.Name = plan.Name.ValueStringPointer()
 	req.Description = plan.Description.ValueStringPointer()
+	req.FolderId = plan.FolderId.ValueStringPointer()
 
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
 		var labels []string
@@ -641,6 +647,7 @@ func (plan *reportResourceModel) toCreateRequest(ctx context.Context) (req model
 func (plan *reportResourceModel) toUpdateRequest(ctx context.Context) (req models.UpdateReportJSONRequestBody, diags diag.Diagnostics) {
 	req.Name = plan.Name.ValueStringPointer()
 	req.Description = plan.Description.ValueStringPointer()
+	req.FolderId = plan.FolderId.ValueStringPointer()
 
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
 		var labels []string
@@ -953,6 +960,7 @@ func (r *reportResource) populateState(ctx context.Context, state *reportResourc
 	state.Id = types.StringPointerValue(resp.Id)
 	state.Name = types.StringValue(resp.Name)
 	state.Description = types.StringPointerValue(resp.Description)
+	state.FolderId = types.StringPointerValue(resp.FolderId)
 	if resp.Type != nil {
 		state.Type = types.StringValue(string(*resp.Type))
 	} else {

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -83,6 +83,7 @@ func (ds *reportDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if data.Id.IsUnknown() {
 		data.Name = types.StringUnknown()
 		data.Description = types.StringUnknown()
+		data.FolderId = types.StringUnknown()
 		data.Type = types.StringUnknown()
 		data.Labels = types.ListUnknown(types.StringType)
 		data.Config = datasource_report.NewConfigValueUnknown()
@@ -136,6 +137,7 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 	state.Id = types.StringPointerValue(resp.Id)
 	state.Name = types.StringValue(resp.Name)
 	state.Description = types.StringPointerValue(resp.Description)
+	state.FolderId = types.StringPointerValue(resp.FolderId)
 	if resp.Type != nil {
 		state.Type = types.StringValue(string(*resp.Type))
 	} else {

--- a/internal/provider/report_data_source_test.go
+++ b/internal/provider/report_data_source_test.go
@@ -178,3 +178,54 @@ data "doit_report" "test" {
 }
 `
 }
+
+// TestAccReportDataSource_FolderId verifies that the data source returns the
+// correct folder_id when a report is created inside a folder.
+func TestAccReportDataSource_FolderId(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-report-ds-f")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportDataSourceFolderIdConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.doit_report.test", "folder_id",
+						"doit_folder.ds_test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccReportDataSourceFolderIdConfig(name string) string {
+	return fmt.Sprintf(`
+resource "doit_folder" "ds_test" {
+    name = "%s-folder"
+}
+
+resource "doit_report" "test" {
+    name      = %q
+    folder_id = doit_folder.ds_test.id
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+    }
+}
+
+data "doit_report" "test" {
+    id = doit_report.test.id
+}
+`, name, name)
+}

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -2593,3 +2593,119 @@ resource "doit_report" "drift_test" {
 }
 `, i)
 }
+
+// TestAccReport_FolderId verifies that reports can be created inside a folder,
+// the folder_id is persisted in state, the report can be moved to root, and
+// that re-applying produces no drift.
+func TestAccReport_FolderId(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create report inside a folder
+			{
+				Config: testAccReportInFolder(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_report.folder_test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"doit_report.folder_test", "folder_id",
+						"doit_folder.test", "id"),
+				),
+			},
+			// Step 2: Drift check — re-apply same config, expect no changes
+			{
+				Config: testAccReportInFolder(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Move report to root (folder_id = "root")
+			{
+				Config: testAccReportInRoot(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_report.folder_test",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_report.folder_test",
+						tfjsonpath.New("folder_id"),
+						knownvalue.StringExact("root")),
+				},
+			},
+			// Step 4: Drift check after move
+			{
+				Config: testAccReportInRoot(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportInFolder(i int) string {
+	return fmt.Sprintf(`
+resource "doit_folder" "test" {
+    name = "tf-acc-report-folder-%d"
+}
+
+resource "doit_report" "folder_test" {
+    name      = "test-in-folder-%d"
+    folder_id = doit_folder.test.id
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+    }
+}
+`, i, i)
+}
+
+func testAccReportInRoot(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "folder_test" {
+    name      = "test-in-folder-%d"
+    folder_id = "root"
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+    }
+}
+`, i)
+}

--- a/internal/provider/resource_allocation/allocation_resource_gen.go
+++ b/internal/provider/resource_allocation/allocation_resource_gen.go
@@ -41,6 +41,12 @@ func AllocationResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Allocation description.",
 				MarkdownDescription: "Allocation description.",
 			},
+			"folder_id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
+				MarkdownDescription: "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Allocation ID.",
@@ -320,6 +326,7 @@ type AllocationModel struct {
 	AnomalyDetection types.Bool   `tfsdk:"anomaly_detection"`
 	CreateTime       types.Int64  `tfsdk:"create_time"`
 	Description      types.String `tfsdk:"description"`
+	FolderId         types.String `tfsdk:"folder_id"`
 	Id               types.String `tfsdk:"id"`
 	Name             types.String `tfsdk:"name"`
 	Rule             RuleValue    `tfsdk:"rule"`

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -895,6 +895,12 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Report description.",
 				MarkdownDescription: "Report description.",
 			},
+			"folder_id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder).",
+				MarkdownDescription: "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder).",
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Report ID.",
@@ -927,6 +933,7 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 type ReportModel struct {
 	Config      ConfigValue  `tfsdk:"config"`
 	Description types.String `tfsdk:"description"`
+	FolderId    types.String `tfsdk:"folder_id"`
 	Id          types.String `tfsdk:"id"`
 	Labels      types.List   `tfsdk:"labels"`
 	Name        types.String `tfsdk:"name"`


### PR DESCRIPTION
## What

Add `folder_id` attribute to `doit_report` and `doit_allocation` resources and their data sources, enabling users to organize Cloud Analytics resources inside folders.

## Why

The upstream API spec added `folderId` support to reports and allocations. This brings the Terraform provider to functional parity.

## Changes

### Resources
- **`report.go`**: overlay, populateState, create/update request mapping for `folder_id`
- **`allocation.go`**: overlay, mapAllocationToModel, fillAllocationCommon for `folder_id`

### Data Sources
- **`report_data_source.go`**: populateState + unknown early return guard
- **`allocation_data_source.go`**: mapAllocationToModel + unknown early return guard
- **`allocations_data_source.go`**: NewAllocationsValue mapping

### Code Generation
- Updated OpenAPI spec with `folderId` on report/allocation schemas
- Regenerated `*_gen.go` files via `make generate`

### Examples & Docs
- Added folder_id examples for both report and allocation resources
- Regenerated docs via `make docs`

## Testing

All 4 new acceptance tests pass against the live API:

| Test | Duration | Result |
|------|----------|--------|
| `TestAccReport_FolderId` | 22.0s | ✅ PASS |
| `TestAccAllocation_FolderId` | 25.4s | ✅ PASS |
| `TestAccReportDataSource_FolderId` | 10.1s | ✅ PASS |
| `TestAccAllocationDataSource_FolderId` | 11.0s | ✅ PASS |

Each resource test covers: create-in-folder → drift check → move-to-root → drift check.
Each data source test verifies `folder_id` propagation from resource to data source.

## Validation
- `go build ./...` ✅
- `go vet ./...` ✅
- `make validate-examples` ✅ (57/57)
- `make docs` ✅

> [!NOTE]
> This PR was developed with AI assistance (Gemini/Antigravity).