### PR TITLE
feat: add total_over_total and count options to aggregation enum

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -1684,7 +1684,7 @@
 															"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 														}
 													],
-													"schema_definition": "stringvalidator.OneOf(\n\"total\",\n\"percent_total\",\n\"percent_col\",\n\"percent_row\",\n)"
+													"schema_definition": "stringvalidator.OneOf(\n\"total\",\n\"percent_total\",\n\"percent_col\",\n\"percent_row\",\n\"total_over_total\",\n\"count\",\n)"
 												}
 											}
 										]

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -5415,6 +5415,8 @@ components:
             - percent_total
             - percent_col
             - percent_row
+            - total_over_total
+            - count
         advancedAnalysis:
           $ref: "#/components/schemas/AdvancedAnalysis"
         timeInterval:

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -5990,6 +5990,8 @@ components:
             - percent_total
             - percent_col
             - percent_row
+            - total_over_total
+            - count
         advancedAnalysis:
           $ref: "#/components/schemas/AdvancedAnalysis"
         timeInterval:

--- a/docs/data-sources/report_query.md
+++ b/docs/data-sources/report_query.md
@@ -103,7 +103,7 @@ Optional:
 
 - `advanced_analysis` (Attributes) Advanced analysis options. Each can be set independently. (see [below for nested schema](#nestedatt--config--advanced_analysis))
 - `aggregation` (String) How to aggregate data values in the report.
-Possible values: `total`, `percent_total`, `percent_col`, `percent_row`
+Possible values: `total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`
 - `currency` (String) Currency code for monetary values.
 Possible values: `USD`, `ILS`, `EUR`, `AUD`, `CAD`, `GBP`, `DKK`, `NOK`, `SEK`, `BRL`, `SGD`, `MXN`, `CHF`, `MYR`, `TWD`, `EGP`, `ZAR`, `JPY`, `IDR`, `AED`, `THB`, `COP`
 - `custom_time_range` (Attributes) Required when the time range is set to "custom". (see [below for nested schema](#nestedatt--config--custom_time_range))

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -335,7 +335,7 @@ Optional:
 
 - `advanced_analysis` (Attributes) Advanced analysis options. Each can be set independently. (see [below for nested schema](#nestedatt--config--advanced_analysis))
 - `aggregation` (String) How to aggregate data values in the report.
-Possible values: `total`, `percent_total`, `percent_col`, `percent_row`
+Possible values: `total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`
 - `currency` (String) Currency code for monetary values.
 Possible values: `USD`, `ILS`, `EUR`, `AUD`, `CAD`, `GBP`, `DKK`, `NOK`, `SEK`, `BRL`, `SGD`, `MXN`, `CHF`, `MYR`, `TWD`, `EGP`, `ZAR`, `JPY`, `IDR`, `AED`, `THB`, `COP`
 - `custom_time_range` (Attributes) Required when the time range is set to "custom". (see [below for nested schema](#nestedatt--config--custom_time_range))

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -1111,15 +1111,19 @@ func (e DimensionsTypes) Valid() bool {
 
 // Defines values for ExternalConfigAggregation.
 const (
-	PercentCol   ExternalConfigAggregation = "percent_col"
-	PercentRow   ExternalConfigAggregation = "percent_row"
-	PercentTotal ExternalConfigAggregation = "percent_total"
-	Total        ExternalConfigAggregation = "total"
+	Count          ExternalConfigAggregation = "count"
+	PercentCol     ExternalConfigAggregation = "percent_col"
+	PercentRow     ExternalConfigAggregation = "percent_row"
+	PercentTotal   ExternalConfigAggregation = "percent_total"
+	Total          ExternalConfigAggregation = "total"
+	TotalOverTotal ExternalConfigAggregation = "total_over_total"
 )
 
 // Valid indicates whether the value is a known member of the ExternalConfigAggregation enum.
 func (e ExternalConfigAggregation) Valid() bool {
 	switch e {
+	case Count:
+		return true
 	case PercentCol:
 		return true
 	case PercentRow:
@@ -1127,6 +1131,8 @@ func (e ExternalConfigAggregation) Valid() bool {
 	case PercentTotal:
 		return true
 	case Total:
+		return true
+	case TotalOverTotal:
 		return true
 	default:
 		return false

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -57,14 +57,16 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 					"aggregation": schema.StringAttribute{
 						Optional:            true,
 						Computed:            true,
-						Description:         "How to aggregate data values in the report.\nPossible values: `total`, `percent_total`, `percent_col`, `percent_row`",
-						MarkdownDescription: "How to aggregate data values in the report.\nPossible values: `total`, `percent_total`, `percent_col`, `percent_row`",
+						Description:         "How to aggregate data values in the report.\nPossible values: `total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`",
+						MarkdownDescription: "How to aggregate data values in the report.\nPossible values: `total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`",
 						Validators: []validator.String{
 							stringvalidator.OneOf(
 								"total",
 								"percent_total",
 								"percent_col",
 								"percent_row",
+								"total_over_total",
+								"count",
 							),
 						},
 					},


### PR DESCRIPTION
This pull request adds two new aggregation types, `total_over_total` and `count`, to the report configuration options across the provider's codebase, documentation, and OpenAPI specifications. These changes ensure that the new aggregation types are validated, documented, and available for use in both resources and data sources.

**Aggregation Options Expansion:**

* Added `total_over_total` and `count` as valid values for the `aggregation` field in report resources and data sources, updating schema definitions, validators, and enum checks in `models_gen.go` and `report_resource_gen.go`. [[1]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR1114-R1126) [[2]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR1135-R1136) [[3]](diffhunk://#diff-0da397a809874eeb4351f431e942f7d642691230722f195ff48ba3f6cf052e4aL60-R69) [[4]](diffhunk://#diff-f4209c2bc6d18870efd503069107472554df80d982a5c4e1a00bc8b4c0ef9e55L1687-R1687)

**Documentation Updates:**

* Updated documentation for `report.md` and `report_query.md` to include the new aggregation options in the list of possible values. [[1]](diffhunk://#diff-f068c4ed2ab8f80d70edeb55e407596abb8d77ccce1cd4dc4f05ad639c1cadb3L338-R338) [[2]](diffhunk://#diff-92686676cd4cbee04a6ec3b984d883512db78842ce2f16cbc30a04822e1844f7L106-R106)

**OpenAPI Specification Updates:**

* Extended the OpenAPI specifications (`openapi_spec_full.yml` and `openapi_spec_processed.yml`) to list `total_over_total` and `count` as valid aggregation values. [[1]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bR5418-R5419) [[2]](diffhunk://#diff-389d555bd5509e14e730dff6a1354d7cb61a2b9bf99e1a547a547513b508385cR5993-R5994)