### PR TITLE
chore: sync spec for cloud diagrams API updates

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -3415,6 +3415,7 @@ paths:
           in: query
           required: true
           description: Start of the period.
+          example: "2026-04-01T00:00:00Z"
           schema:
             type: string
             format: date-time
@@ -3422,6 +3423,7 @@ paths:
           in: query
           required: true
           description: End of the period.
+          example: "2026-04-28T00:00:00Z"
           schema:
             type: string
             format: date-time
@@ -3446,14 +3448,14 @@ paths:
         - Cloud Diagrams
       summary: Get diagram components
       description: |-
-        Returns diagram and statussheet data. When the request body is empty, returns all diagrams
-        the caller has access to (scheme map only). When the body is populated, returns full diagram
-        data including statussheet components projected to key display and cloud fields.
+        Returns diagram and layer data. When the request body is empty, returns all diagrams
+        the caller has access to. When the body is populated, returns full diagram data including
+        layer components projected to key display and cloud fields.
       operationId: getCloudDiagramComponents
       parameters:
         - name: components
           in: query
-          description: Include components in the statussheet response.
+          description: Include components in the layer response.
           schema:
             type: boolean
         - name: external
@@ -3562,8 +3564,8 @@ paths:
         - Cloud Diagrams
       summary: Search diagrams and components
       description: |-
-        Full-text search across statussheets (cloud accounts), components by name, and components by
-        property values. Returns three result categories: scheme (matching statussheets), component
+        Full-text search across diagram layers, components by name, and components
+        by property values. Returns three result categories: diagram (matching layers), component
         (matching components by name), and prop (matching components by property values).
       operationId: searchCloudDiagrams
       requestBody:
@@ -3589,16 +3591,16 @@ paths:
     post:
       tags:
         - Cloud Diagrams
-      summary: Get statussheet components
+      summary: Get layer components
       description: |-
-        Returns the components of the specified statussheet, optionally filtered to specific
+        Returns the components of the specified diagram layer, optionally filtered to specific
         component IDs. Omit the request body (or send an empty object) to retrieve all components.
       operationId: getStatussheetComponents
       parameters:
         - name: id
           in: path
           required: true
-          description: Statussheet ID.
+          description: Layer ID.
           schema:
             type: string
         - name: p
@@ -3614,7 +3616,7 @@ paths:
               $ref: "#/components/schemas/CloudDiagramStatussheetGetRequest"
       responses:
         "200":
-          description: OK - Statussheet components returned.
+          description: OK - Layer components returned.
           content:
             application/json:
               schema:
@@ -3633,14 +3635,14 @@ paths:
         - Cloud Diagrams
       summary: Export diagram as JSON
       description: |-
-        Exports the full content of a statussheet (diagram layer) as a structured JSON document,
+        Exports the full content of a diagram layer as a structured JSON document,
         including all components and export metadata.
       operationId: exportCloudDiagramJson
       parameters:
         - name: id
           in: path
           required: true
-          description: Statussheet ID.
+          description: Layer ID.
           schema:
             type: string
       responses:
@@ -7021,7 +7023,7 @@ components:
           description: ID of the diagram.
         ss_id:
           type: string
-          description: ID of the statussheet the diagram belongs to.
+          description: ID of the layer the diagram belongs to.
         name:
           type: string
           description: Name of the diagram.
@@ -7130,10 +7132,10 @@ components:
           description: Parent diagram ID.
         ss_id:
           type: string
-          description: Parent statussheet ID.
+          description: Parent layer ID.
     CloudDiagramComponentBase:
       type: object
-      description: Common fields shared by all statussheet component types.
+      description: Common fields shared by all layer component types.
       properties:
         name:
           type: string
@@ -7329,7 +7331,7 @@ components:
               description: Link connection type.
             owner_ss_id:
               type: string
-              description: Owner statussheet ID for cross-diagram links.
+              description: Owner layer ID for cross-diagram links.
             issues:
               type: array
               description: Issues associated with this link.
@@ -7426,7 +7428,7 @@ components:
           description: Note font size.
     CloudDiagramStatussheetComponents:
       type: object
-      description: Component collections of a statussheet, keyed by component ID.
+      description: Component collections of a diagram layer, keyed by component ID.
       properties:
         node:
           type: object
@@ -7469,12 +7471,12 @@ components:
         - _id
         - updatedAt
       description: |-
-        Projected statussheet document returned inside each statussheet entry.
-        Fields reflect the SS_CLIENT_OPTIONS projection: _id, import, updatedAt, linksVersion.
+        Projected layer metadata returned inside each layer entry.
+        Contains import state, last updated timestamp, and links version.
       properties:
         _id:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         import:
           $ref: "#/components/schemas/CloudDiagramImportState"
         updatedAt:
@@ -7490,7 +7492,7 @@ components:
         - type: object
           required:
             - statussheet
-          description: A statussheet entry with projected metadata and component collections.
+          description: A layer entry with projected metadata and component collections.
           properties:
             statussheet:
               $ref: "#/components/schemas/CloudDiagramStatussheetMeta"
@@ -7503,14 +7505,14 @@ components:
         - alarms_count
         - empty
         - color
-      description: Summary of a cloud account (statussheet) connected to a diagram.
+      description: Summary of a cloud account (layer) connected to a diagram.
       properties:
         ssid:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         name:
           type: string
-          description: Statussheet name.
+          description: Layer name.
         account_name:
           type: string
           description: Connected cloud account name.
@@ -7519,10 +7521,10 @@ components:
           description: Number of active alarms.
         empty:
           type: boolean
-          description: True when the statussheet contains no components.
+          description: True when the layer contains no components.
         color:
           type: string
-          description: Statussheet color.
+          description: Layer color.
     CloudDiagramSchemeResult:
       type: object
       required:
@@ -7551,7 +7553,7 @@ components:
           description: Diagram type.
         statussheet:
           type: array
-          description: Connected cloud accounts (statussheets).
+          description: Connected cloud accounts (layers).
           items:
             $ref: "#/components/schemas/CloudDiagramSchemeStatussheetInfo"
     CloudDiagramsGetRequest:
@@ -7567,11 +7569,11 @@ components:
             type: string
         statussheet:
           type: array
-          description: IDs of statussheets to load.
+          description: IDs of layers to load.
           items:
             type: string
         template:
-          description: Template type or array of template statussheet IDs to include.
+          description: Template type or array of template layer IDs to include.
           oneOf:
             - type: string
               enum:
@@ -7583,9 +7585,9 @@ components:
     CloudDiagramsGetResponse:
       type: object
       description: |-
-        Diagram and statussheet data.
-        When called with an empty body, only the scheme map is populated.
-        When called with a populated body, both scheme and statussheet maps are returned
+        Diagram and layer data.
+        When called with an empty body, only the diagram map is populated.
+        When called with a populated body, both diagram and layer maps are returned
         with components projected to key display and cloud fields by default.
       properties:
         scheme:
@@ -7596,24 +7598,24 @@ components:
         statussheet:
           type: object
           description: |-
-            Map of statussheet ID to statussheet metadata and component collections.
+            Map of layer ID to layer metadata and component collections.
             Components are projected to key display and cloud fields by default.
           additionalProperties:
             $ref: "#/components/schemas/CloudDiagramStatussheetData"
         template:
           type: object
-          description: Map of template statussheet ID to template data.
+          description: Map of template layer ID to template data.
           additionalProperties: true
     CloudDiagramSchemeSearchItem:
       type: object
       required:
         - _id
         - type
-      description: A statussheet (cloud account) matching the search query.
+      description: A diagram layer (cloud account) matching the search query.
       properties:
         _id:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         account_name:
           type: string
           description: Cloud account name.
@@ -7622,7 +7624,7 @@ components:
           description: Parent diagram ID.
         ss_id:
           type: string
-          description: Statussheet ID (same as _id).
+          description: Layer ID (same as _id).
         scheme:
           type: string
           description: Parent diagram name.
@@ -7631,7 +7633,7 @@ components:
           description: Import/sync status.
         name:
           type: string
-          description: Statussheet name.
+          description: Layer name.
         type:
           type: string
           enum:
@@ -7661,7 +7663,7 @@ components:
           description: Parent diagram ID.
         ss_id:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         name:
           type: string
           description: Component name.
@@ -7709,7 +7711,7 @@ components:
           description: Search query string.
         ss_id:
           type: string
-          description: Limit search to components within this statussheet.
+          description: Limit search to components within this layer.
         from:
           type: integer
           minimum: 0
@@ -7724,7 +7726,7 @@ components:
       properties:
         scheme:
           type: array
-          description: statussheets (cloud accounts) matching the query.
+          description: Diagram layers (cloud accounts) matching the query.
           items:
             $ref: "#/components/schemas/CloudDiagramSchemeSearchItem"
         component:
@@ -7740,7 +7742,7 @@ components:
     CloudDiagramStatussheetGetRequest:
       type: object
       description: |-
-        Request body for getting statussheet components.
+        Request body for getting layer components.
         Omit or send an empty object to retrieve all components.
       properties:
         node:
@@ -7809,7 +7811,7 @@ components:
       properties:
         statussheet:
           type: object
-          description: Diagram-level metadata (scheme fields, excluding internal IDs).
+          description: Diagram-level metadata (excluding internal IDs).
           additionalProperties: true
         metadata:
           $ref: "#/components/schemas/CloudDiagramExportJsonMetadata"

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -2833,6 +2833,7 @@ paths:
           in: query
           required: true
           description: Start of the period.
+          example: "2026-04-01T00:00:00Z"
           schema:
             type: string
             format: date-time
@@ -2840,6 +2841,7 @@ paths:
           in: query
           required: true
           description: End of the period.
+          example: "2026-04-28T00:00:00Z"
           schema:
             type: string
             format: date-time
@@ -2864,14 +2866,14 @@ paths:
         - Cloud Diagrams
       summary: Get diagram components
       description: |-
-        Returns diagram and statussheet data. When the request body is empty, returns all diagrams
-        the caller has access to (scheme map only). When the body is populated, returns full diagram
-        data including statussheet components projected to key display and cloud fields.
+        Returns diagram and layer data. When the request body is empty, returns all diagrams
+        the caller has access to. When the body is populated, returns full diagram data including
+        layer components projected to key display and cloud fields.
       operationId: getCloudDiagramComponents
       parameters:
         - name: components
           in: query
-          description: Include components in the statussheet response.
+          description: Include components in the layer response.
           schema:
             type: boolean
         - name: external
@@ -2980,8 +2982,8 @@ paths:
         - Cloud Diagrams
       summary: Search diagrams and components
       description: |-
-        Full-text search across statussheets (cloud accounts), components by name, and components by
-        property values. Returns three result categories: scheme (matching statussheets), component
+        Full-text search across diagram layers, components by name, and components
+        by property values. Returns three result categories: diagram (matching layers), component
         (matching components by name), and prop (matching components by property values).
       operationId: searchCloudDiagrams
       requestBody:
@@ -3007,16 +3009,16 @@ paths:
     post:
       tags:
         - Cloud Diagrams
-      summary: Get statussheet components
+      summary: Get layer components
       description: |-
-        Returns the components of the specified statussheet, optionally filtered to specific
+        Returns the components of the specified diagram layer, optionally filtered to specific
         component IDs. Omit the request body (or send an empty object) to retrieve all components.
       operationId: getStatussheetComponents
       parameters:
         - name: id
           in: path
           required: true
-          description: Statussheet ID.
+          description: Layer ID.
           schema:
             type: string
         - name: p
@@ -3032,7 +3034,7 @@ paths:
               $ref: "#/components/schemas/CloudDiagramStatussheetGetRequest"
       responses:
         "200":
-          description: OK - Statussheet components returned.
+          description: OK - Layer components returned.
           content:
             application/json:
               schema:
@@ -3051,14 +3053,14 @@ paths:
         - Cloud Diagrams
       summary: Export diagram as JSON
       description: |-
-        Exports the full content of a statussheet (diagram layer) as a structured JSON document,
+        Exports the full content of a diagram layer as a structured JSON document,
         including all components and export metadata.
       operationId: exportCloudDiagramJson
       parameters:
         - name: id
           in: path
           required: true
-          description: Statussheet ID.
+          description: Layer ID.
           schema:
             type: string
       responses:
@@ -4444,7 +4446,7 @@ components:
           description: Component type.
     CloudDiagramComponentBase:
       type: object
-      description: Common fields shared by all statussheet component types.
+      description: Common fields shared by all layer component types.
       properties:
         name:
           type: string
@@ -4498,7 +4500,7 @@ components:
           description: Parent diagram ID.
         ss_id:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         name:
           type: string
           description: Component name.
@@ -4595,7 +4597,7 @@ components:
       properties:
         statussheet:
           type: object
-          description: Diagram-level metadata (scheme fields, excluding internal IDs).
+          description: Diagram-level metadata (excluding internal IDs).
           additionalProperties: true
         metadata:
           $ref: "#/components/schemas/CloudDiagramExportJsonMetadata"
@@ -4760,7 +4762,7 @@ components:
           description: Parent diagram ID.
         ss_id:
           type: string
-          description: Parent statussheet ID.
+          description: Parent layer ID.
     CloudDiagramIssue:
       type: object
       description: Issue annotation linked to a component.
@@ -4807,7 +4809,7 @@ components:
               description: Link connection type.
             owner_ss_id:
               type: string
-              description: Owner statussheet ID for cross-diagram links.
+              description: Owner layer ID for cross-diagram links.
             issues:
               type: array
               description: Issues associated with this link.
@@ -4892,7 +4894,7 @@ components:
           description: Diagram type.
         statussheet:
           type: array
-          description: Connected cloud accounts (statussheets).
+          description: Connected cloud accounts (layers).
           items:
             $ref: "#/components/schemas/CloudDiagramSchemeStatussheetInfo"
     CloudDiagramSchemeSearchItem:
@@ -4900,11 +4902,11 @@ components:
       required:
         - _id
         - type
-      description: A statussheet (cloud account) matching the search query.
+      description: A diagram layer (cloud account) matching the search query.
       properties:
         _id:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         account_name:
           type: string
           description: Cloud account name.
@@ -4913,7 +4915,7 @@ components:
           description: Parent diagram ID.
         ss_id:
           type: string
-          description: Statussheet ID (same as _id).
+          description: Layer ID (same as _id).
         scheme:
           type: string
           description: Parent diagram name.
@@ -4922,7 +4924,7 @@ components:
           description: Import/sync status.
         name:
           type: string
-          description: Statussheet name.
+          description: Layer name.
         type:
           type: string
           enum:
@@ -4937,14 +4939,14 @@ components:
         - alarms_count
         - empty
         - color
-      description: Summary of a cloud account (statussheet) connected to a diagram.
+      description: Summary of a cloud account (layer) connected to a diagram.
       properties:
         ssid:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         name:
           type: string
-          description: Statussheet name.
+          description: Layer name.
         account_name:
           type: string
           description: Connected cloud account name.
@@ -4953,10 +4955,10 @@ components:
           description: Number of active alarms.
         empty:
           type: boolean
-          description: True when the statussheet contains no components.
+          description: True when the layer contains no components.
         color:
           type: string
-          description: Statussheet color.
+          description: Layer color.
     CloudDiagramStats:
       type: object
       description: Diagram with activity stats for a given time period.
@@ -4966,7 +4968,7 @@ components:
           description: ID of the diagram.
         ss_id:
           type: string
-          description: ID of the statussheet the diagram belongs to.
+          description: ID of the layer the diagram belongs to.
         name:
           type: string
           description: Name of the diagram.
@@ -5013,7 +5015,7 @@ components:
           description: Number of occurrences of this change type.
     CloudDiagramStatussheetComponents:
       type: object
-      description: Component collections of a statussheet, keyed by component ID.
+      description: Component collections of a diagram layer, keyed by component ID.
       properties:
         node:
           type: object
@@ -5056,14 +5058,14 @@ components:
         - type: object
           required:
             - statussheet
-          description: A statussheet entry with projected metadata and component collections.
+          description: A layer entry with projected metadata and component collections.
           properties:
             statussheet:
               $ref: "#/components/schemas/CloudDiagramStatussheetMeta"
     CloudDiagramStatussheetGetRequest:
       type: object
       description: |-
-        Request body for getting statussheet components.
+        Request body for getting layer components.
         Omit or send an empty object to retrieve all components.
       properties:
         node:
@@ -5107,12 +5109,12 @@ components:
         - _id
         - updatedAt
       description: |-
-        Projected statussheet document returned inside each statussheet entry.
-        Fields reflect the SS_CLIENT_OPTIONS projection: _id, import, updatedAt, linksVersion.
+        Projected layer metadata returned inside each layer entry.
+        Contains import state, last updated timestamp, and links version.
       properties:
         _id:
           type: string
-          description: Statussheet ID.
+          description: Layer ID.
         import:
           $ref: "#/components/schemas/CloudDiagramImportState"
         updatedAt:
@@ -5135,11 +5137,11 @@ components:
             type: string
         statussheet:
           type: array
-          description: IDs of statussheets to load.
+          description: IDs of layers to load.
           items:
             type: string
         template:
-          description: Template type or array of template statussheet IDs to include.
+          description: Template type or array of template layer IDs to include.
           oneOf:
             - type: string
               enum:
@@ -5151,9 +5153,9 @@ components:
     CloudDiagramsGetResponse:
       type: object
       description: |-
-        Diagram and statussheet data.
-        When called with an empty body, only the scheme map is populated.
-        When called with a populated body, both scheme and statussheet maps are returned
+        Diagram and layer data.
+        When called with an empty body, only the diagram map is populated.
+        When called with a populated body, both diagram and layer maps are returned
         with components projected to key display and cloud fields by default.
       properties:
         scheme:
@@ -5164,13 +5166,13 @@ components:
         statussheet:
           type: object
           description: |-
-            Map of statussheet ID to statussheet metadata and component collections.
+            Map of layer ID to layer metadata and component collections.
             Components are projected to key display and cloud fields by default.
           additionalProperties:
             $ref: "#/components/schemas/CloudDiagramStatussheetData"
         template:
           type: object
-          description: Map of template statussheet ID to template data.
+          description: Map of template layer ID to template data.
           additionalProperties: true
     CloudDiagramsSearchRequest:
       type: object
@@ -5183,7 +5185,7 @@ components:
           description: Search query string.
         ss_id:
           type: string
-          description: Limit search to components within this statussheet.
+          description: Limit search to components within this layer.
         from:
           type: integer
           minimum: 0
@@ -5198,7 +5200,7 @@ components:
       properties:
         scheme:
           type: array
-          description: statussheets (cloud accounts) matching the query.
+          description: Diagram layers (cloud accounts) matching the query.
           items:
             $ref: "#/components/schemas/CloudDiagramSchemeSearchItem"
         component:

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3734,7 +3734,7 @@ type CloudDiagramCombinerItem struct {
 // CloudDiagramCombinerItemType Component type.
 type CloudDiagramCombinerItemType string
 
-// CloudDiagramComponentBase Common fields shared by all statussheet component types.
+// CloudDiagramComponentBase Common fields shared by all layer component types.
 type CloudDiagramComponentBase struct {
 	// CldAccount Cloud account ID.
 	CldAccount *string `json:"cld_account,omitempty"`
@@ -3790,7 +3790,7 @@ type CloudDiagramComponentSearchItem struct {
 	// SchemeId Parent diagram ID.
 	SchemeId *string `json:"scheme_id,omitempty"`
 
-	// SsId Statussheet ID.
+	// SsId Layer ID.
 	SsId *string `json:"ss_id,omitempty"`
 
 	// Type Component type.
@@ -3892,7 +3892,7 @@ type CloudDiagramExportJsonResponse struct {
 	// Notes Exported notes.
 	Notes *[]CloudDiagramNote `json:"notes,omitempty"`
 
-	// Statussheet Diagram-level metadata (scheme fields, excluding internal IDs).
+	// Statussheet Diagram-level metadata (excluding internal IDs).
 	Statussheet *map[string]interface{} `json:"statussheet,omitempty"`
 }
 
@@ -3991,7 +3991,7 @@ type CloudDiagramInfraNodeRef struct {
 	// SchemeId Parent diagram ID.
 	SchemeId string `json:"scheme_id"`
 
-	// SsId Parent statussheet ID.
+	// SsId Parent layer ID.
 	SsId string `json:"ss_id"`
 }
 
@@ -4036,7 +4036,7 @@ type CloudDiagramLink struct {
 	// Name Component name.
 	Name *string `json:"name,omitempty"`
 
-	// OwnerSsId Owner statussheet ID for cross-diagram links.
+	// OwnerSsId Owner layer ID for cross-diagram links.
 	OwnerSsId *string `json:"owner_ss_id,omitempty"`
 
 	// Props Custom component properties (key-value pairs).
@@ -4129,7 +4129,7 @@ type CloudDiagramSchemeResult struct {
 	// Name Diagram name.
 	Name string `json:"name"`
 
-	// Statussheet Connected cloud accounts (statussheets).
+	// Statussheet Connected cloud accounts (layers).
 	Statussheet []CloudDiagramSchemeStatussheetInfo `json:"statussheet"`
 
 	// Type Diagram type.
@@ -4139,15 +4139,15 @@ type CloudDiagramSchemeResult struct {
 // CloudDiagramSchemeResultType Diagram type.
 type CloudDiagramSchemeResultType string
 
-// CloudDiagramSchemeSearchItem A statussheet (cloud account) matching the search query.
+// CloudDiagramSchemeSearchItem A diagram layer (cloud account) matching the search query.
 type CloudDiagramSchemeSearchItem struct {
-	// UnderscoreId Statussheet ID.
+	// UnderscoreId Layer ID.
 	UnderscoreId string `json:"_id"`
 
 	// AccountName Cloud account name.
 	AccountName *string `json:"account_name,omitempty"`
 
-	// Name Statussheet name.
+	// Name Layer name.
 	Name *string `json:"name,omitempty"`
 
 	// Scheme Parent diagram name.
@@ -4156,7 +4156,7 @@ type CloudDiagramSchemeSearchItem struct {
 	// SchemeId Parent diagram ID.
 	SchemeId *string `json:"scheme_id,omitempty"`
 
-	// SsId Statussheet ID (same as _id).
+	// SsId Layer ID (same as _id).
 	SsId *string `json:"ss_id,omitempty"`
 
 	// Status Import/sync status.
@@ -4169,7 +4169,7 @@ type CloudDiagramSchemeSearchItem struct {
 // CloudDiagramSchemeSearchItemType Component type — always "statussheet" for this category.
 type CloudDiagramSchemeSearchItemType string
 
-// CloudDiagramSchemeStatussheetInfo Summary of a cloud account (statussheet) connected to a diagram.
+// CloudDiagramSchemeStatussheetInfo Summary of a cloud account (layer) connected to a diagram.
 type CloudDiagramSchemeStatussheetInfo struct {
 	// AccountName Connected cloud account name.
 	AccountName string `json:"account_name"`
@@ -4177,16 +4177,16 @@ type CloudDiagramSchemeStatussheetInfo struct {
 	// AlarmsCount Number of active alarms.
 	AlarmsCount int `json:"alarms_count"`
 
-	// Color Statussheet color.
+	// Color Layer color.
 	Color string `json:"color"`
 
-	// Empty True when the statussheet contains no components.
+	// Empty True when the layer contains no components.
 	Empty bool `json:"empty"`
 
-	// Name Statussheet name.
+	// Name Layer name.
 	Name string `json:"name"`
 
-	// Ssid Statussheet ID.
+	// Ssid Layer ID.
 	Ssid string `json:"ssid"`
 }
 
@@ -4213,7 +4213,7 @@ type CloudDiagramStats struct {
 	// Name Name of the diagram.
 	Name *string `json:"name,omitempty"`
 
-	// SsId ID of the statussheet the diagram belongs to.
+	// SsId ID of the layer the diagram belongs to.
 	SsId *string `json:"ss_id,omitempty"`
 
 	// Type Type of the diagram.
@@ -4238,7 +4238,7 @@ type CloudDiagramStatsChange struct {
 // CloudDiagramStatsChangeType Type of the change.
 type CloudDiagramStatsChangeType string
 
-// CloudDiagramStatussheetComponents Component collections of a statussheet, keyed by component ID.
+// CloudDiagramStatussheetComponents Component collections of a diagram layer, keyed by component ID.
 type CloudDiagramStatussheetComponents struct {
 	// Attachment Map of attachment ID to attachment component.
 	Attachment *map[string]CloudDiagramAttachment `json:"attachment,omitempty"`
@@ -4285,12 +4285,12 @@ type CloudDiagramStatussheetData struct {
 	// Note Map of note ID to note component.
 	Note *map[string]CloudDiagramNote `json:"note,omitempty"`
 
-	// Statussheet Projected statussheet document returned inside each statussheet entry.
-	// Fields reflect the SS_CLIENT_OPTIONS projection: _id, import, updatedAt, linksVersion.
+	// Statussheet Projected layer metadata returned inside each layer entry.
+	// Contains import state, last updated timestamp, and links version.
 	Statussheet CloudDiagramStatussheetMeta `json:"statussheet"`
 }
 
-// CloudDiagramStatussheetGetRequest Request body for getting statussheet components.
+// CloudDiagramStatussheetGetRequest Request body for getting layer components.
 // Omit or send an empty object to retrieve all components.
 type CloudDiagramStatussheetGetRequest struct {
 	// Attachment Attachment IDs to fetch.
@@ -4315,10 +4315,10 @@ type CloudDiagramStatussheetGetRequest struct {
 	Note *[]string `json:"note,omitempty"`
 }
 
-// CloudDiagramStatussheetMeta Projected statussheet document returned inside each statussheet entry.
-// Fields reflect the SS_CLIENT_OPTIONS projection: _id, import, updatedAt, linksVersion.
+// CloudDiagramStatussheetMeta Projected layer metadata returned inside each layer entry.
+// Contains import state, last updated timestamp, and links version.
 type CloudDiagramStatussheetMeta struct {
-	// UnderscoreId Statussheet ID.
+	// UnderscoreId Layer ID.
 	UnderscoreId string `json:"_id"`
 
 	// Import Current import/sync state for a cloud-connected diagram.
@@ -4337,10 +4337,10 @@ type CloudDiagramsGetRequest struct {
 	// Scheme IDs of diagrams to load.
 	Scheme *[]string `json:"scheme,omitempty"`
 
-	// Statussheet IDs of statussheets to load.
+	// Statussheet IDs of layers to load.
 	Statussheet *[]string `json:"statussheet,omitempty"`
 
-	// Template Template type or array of template statussheet IDs to include.
+	// Template Template type or array of template layer IDs to include.
 	Template *CloudDiagramsGetRequest_Template `json:"template,omitempty"`
 }
 
@@ -4350,24 +4350,24 @@ type CloudDiagramsGetRequestTemplate0 string
 // CloudDiagramsGetRequestTemplate1 defines model for .
 type CloudDiagramsGetRequestTemplate1 = []string
 
-// CloudDiagramsGetRequest_Template Template type or array of template statussheet IDs to include.
+// CloudDiagramsGetRequest_Template Template type or array of template layer IDs to include.
 type CloudDiagramsGetRequest_Template struct {
 	union json.RawMessage
 }
 
-// CloudDiagramsGetResponse Diagram and statussheet data.
-// When called with an empty body, only the scheme map is populated.
-// When called with a populated body, both scheme and statussheet maps are returned
+// CloudDiagramsGetResponse Diagram and layer data.
+// When called with an empty body, only the diagram map is populated.
+// When called with a populated body, both diagram and layer maps are returned
 // with components projected to key display and cloud fields by default.
 type CloudDiagramsGetResponse struct {
 	// Scheme Map of diagram ID to diagram with its connected cloud accounts.
 	Scheme *map[string]CloudDiagramSchemeResult `json:"scheme,omitempty"`
 
-	// Statussheet Map of statussheet ID to statussheet metadata and component collections.
+	// Statussheet Map of layer ID to layer metadata and component collections.
 	// Components are projected to key display and cloud fields by default.
 	Statussheet *map[string]CloudDiagramStatussheetData `json:"statussheet,omitempty"`
 
-	// Template Map of template statussheet ID to template data.
+	// Template Map of template layer ID to template data.
 	Template *map[string]interface{} `json:"template,omitempty"`
 }
 
@@ -4382,7 +4382,7 @@ type CloudDiagramsSearchRequest struct {
 	// Size Maximum number of results per category (default 20).
 	Size *int `json:"size,omitempty"`
 
-	// SsId Limit search to components within this statussheet.
+	// SsId Limit search to components within this layer.
 	SsId *string `json:"ss_id,omitempty"`
 }
 
@@ -4394,7 +4394,7 @@ type CloudDiagramsSearchResponse struct {
 	// Prop Components matching the query by property values.
 	Prop *[]CloudDiagramComponentSearchItem `json:"prop,omitempty"`
 
-	// Scheme statussheets (cloud accounts) matching the query.
+	// Scheme Diagram layers (cloud accounts) matching the query.
 	Scheme *[]CloudDiagramSchemeSearchItem `json:"scheme,omitempty"`
 }
 
@@ -6831,7 +6831,7 @@ type ListInvoicesParams struct {
 
 // GetCloudDiagramComponentsParams defines parameters for GetCloudDiagramComponents.
 type GetCloudDiagramComponentsParams struct {
-	// Components Include components in the statussheet response.
+	// Components Include components in the layer response.
 	Components *bool `form:"components,omitempty" json:"components,omitempty"`
 
 	// External Include external (cross-diagram) components.


### PR DESCRIPTION
This pull request updates the OpenAPI specification to consistently use the term "layer" instead of "statussheet" when referring to diagram subunits and their components. It also clarifies descriptions throughout the spec and adds example values for date-time query parameters. These changes improve clarity and align the API documentation with current terminology.

**Terminology updates (statussheet → layer):**

* Replaced all references to "statussheet" with "layer" in operation summaries, descriptions, parameter descriptions, and schema property documentation throughout `OpenAPI/openapi_spec_full.yml` and `OpenAPI/openapi_spec_processed.yml`. This affects endpoints, request/response bodies, and schema definitions related to diagram components, search, export, and metadata. [[1]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3449-R3458) [[2]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3565-R3568) [[3]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3592-R3603) [[4]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3617-R3619) [[5]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3636-R3645) [[6]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7024-R7026) [[7]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7133-R7138) [[8]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7332-R7334) [[9]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7429-R7431) [[10]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7472-R7479) [[11]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7493-R7495) [[12]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7506-R7515) [[13]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7522-R7527) [[14]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7554-R7556) [[15]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7570-R7576) [[16]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7586-R7590) [[17]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7599-R7618) [[18]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7625-R7627) [[19]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7634-R7636) [[20]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7664-R7666) [[21]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7712-R7714) [[22]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7727-R7729) [[23]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7743-R7745) [[24]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7812-R7814)

**Description clarifications:**

* Improved and clarified descriptions for endpoints and schema properties to reflect the new terminology and provide clearer explanations of request/response structures. [[1]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3449-R3458) [[2]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL3592-R3603) [[3]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bL7586-R7590)

**Examples for query parameters:**

* Added example values for date-time query parameters (`start`, `end`) in the OpenAPI spec to improve documentation and client generation. [[1]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bR3418-R3426) [[2]](diffhunk://#diff-389d555bd5509e14e730dff6a1354d7cb61a2b9bf99e1a547a547513b508385cR2836-R2844)

These changes are mirrored in both the full and processed OpenAPI spec files to keep them in sync.