### PR TITLE
feat(support_request): add platform_info attribute to data source

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -5115,6 +5115,13 @@
 						}
 					},
 					{
+						"name": "platform_info",
+						"string": {
+							"computed_optional_required": "computed",
+							"description": "The cloud asset identifier the requester selected on the support\nform's asset-selector control — typically the GCP project ID, AWS\naccount ID, Azure subscription ID, or equivalent. Empty string\nwhen the ticket has no asset value (e.g. older tickets or tickets\nopened through paths that bypass the form selector)."
+						}
+					},
+					{
 						"name": "product",
 						"string": {
 							"computed_optional_required": "computed",

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -6849,6 +6849,15 @@ components:
         product:
           type: string
           description: Ticket product.
+        platform_info:
+          type: string
+          description: |-
+            The cloud asset identifier the requester selected on the support
+            form's asset-selector control — typically the GCP project ID, AWS
+            account ID, Azure subscription ID, or equivalent. Empty string
+            when the ticket has no asset value (e.g. older tickets or tickets
+            opened through paths that bypass the form selector).
+          example: cmp-playground
         status:
           type: string
           description: Ticket status.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -7634,6 +7634,15 @@ components:
         product:
           type: string
           description: Ticket product.
+        platform_info:
+          type: string
+          description: |-
+            The cloud asset identifier the requester selected on the support
+            form's asset-selector control — typically the GCP project ID, AWS
+            account ID, Azure subscription ID, or equivalent. Empty string
+            when the ticket has no asset value (e.g. older tickets or tickets
+            opened through paths that bypass the form selector).
+          example: cmp-playground
         status:
           type: string
           description: Ticket status.

--- a/docs/data-sources/support_request.md
+++ b/docs/data-sources/support_request.md
@@ -45,6 +45,11 @@ output "status" {
 - `id` (Number) Ticket ID.
 - `is_public` (Boolean) Whether the ticket is public.
 - `platform` (String) Platform of the ticket.
+- `platform_info` (String) The cloud asset identifier the requester selected on the support
+form's asset-selector control — typically the GCP project ID, AWS
+account ID, Azure subscription ID, or equivalent. Empty string
+when the ticket has no asset value (e.g. older tickets or tickets
+opened through paths that bypass the form selector).
 - `product` (String) Ticket product.
 - `requester` (String) Email address of the ticket requester.
 - `severity` (String) Ticket severity.

--- a/internal/provider/datasource_support_request/support_request_data_source_gen.go
+++ b/internal/provider/datasource_support_request/support_request_data_source_gen.go
@@ -37,6 +37,11 @@ func SupportRequestDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Platform of the ticket.",
 				MarkdownDescription: "Platform of the ticket.",
 			},
+			"platform_info": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The cloud asset identifier the requester selected on the support\nform's asset-selector control — typically the GCP project ID, AWS\naccount ID, Azure subscription ID, or equivalent. Empty string\nwhen the ticket has no asset value (e.g. older tickets or tickets\nopened through paths that bypass the form selector).",
+				MarkdownDescription: "The cloud asset identifier the requester selected on the support\nform's asset-selector control — typically the GCP project ID, AWS\naccount ID, Azure subscription ID, or equivalent. Empty string\nwhen the ticket has no asset value (e.g. older tickets or tickets\nopened through paths that bypass the form selector).",
+			},
 			"product": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Ticket product.",
@@ -84,17 +89,18 @@ func SupportRequestDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type SupportRequestModel struct {
-	CreateTime  types.Int64  `tfsdk:"create_time"`
-	Description types.String `tfsdk:"description"`
-	Id          types.Int64  `tfsdk:"id"`
-	IsPublic    types.Bool   `tfsdk:"is_public"`
-	Platform    types.String `tfsdk:"platform"`
-	Product     types.String `tfsdk:"product"`
-	Requester   types.String `tfsdk:"requester"`
-	Severity    types.String `tfsdk:"severity"`
-	Status      types.String `tfsdk:"status"`
-	Subject     types.String `tfsdk:"subject"`
-	TicketId    types.Int64  `tfsdk:"ticket_id"`
-	UpdateTime  types.Int64  `tfsdk:"update_time"`
-	UrlUi       types.String `tfsdk:"url_ui"`
+	CreateTime   types.Int64  `tfsdk:"create_time"`
+	Description  types.String `tfsdk:"description"`
+	Id           types.Int64  `tfsdk:"id"`
+	IsPublic     types.Bool   `tfsdk:"is_public"`
+	Platform     types.String `tfsdk:"platform"`
+	PlatformInfo types.String `tfsdk:"platform_info"`
+	Product      types.String `tfsdk:"product"`
+	Requester    types.String `tfsdk:"requester"`
+	Severity     types.String `tfsdk:"severity"`
+	Status       types.String `tfsdk:"status"`
+	Subject      types.String `tfsdk:"subject"`
+	TicketId     types.Int64  `tfsdk:"ticket_id"`
+	UpdateTime   types.Int64  `tfsdk:"update_time"`
+	UrlUi        types.String `tfsdk:"url_ui"`
 }

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -6057,6 +6057,13 @@ type TicketDetailExtAPI struct {
 	// Platform Platform of the ticket.
 	Platform *TicketDetailExtAPIPlatform `json:"platform,omitempty"`
 
+	// PlatformInfo The cloud asset identifier the requester selected on the support
+	// form's asset-selector control — typically the GCP project ID, AWS
+	// account ID, Azure subscription ID, or equivalent. Empty string
+	// when the ticket has no asset value (e.g. older tickets or tickets
+	// opened through paths that bypass the form selector).
+	PlatformInfo *string `json:"platform_info,omitempty"`
+
 	// Product Ticket product.
 	Product *string `json:"product,omitempty"`
 

--- a/internal/provider/support_request_data_source.go
+++ b/internal/provider/support_request_data_source.go
@@ -77,6 +77,7 @@ func (ds *supportRequestDataSource) Read(ctx context.Context, req datasource.Rea
 		state.CreateTime = types.Int64Unknown()
 		state.Description = types.StringUnknown()
 		state.IsPublic = types.BoolUnknown()
+		state.PlatformInfo = types.StringUnknown()
 		state.Product = types.StringUnknown()
 		state.Requester = types.StringUnknown()
 		state.Status = types.StringUnknown()
@@ -120,6 +121,7 @@ func (ds *supportRequestDataSource) Read(ctx context.Context, req datasource.Rea
 	state.Subject = types.StringPointerValue(ticket.Subject)
 	state.UpdateTime = types.Int64PointerValue(ticket.UpdateTime)
 	state.UrlUi = types.StringPointerValue(ticket.UrlUI)
+	state.PlatformInfo = types.StringPointerValue(ticket.PlatformInfo)
 
 	// Handle enum types — convert to string
 	if ticket.Platform != nil {


### PR DESCRIPTION
## What

Add the new `platform_info` computed attribute to the `doit_support_request` data source, reflecting the upstream API addition.

`platform_info` contains the cloud asset identifier the requester selected on the support form's asset-selector control — typically the GCP project ID, AWS account ID, or Azure subscription ID. It is null/empty for older tickets that predate this field.

## Changes

- **OpenAPI spec**: Added `platform_info` string property to `TicketDetailExtAPI`
- **Generated code** (`make generate`): Updated models, schema, and codegen output
- **Data source handler**: Wired `platform_info` through both the unknown-value early-return guard and the API response mapping
- **Documentation** (`make docs`): Regenerated

## Validation

- `go build ./...` — clean
- `make testacc-run TEST=TestAccSupportRequestDataSource_Basic` — **PASS** (including drift check with `ExpectEmptyPlan`)

## Notes

- The plural `doit_support_requests` data source uses `TicketListItem` which does **not** include `platform_info` in the API spec — no changes needed there.
- No explicit `TestCheckResourceAttrSet` assertion for `platform_info` since the test fetches arbitrary tickets and older ones return `nil` for this field. The drift check (`ExpectEmptyPlan`) validates consistent handling.