### PR TITLE
chore: sync new ticket tag endpoints from upstream spec

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -3349,6 +3349,95 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+  /support/v1/tickets/{ticketId}/tags:
+    post:
+      tags:
+        - Support Requests
+      summary: Add tags to a support request
+      description: |-
+        Adds one or more tags to an existing support request. The operation is
+        surgical — only the tags listed in the request are added; existing tags
+        on the ticket are preserved. Re-adding a tag that is already present is
+        a successful no-op.
+
+        All submitted tags are normalized (trim + lowercase) before storage. For
+        customers, the system additionally applies a `customer_tag/` namespace
+        prefix to prevent collisions with internal DoiT process tags. The
+        response echoes the actual stored strings so callers can verify the
+        transform.
+      operationId: idOfTicketTagsAdd
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          description: The unique identifier of the support request.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TagsRequest"
+      responses:
+        "200":
+          description: OK - Tags added (or already present).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagsResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+    delete:
+      tags:
+        - Support Requests
+      summary: Remove tags from a support request
+      description: |-
+        Removes one or more tags from an existing support request. The operation
+        is surgical — only the tags listed in the request are removed; tags not
+        listed are preserved. Removing a tag that is not present is a successful
+        no-op.
+
+        For customers, the system applies the same `customer_tag/` namespace
+        mapping as on add, so a customer who added `my_tag` (stored as
+        `customer_tag/my_tag`) can remove it by sending `my_tag`.
+      operationId: idOfTicketTagsRemove
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          description: The unique identifier of the support request.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TagsRequest"
+      responses:
+        "200":
+          description: OK - Tags removed (or already absent).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagsResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /iam/v1/users/invite:
     post:
       tags:
@@ -6927,6 +7016,36 @@ components:
           type: boolean
           description: If true, creates a private internal note. Only honored for DoiT employees; ignored for customers.
           default: false
+    TagsRequest:
+      type: object
+      description: |
+        Request body for adding (POST) or removing (DELETE) tags on a support
+        request. The operation is surgical — only the tags listed are affected;
+        any other tags on the ticket are preserved.
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            type: string
+            minLength: 1
+            maxLength: 80
+          description: List of tags to add or remove. Customer-submitted tags are auto-prefixed with `customer_tag/`.
+    TagsResponse:
+      type: object
+      description: |
+        Response body echoing the tags the operation actually acted on, after
+        server-side transformation (trim + lowercase + customer namespace prefix
+        where applicable).
+      properties:
+        applied_tags:
+          type: array
+          items:
+            type: string
+          description: The tags that were stored on (POST) or removed from (DELETE) the ticket.
     ResourceReference:
       type: object
       description: Reference to another resource, used when listing blockers or usages.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -2767,6 +2767,95 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+  /support/v1/tickets/{ticketId}/tags:
+    post:
+      tags:
+        - Support Requests
+      summary: Add tags to a support request
+      description: |-
+        Adds one or more tags to an existing support request. The operation is
+        surgical — only the tags listed in the request are added; existing tags
+        on the ticket are preserved. Re-adding a tag that is already present is
+        a successful no-op.
+
+        All submitted tags are normalized (trim + lowercase) before storage. For
+        customers, the system additionally applies a `customer_tag/` namespace
+        prefix to prevent collisions with internal DoiT process tags. The
+        response echoes the actual stored strings so callers can verify the
+        transform.
+      operationId: idOfTicketTagsAdd
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          description: The unique identifier of the support request.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TagsRequest"
+      responses:
+        "200":
+          description: OK - Tags added (or already present).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagsResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+    delete:
+      tags:
+        - Support Requests
+      summary: Remove tags from a support request
+      description: |-
+        Removes one or more tags from an existing support request. The operation
+        is surgical — only the tags listed in the request are removed; tags not
+        listed are preserved. Removing a tag that is not present is a successful
+        no-op.
+
+        For customers, the system applies the same `customer_tag/` namespace
+        mapping as on add, so a customer who added `my_tag` (stored as
+        `customer_tag/my_tag`) can remove it by sending `my_tag`.
+      operationId: idOfTicketTagsRemove
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          description: The unique identifier of the support request.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TagsRequest"
+      responses:
+        "200":
+          description: OK - Tags removed (or already absent).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagsResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
   /iam/v1/users/invite:
     post:
       tags:
@@ -7588,6 +7677,36 @@ components:
           type: integer
           description: The start time of the commitment interval, in milliseconds since the epoch.
           format: int64
+    TagsRequest:
+      type: object
+      description: |
+        Request body for adding (POST) or removing (DELETE) tags on a support
+        request. The operation is surgical — only the tags listed are affected;
+        any other tags on the ticket are preserved.
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            type: string
+            minLength: 1
+            maxLength: 80
+          description: List of tags to add or remove. Customer-submitted tags are auto-prefixed with `customer_tag/`.
+    TagsResponse:
+      type: object
+      description: |
+        Response body echoing the tags the operation actually acted on, after
+        server-side transformation (trim + lowercase + customer namespace prefix
+        where applicable).
+      properties:
+        applied_tags:
+          type: array
+          items:
+            type: string
+          description: The tags that were stored on (POST) or removed from (DELETE) the ticket.
     TicketCreateFormExtAPI:
       type: object
       description: Wrapper object for creating support tickets via the external API.

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -6034,6 +6034,22 @@ type SubscriptionPlanCommitmentInterval struct {
 	StartTime *int64 `json:"startTime,omitempty"`
 }
 
+// TagsRequest Request body for adding (POST) or removing (DELETE) tags on a support
+// request. The operation is surgical — only the tags listed are affected;
+// any other tags on the ticket are preserved.
+type TagsRequest struct {
+	// Tags List of tags to add or remove. Customer-submitted tags are auto-prefixed with `customer_tag/`.
+	Tags []string `json:"tags"`
+}
+
+// TagsResponse Response body echoing the tags the operation actually acted on, after
+// server-side transformation (trim + lowercase + customer namespace prefix
+// where applicable).
+type TagsResponse struct {
+	// AppliedTags The tags that were stored on (POST) or removed from (DELETE) the ticket.
+	AppliedTags *[]string `json:"applied_tags,omitempty"`
+}
+
 // TicketCreateFormExtAPI Wrapper object for creating support tickets via the external API.
 type TicketCreateFormExtAPI struct {
 	// Ticket Payload to create a support ticket via API.
@@ -7064,6 +7080,12 @@ type IdOfTicketsPostJSONRequestBody = TicketCreateFormExtAPI
 // IdOfTicketCommentsPostJSONRequestBody defines body for IdOfTicketCommentsPost for application/json ContentType.
 type IdOfTicketCommentsPostJSONRequestBody = CreateCommentRequest
 
+// IdOfTicketTagsRemoveJSONRequestBody defines body for IdOfTicketTagsRemove for application/json ContentType.
+type IdOfTicketTagsRemoveJSONRequestBody = TagsRequest
+
+// IdOfTicketTagsAddJSONRequestBody defines body for IdOfTicketTagsAdd for application/json ContentType.
+type IdOfTicketTagsAddJSONRequestBody = TagsRequest
+
 // AsCloudDiagramsGetRequestTemplate0 returns the union data inside the CloudDiagramsGetRequest_Template as a CloudDiagramsGetRequestTemplate0
 func (t CloudDiagramsGetRequest_Template) AsCloudDiagramsGetRequestTemplate0() (CloudDiagramsGetRequestTemplate0, error) {
 	var body CloudDiagramsGetRequestTemplate0
@@ -7683,6 +7705,16 @@ type ClientInterface interface {
 	IdOfTicketCommentsPostWithBody(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	IdOfTicketCommentsPost(ctx context.Context, ticketId int64, body IdOfTicketCommentsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IdOfTicketTagsRemoveWithBody request with any body
+	IdOfTicketTagsRemoveWithBody(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IdOfTicketTagsRemove(ctx context.Context, ticketId int64, body IdOfTicketTagsRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IdOfTicketTagsAddWithBody request with any body
+	IdOfTicketTagsAddWithBody(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IdOfTicketTagsAdd(ctx context.Context, ticketId int64, body IdOfTicketTagsAddJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ListAlerts(ctx context.Context, params *ListAlertsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -9151,6 +9183,54 @@ func (c *Client) IdOfTicketCommentsPostWithBody(ctx context.Context, ticketId in
 
 func (c *Client) IdOfTicketCommentsPost(ctx context.Context, ticketId int64, body IdOfTicketCommentsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIdOfTicketCommentsPostRequest(c.Server, ticketId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IdOfTicketTagsRemoveWithBody(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIdOfTicketTagsRemoveRequestWithBody(c.Server, ticketId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IdOfTicketTagsRemove(ctx context.Context, ticketId int64, body IdOfTicketTagsRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIdOfTicketTagsRemoveRequest(c.Server, ticketId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IdOfTicketTagsAddWithBody(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIdOfTicketTagsAddRequestWithBody(c.Server, ticketId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IdOfTicketTagsAdd(ctx context.Context, ticketId int64, body IdOfTicketTagsAddJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIdOfTicketTagsAddRequest(c.Server, ticketId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13938,6 +14018,100 @@ func NewIdOfTicketCommentsPostRequestWithBody(server string, ticketId int64, con
 	return req, nil
 }
 
+// NewIdOfTicketTagsRemoveRequest calls the generic IdOfTicketTagsRemove builder with application/json body
+func NewIdOfTicketTagsRemoveRequest(server string, ticketId int64, body IdOfTicketTagsRemoveJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIdOfTicketTagsRemoveRequestWithBody(server, ticketId, "application/json", bodyReader)
+}
+
+// NewIdOfTicketTagsRemoveRequestWithBody generates requests for IdOfTicketTagsRemove with any type of body
+func NewIdOfTicketTagsRemoveRequestWithBody(server string, ticketId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "ticketId", ticketId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/support/v1/tickets/%s/tags", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewIdOfTicketTagsAddRequest calls the generic IdOfTicketTagsAdd builder with application/json body
+func NewIdOfTicketTagsAddRequest(server string, ticketId int64, body IdOfTicketTagsAddJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIdOfTicketTagsAddRequestWithBody(server, ticketId, "application/json", bodyReader)
+}
+
+// NewIdOfTicketTagsAddRequestWithBody generates requests for IdOfTicketTagsAdd with any type of body
+func NewIdOfTicketTagsAddRequestWithBody(server string, ticketId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "ticketId", ticketId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/support/v1/tickets/%s/tags", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -14315,6 +14489,16 @@ type ClientWithResponsesInterface interface {
 	IdOfTicketCommentsPostWithBodyWithResponse(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IdOfTicketCommentsPostResp, error)
 
 	IdOfTicketCommentsPostWithResponse(ctx context.Context, ticketId int64, body IdOfTicketCommentsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*IdOfTicketCommentsPostResp, error)
+
+	// IdOfTicketTagsRemoveWithBodyWithResponse request with any body
+	IdOfTicketTagsRemoveWithBodyWithResponse(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IdOfTicketTagsRemoveResp, error)
+
+	IdOfTicketTagsRemoveWithResponse(ctx context.Context, ticketId int64, body IdOfTicketTagsRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*IdOfTicketTagsRemoveResp, error)
+
+	// IdOfTicketTagsAddWithBodyWithResponse request with any body
+	IdOfTicketTagsAddWithBodyWithResponse(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IdOfTicketTagsAddResp, error)
+
+	IdOfTicketTagsAddWithResponse(ctx context.Context, ticketId int64, body IdOfTicketTagsAddJSONRequestBody, reqEditors ...RequestEditorFn) (*IdOfTicketTagsAddResp, error)
 }
 
 type ListAlertsResp struct {
@@ -16621,6 +16805,58 @@ func (r IdOfTicketCommentsPostResp) StatusCode() int {
 	return 0
 }
 
+type IdOfTicketTagsRemoveResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TagsResponse
+	JSON400      *N400
+	JSON401      *N401
+	JSON403      *N403
+	JSON404      *N404
+}
+
+// Status returns HTTPResponse.Status
+func (r IdOfTicketTagsRemoveResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IdOfTicketTagsRemoveResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IdOfTicketTagsAddResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TagsResponse
+	JSON400      *N400
+	JSON401      *N401
+	JSON403      *N403
+	JSON404      *N404
+}
+
+// Status returns HTTPResponse.Status
+func (r IdOfTicketTagsAddResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IdOfTicketTagsAddResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // ListAlertsWithResponse request returning *ListAlertsResp
 func (c *ClientWithResponses) ListAlertsWithResponse(ctx context.Context, params *ListAlertsParams, reqEditors ...RequestEditorFn) (*ListAlertsResp, error) {
 	rsp, err := c.ListAlerts(ctx, params, reqEditors...)
@@ -17692,6 +17928,40 @@ func (c *ClientWithResponses) IdOfTicketCommentsPostWithResponse(ctx context.Con
 		return nil, err
 	}
 	return ParseIdOfTicketCommentsPostResp(rsp)
+}
+
+// IdOfTicketTagsRemoveWithBodyWithResponse request with arbitrary body returning *IdOfTicketTagsRemoveResp
+func (c *ClientWithResponses) IdOfTicketTagsRemoveWithBodyWithResponse(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IdOfTicketTagsRemoveResp, error) {
+	rsp, err := c.IdOfTicketTagsRemoveWithBody(ctx, ticketId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIdOfTicketTagsRemoveResp(rsp)
+}
+
+func (c *ClientWithResponses) IdOfTicketTagsRemoveWithResponse(ctx context.Context, ticketId int64, body IdOfTicketTagsRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*IdOfTicketTagsRemoveResp, error) {
+	rsp, err := c.IdOfTicketTagsRemove(ctx, ticketId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIdOfTicketTagsRemoveResp(rsp)
+}
+
+// IdOfTicketTagsAddWithBodyWithResponse request with arbitrary body returning *IdOfTicketTagsAddResp
+func (c *ClientWithResponses) IdOfTicketTagsAddWithBodyWithResponse(ctx context.Context, ticketId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IdOfTicketTagsAddResp, error) {
+	rsp, err := c.IdOfTicketTagsAddWithBody(ctx, ticketId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIdOfTicketTagsAddResp(rsp)
+}
+
+func (c *ClientWithResponses) IdOfTicketTagsAddWithResponse(ctx context.Context, ticketId int64, body IdOfTicketTagsAddJSONRequestBody, reqEditors ...RequestEditorFn) (*IdOfTicketTagsAddResp, error) {
+	rsp, err := c.IdOfTicketTagsAdd(ctx, ticketId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIdOfTicketTagsAddResp(rsp)
 }
 
 // ParseListAlertsResp parses an HTTP response from a ListAlertsWithResponse call
@@ -22396,6 +22666,114 @@ func ParseIdOfTicketCommentsPostResp(rsp *http.Response) (*IdOfTicketCommentsPos
 			return nil, err
 		}
 		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest N403
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIdOfTicketTagsRemoveResp parses an HTTP response from a IdOfTicketTagsRemoveWithResponse call
+func ParseIdOfTicketTagsRemoveResp(rsp *http.Response) (*IdOfTicketTagsRemoveResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IdOfTicketTagsRemoveResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TagsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest N403
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIdOfTicketTagsAddResp parses an HTTP response from a IdOfTicketTagsAddWithResponse call
+func ParseIdOfTicketTagsAddResp(rsp *http.Response) (*IdOfTicketTagsAddResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IdOfTicketTagsAddResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TagsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400


### PR DESCRIPTION
This pull request introduces a new API for managing tags on support requests, including both OpenAPI specification and generated Go client code. The main focus is to allow clients to add or remove tags from support tickets in a controlled way, with normalization and namespace handling for customer tags.

The most important changes are:

**OpenAPI Spec Additions:**

* Added two new endpoints under `/support/v1/tickets/{ticketId}/tags` for POST (add tags) and DELETE (remove tags), including detailed descriptions, request/response bodies, and error handling. These endpoints ensure tags are normalized and customer tags are namespaced to avoid conflicts. [[1]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bR3352-R3440) [[2]](diffhunk://#diff-389d555bd5509e14e730dff6a1354d7cb61a2b9bf99e1a547a547513b508385cR2770-R2858)
* Defined new `TagsRequest` and `TagsResponse` schemas for these operations, specifying tag constraints and server-side transformations. [[1]](diffhunk://#diff-1351d08c9fc63a567951c506a54c81b45a1d94db767186eecbf4a94c587adf7bR7019-R7048) [[2]](diffhunk://#diff-389d555bd5509e14e730dff6a1354d7cb61a2b9bf99e1a547a547513b508385cR7680-R7709)

**Go Client Model and Interface Updates:**

* Added `TagsRequest` and `TagsResponse` types to the generated Go models, mirroring the OpenAPI schemas.
* Introduced new request body type aliases for the add/remove tag operations, and extended the client interfaces (`ClientInterface`, `ClientWithResponsesInterface`) with methods for these endpoints. [[1]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR7083-R7088) [[2]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR7708-R7717) [[3]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR14492-R14501)
* Implemented request constructors and client methods for invoking the new endpoints, including both raw and typed response variants. [[1]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR9196-R9243) [[2]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR14021-R14114) [[3]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR16808-R16859) [[4]](diffhunk://#diff-66423933fcd37e50b21a19d4f61d049934cfa45466896f2d2b66a170770cd5cbR17933-R17966)

These changes provide a complete, strongly-typed client and API contract for adding and removing tags on support tickets, with robust request/response handling and documentation.