### PR TITLE
feat(anomalies): add notifications support to anomaly and anomalies data sources

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -1310,6 +1310,31 @@
 										}
 									},
 									{
+										"name": "notifications",
+										"list_nested": {
+											"computed_optional_required": "computed",
+											"nested_object": {
+												"attributes": [
+													{
+														"name": "channel",
+														"string": {
+															"computed_optional_required": "computed",
+															"description": "Dispatch channel."
+														}
+													},
+													{
+														"name": "timestamp",
+														"string": {
+															"computed_optional_required": "computed",
+															"description": "Dispatch timestamp in RFC3339 UTC."
+														}
+													}
+												]
+											},
+											"description": "Chronologically ordered notification dispatch events."
+										}
+									},
+									{
 										"name": "platform",
 										"string": {
 											"computed_optional_required": "computed",
@@ -1521,6 +1546,31 @@
 						"int64": {
 							"computed_optional_required": "computed",
 							"description": "End of the anomaly"
+						}
+					},
+					{
+						"name": "notifications",
+						"list_nested": {
+							"computed_optional_required": "computed",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "channel",
+										"string": {
+											"computed_optional_required": "computed",
+											"description": "Dispatch channel."
+										}
+									},
+									{
+										"name": "timestamp",
+										"string": {
+											"computed_optional_required": "computed",
+											"description": "Dispatch timestamp in RFC3339 UTC."
+										}
+									}
+								]
+							},
+							"description": "Chronologically ordered notification dispatch events."
 						}
 					},
 					{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -1882,6 +1882,7 @@ paths:
                   - startTime
                   - timeFrame
                   - top3SKUs
+                  - notifications
                 type: object
                 properties:
                   attribution:
@@ -1939,6 +1940,8 @@ paths:
                     description: "Email of the user who first acknowledged the anomaly"
                     type: string
                     nullable: true
+                  notifications:
+                    $ref: "#/components/schemas/NotificationEventArray"
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -5262,6 +5265,7 @@ components:
         - startTime
         - timeFrame
         - top3SKUs
+        - notifications
       type: object
       description: Detailed information about a detected anomaly.
       properties:
@@ -5322,6 +5326,8 @@ components:
           description: "Email of the user who first acknowledged the anomaly"
           type: string
           nullable: true
+        notifications:
+          $ref: "#/components/schemas/NotificationEventArray"
 
     AnomalySKU:
       type: object
@@ -5337,6 +5343,31 @@ components:
       description: Array of SKU entries contributing to an anomaly.
       items:
         $ref: "#/components/schemas/AnomalySKU"
+    NotificationEvent:
+      type: object
+      description: |-
+        A successful notification dispatch for an anomaly.
+        This records that the API/worker sent the notification, not that delivery was confirmed.
+      required:
+        - timestamp
+        - channel
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Dispatch timestamp in RFC3339 UTC.
+        channel:
+          type: string
+          description: Dispatch channel.
+          enum:
+            - email
+            - slack
+            - msteams
+    NotificationEventArray:
+      type: array
+      description: Chronologically ordered notification dispatch events.
+      items:
+        $ref: "#/components/schemas/NotificationEvent"
     AnomalyResource:
       type: object
       description: Resource-specific contribution to an anomaly.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -4151,6 +4151,7 @@ components:
         - startTime
         - timeFrame
         - top3SKUs
+        - notifications
       type: object
       description: Detailed information about a detected anomaly.
       properties:
@@ -4211,6 +4212,8 @@ components:
           description: "Email of the user who first acknowledged the anomaly"
           type: string
           nullable: true
+        notifications:
+          $ref: "#/components/schemas/NotificationEventArray"
     AnomalyResource:
       type: object
       description: Resource-specific contribution to an anomaly.
@@ -6988,6 +6991,7 @@ components:
         - startTime
         - timeFrame
         - top3SKUs
+        - notifications
       type: object
       properties:
         attribution:
@@ -7045,6 +7049,8 @@ components:
           description: "Email of the user who first acknowledged the anomaly"
           type: string
           nullable: true
+        notifications:
+          $ref: "#/components/schemas/NotificationEventArray"
     GetDatahubDataset200Response:
       type: object
       properties:
@@ -7903,6 +7909,31 @@ components:
     MetricType:
       type: string
       description: Identifier for metric type (e.g., basic, custom, extended).
+    NotificationEvent:
+      type: object
+      description: |-
+        A successful notification dispatch for an anomaly.
+        This records that the API/worker sent the notification, not that delivery was confirmed.
+      required:
+        - timestamp
+        - channel
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Dispatch timestamp in RFC3339 UTC.
+        channel:
+          type: string
+          description: Dispatch channel.
+          enum:
+            - email
+            - slack
+            - msteams
+    NotificationEventArray:
+      type: array
+      description: Chronologically ordered notification dispatch events.
+      items:
+        $ref: "#/components/schemas/NotificationEvent"
     ObjectType:
       type: string
       description: Generic object type identifier.

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -274,6 +274,7 @@ Read-Only:
 - `cost_of_anomaly` (Number) Excess cost over and above the expected normal cost.
 - `end_time` (Number) End of the anomaly.
 - `id` (String)
+- `notifications` (Attributes List) Chronologically ordered notification dispatch events. (see [below for nested schema](#nestedatt--anomalies--notifications))
 - `platform` (String) Cloud Provider name.
 - `resource_data` (Attributes List) Array of resources contributing to an anomaly. (see [below for nested schema](#nestedatt--anomalies--resource_data))
 - `scope` (String) Scope: Project or Account
@@ -283,6 +284,15 @@ Read-Only:
 - `status` (String)
 - `time_frame` (String) Timeframe: Daily or Hourly
 - `top3skus` (Attributes List) Array of SKU entries contributing to an anomaly. (see [below for nested schema](#nestedatt--anomalies--top3skus))
+
+<a id="nestedatt--anomalies--notifications"></a>
+### Nested Schema for `anomalies.notifications`
+
+Read-Only:
+
+- `channel` (String) Dispatch channel.
+- `timestamp` (String) Dispatch timestamp in RFC3339 UTC.
+
 
 <a id="nestedatt--anomalies--resource_data"></a>
 ### Nested Schema for `anomalies.resource_data`

--- a/docs/data-sources/anomaly.md
+++ b/docs/data-sources/anomaly.md
@@ -75,6 +75,7 @@ output "anomaly_acknowledged_by" {
 - `billing_account` (String) Billing account ID
 - `cost_of_anomaly` (Number) The difference between the actual cost and the maximum cost in the normal range.
 - `end_time` (Number) End of the anomaly
+- `notifications` (Attributes List) Chronologically ordered notification dispatch events. (see [below for nested schema](#nestedatt--notifications))
 - `platform` (String) Cloud Provider name
 - `resource_data` (Attributes List) Array of resources contributing to an anomaly. (see [below for nested schema](#nestedatt--resource_data))
 - `scope` (String) Scope: Project or Account
@@ -91,6 +92,15 @@ output "anomaly_acknowledged_by" {
 Optional:
 
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+
+<a id="nestedatt--notifications"></a>
+### Nested Schema for `notifications`
+
+Read-Only:
+
+- `channel` (String) Dispatch channel.
+- `timestamp` (String) Dispatch timestamp in RFC3339 UTC.
 
 
 <a id="nestedatt--resource_data"></a>

--- a/internal/provider/anomalies_data_source.go
+++ b/internal/provider/anomalies_data_source.go
@@ -209,6 +209,9 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 			// Map Top3SKUs nested list
 			top3skusList := mapAnomalyTop3SKUs(ctx, anomaly.Top3SKUs, &resp.Diagnostics)
 
+			// Map Notifications nested list
+			notificationsList := mapAnomalyNotifications(ctx, anomaly.Notifications, &resp.Diagnostics)
+
 			anomalyVal, diags := datasource_anomalies.NewAnomaliesValue(
 				datasource_anomalies.AnomaliesValue{}.AttributeTypes(ctx),
 				map[string]attr.Value{
@@ -220,6 +223,7 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 					"billing_account": types.StringValue(anomaly.BillingAccount),
 					"cost_of_anomaly": types.Float64Value(anomaly.CostOfAnomaly),
 					"end_time":        endTimeVal,
+					"notifications":   notificationsList,
 					"platform":        types.StringValue(anomaly.Platform),
 					"scope":           types.StringValue(anomaly.Scope),
 					"service_name":    types.StringValue(anomaly.ServiceName),
@@ -328,6 +332,32 @@ func mapAnomalyTop3SKUs(ctx context.Context, skus models.AnomalySKUArray, diagno
 	}
 
 	list, diags := types.ListValueFrom(ctx, datasource_anomalies.Top3skusValue{}.Type(ctx), vals)
+	diagnostics.Append(diags...)
+	return list
+}
+
+// mapAnomalyNotifications maps API NotificationEvent slice to Terraform list.
+func mapAnomalyNotifications(ctx context.Context, notifications []models.NotificationEvent, diagnostics *diag.Diagnostics) types.List {
+	if len(notifications) == 0 {
+		emptyNotifications, d := types.ListValueFrom(ctx, datasource_anomalies.NotificationsValue{}.Type(ctx), []datasource_anomalies.NotificationsValue{})
+		diagnostics.Append(d...)
+		return emptyNotifications
+	}
+
+	vals := make([]datasource_anomalies.NotificationsValue, 0, len(notifications))
+	for _, n := range notifications {
+		notificationVal, diags := datasource_anomalies.NewNotificationsValue(
+			datasource_anomalies.NotificationsValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"channel":   types.StringValue(string(n.Channel)),
+				"timestamp": types.StringValue(n.Timestamp.UTC().Format(time.RFC3339)),
+			},
+		)
+		diagnostics.Append(diags...)
+		vals = append(vals, notificationVal)
+	}
+
+	list, diags := types.ListValueFrom(ctx, datasource_anomalies.NotificationsValue{}.Type(ctx), vals)
 	diagnostics.Append(diags...)
 	return list
 }

--- a/internal/provider/anomalies_data_source_test.go
+++ b/internal/provider/anomalies_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccAnomaliesDataSource_MaxResultsOnly(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.doit_anomalies.limited", "anomalies.#", "1"),
 					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "page_token"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "anomalies.0.notifications.#"),
 				),
 			},
 			{
@@ -212,6 +213,7 @@ func TestAccAnomaliesDataSource_AcknowledgedFields(t *testing.T) {
 				Config: testAccAnomaliesDataSourceAcknowledgedConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.doit_anomalies.ack_test", "row_count"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.ack_test", "anomalies.0.notifications.#"),
 				),
 			},
 			// Drift verification
@@ -243,6 +245,14 @@ output "anomaly_acknowledged_at" {
 
 output "anomaly_acknowledged_by" {
   value = [for a in data.doit_anomalies.ack_test.anomalies : a.acknowledged_by != null ? a.acknowledged_by : ""]
+}
+
+output "anomaly_notifications" {
+  value = [
+    for a in data.doit_anomalies.ack_test.anomalies : [
+      for n in a.notifications : n.channel
+    ]
+  ]
 }
 `
 }

--- a/internal/provider/anomaly_data_source.go
+++ b/internal/provider/anomaly_data_source.go
@@ -82,6 +82,7 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 		data.BillingAccount = types.StringUnknown()
 		data.CostOfAnomaly = types.Float64Unknown()
 		data.EndTime = types.Int64Unknown()
+		data.Notifications = types.ListUnknown(datasource_anomaly.NotificationsValue{}.Type(ctx))
 		data.Platform = types.StringUnknown()
 		data.ResourceData = types.ListUnknown(datasource_anomaly.ResourceDataValue{}.Type(ctx))
 		data.Scope = types.StringUnknown()
@@ -204,6 +205,9 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 		data.Top3skus = emptyList
 	}
 
+	// Map notifications
+	data.Notifications = mapAnomalyNotificationsForAnomaly(ctx, anomaly.Notifications, &resp.Diagnostics)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -231,6 +235,33 @@ func mapAnomalyResourceLabelsForAnomaly(ctx context.Context, labels *[]models.An
 	}
 
 	list, diags := types.ListValueFrom(ctx, datasource_anomaly.LabelsValue{}.Type(ctx), vals)
+	diagnostics.Append(diags...)
+	return list
+}
+
+// mapAnomalyNotificationsForAnomaly maps API NotificationEvent slice to Terraform list
+// for the singular anomaly data source.
+func mapAnomalyNotificationsForAnomaly(ctx context.Context, notifications []models.NotificationEvent, diagnostics *diag.Diagnostics) types.List {
+	if len(notifications) == 0 {
+		emptyNotifications, d := types.ListValueFrom(ctx, datasource_anomaly.NotificationsValue{}.Type(ctx), []datasource_anomaly.NotificationsValue{})
+		diagnostics.Append(d...)
+		return emptyNotifications
+	}
+
+	vals := make([]datasource_anomaly.NotificationsValue, 0, len(notifications))
+	for _, n := range notifications {
+		notificationVal, diags := datasource_anomaly.NewNotificationsValue(
+			datasource_anomaly.NotificationsValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"channel":   types.StringValue(string(n.Channel)),
+				"timestamp": types.StringValue(n.Timestamp.UTC().Format(time.RFC3339)),
+			},
+		)
+		diagnostics.Append(diags...)
+		vals = append(vals, notificationVal)
+	}
+
+	list, diags := types.ListValueFrom(ctx, datasource_anomaly.NotificationsValue{}.Type(ctx), vals)
 	diagnostics.Append(diags...)
 	return list
 }

--- a/internal/provider/anomaly_data_source_test.go
+++ b/internal/provider/anomaly_data_source_test.go
@@ -29,6 +29,7 @@ func TestAccAnomalyDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.doit_anomaly.test", "resource_data.#"),
 					// acknowledged is always a bool (true/false), never null
 					resource.TestCheckResourceAttrSet("data.doit_anomaly.test", "acknowledged"),
+					resource.TestCheckResourceAttrSet("data.doit_anomaly.test", "notifications.#"),
 				),
 			},
 			// Drift verification: re-apply the same config should produce an empty plan
@@ -138,6 +139,10 @@ output "acknowledged_at" {
 
 output "acknowledged_by" {
   value = data.doit_anomaly.test.acknowledged_by
+}
+
+output "notifications" {
+  value = [for n in data.doit_anomaly.test.notifications : n.channel]
 }
 `, id)
 }

--- a/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
+++ b/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
@@ -59,6 +59,30 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 						"id": schema.StringAttribute{
 							Computed: true,
 						},
+						"notifications": schema.ListNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"channel": schema.StringAttribute{
+										Computed:            true,
+										Description:         "Dispatch channel.",
+										MarkdownDescription: "Dispatch channel.",
+									},
+									"timestamp": schema.StringAttribute{
+										Computed:            true,
+										Description:         "Dispatch timestamp in RFC3339 UTC.",
+										MarkdownDescription: "Dispatch timestamp in RFC3339 UTC.",
+									},
+								},
+								CustomType: NotificationsType{
+									ObjectType: types.ObjectType{
+										AttrTypes: NotificationsValue{}.AttributeTypes(ctx),
+									},
+								},
+							},
+							Computed:            true,
+							Description:         "Chronologically ordered notification dispatch events.",
+							MarkdownDescription: "Chronologically ordered notification dispatch events.",
+						},
 						"platform": schema.StringAttribute{
 							Computed:            true,
 							Description:         "Cloud Provider name.",
@@ -396,6 +420,24 @@ func (t AnomaliesType) ValueFromObject(ctx context.Context, in basetypes.ObjectV
 			fmt.Sprintf(`id expected to be basetypes.StringValue, was: %T`, idAttribute))
 	}
 
+	notificationsAttribute, ok := attributes["notifications"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`notifications is missing from object`)
+
+		return nil, diags
+	}
+
+	notificationsVal, ok := notificationsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`notifications expected to be basetypes.ListValue, was: %T`, notificationsAttribute))
+	}
+
 	platformAttribute, ok := attributes["platform"]
 
 	if !ok {
@@ -571,6 +613,7 @@ func (t AnomaliesType) ValueFromObject(ctx context.Context, in basetypes.ObjectV
 		CostOfAnomaly:  costOfAnomalyVal,
 		EndTime:        endTimeVal,
 		Id:             idVal,
+		Notifications:  notificationsVal,
 		Platform:       platformVal,
 		ResourceData:   resourceDataVal,
 		Scope:          scopeVal,
@@ -791,6 +834,24 @@ func NewAnomaliesValue(attributeTypes map[string]attr.Type, attributes map[strin
 			fmt.Sprintf(`id expected to be basetypes.StringValue, was: %T`, idAttribute))
 	}
 
+	notificationsAttribute, ok := attributes["notifications"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`notifications is missing from object`)
+
+		return NewAnomaliesValueUnknown(), diags
+	}
+
+	notificationsVal, ok := notificationsAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`notifications expected to be basetypes.ListValue, was: %T`, notificationsAttribute))
+	}
+
 	platformAttribute, ok := attributes["platform"]
 
 	if !ok {
@@ -966,6 +1027,7 @@ func NewAnomaliesValue(attributeTypes map[string]attr.Type, attributes map[strin
 		CostOfAnomaly:  costOfAnomalyVal,
 		EndTime:        endTimeVal,
 		Id:             idVal,
+		Notifications:  notificationsVal,
 		Platform:       platformVal,
 		ResourceData:   resourceDataVal,
 		Scope:          scopeVal,
@@ -1055,6 +1117,7 @@ type AnomaliesValue struct {
 	CostOfAnomaly  basetypes.Float64Value `tfsdk:"cost_of_anomaly"`
 	EndTime        basetypes.Int64Value   `tfsdk:"end_time"`
 	Id             basetypes.StringValue  `tfsdk:"id"`
+	Notifications  basetypes.ListValue    `tfsdk:"notifications"`
 	Platform       basetypes.StringValue  `tfsdk:"platform"`
 	ResourceData   basetypes.ListValue    `tfsdk:"resource_data"`
 	Scope          basetypes.StringValue  `tfsdk:"scope"`
@@ -1068,7 +1131,7 @@ type AnomaliesValue struct {
 }
 
 func (v AnomaliesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 17)
+	attrTypes := make(map[string]tftypes.Type, 18)
 
 	var val tftypes.Value
 	var err error
@@ -1081,6 +1144,9 @@ func (v AnomaliesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 	attrTypes["cost_of_anomaly"] = basetypes.Float64Type{}.TerraformType(ctx)
 	attrTypes["end_time"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["notifications"] = basetypes.ListType{
+		ElemType: NotificationsValue{}.Type(ctx),
+	}.TerraformType(ctx)
 	attrTypes["platform"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["resource_data"] = basetypes.ListType{
 		ElemType: ResourceDataValue{}.Type(ctx),
@@ -1099,7 +1165,7 @@ func (v AnomaliesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 17)
+		vals := make(map[string]tftypes.Value, 18)
 
 		val, err = v.Acknowledged.ToTerraformValue(ctx)
 
@@ -1164,6 +1230,14 @@ func (v AnomaliesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		}
 
 		vals["id"] = val
+
+		val, err = v.Notifications.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["notifications"] = val
 
 		val, err = v.Platform.ToTerraformValue(ctx)
 
@@ -1266,6 +1340,12 @@ func (v AnomaliesValue) String() string {
 func (v AnomaliesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	var notifications attr.Value
+
+	{
+		notifications = v.Notifications
+	}
+
 	var resourceData attr.Value
 
 	{
@@ -1287,7 +1367,10 @@ func (v AnomaliesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValu
 		"cost_of_anomaly": basetypes.Float64Type{},
 		"end_time":        basetypes.Int64Type{},
 		"id":              basetypes.StringType{},
-		"platform":        basetypes.StringType{},
+		"notifications": basetypes.ListType{
+			ElemType: NotificationsValue{}.Type(ctx),
+		},
+		"platform": basetypes.StringType{},
 		"resource_data": basetypes.ListType{
 			ElemType: ResourceDataValue{}.Type(ctx),
 		},
@@ -1321,6 +1404,7 @@ func (v AnomaliesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValu
 			"cost_of_anomaly": v.CostOfAnomaly,
 			"end_time":        v.EndTime,
 			"id":              v.Id,
+			"notifications":   notifications,
 			"platform":        v.Platform,
 			"resource_data":   resourceData,
 			"scope":           v.Scope,
@@ -1382,6 +1466,10 @@ func (v AnomaliesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.Notifications.Equal(other.Notifications) {
+		return false
+	}
+
 	if !v.Platform.Equal(other.Platform) {
 		return false
 	}
@@ -1439,7 +1527,10 @@ func (v AnomaliesValue) AttributeTypes(ctx context.Context) map[string]attr.Type
 		"cost_of_anomaly": basetypes.Float64Type{},
 		"end_time":        basetypes.Int64Type{},
 		"id":              basetypes.StringType{},
-		"platform":        basetypes.StringType{},
+		"notifications": basetypes.ListType{
+			ElemType: NotificationsValue{}.Type(ctx),
+		},
+		"platform": basetypes.StringType{},
 		"resource_data": basetypes.ListType{
 			ElemType: ResourceDataValue{}.Type(ctx),
 		},
@@ -1452,6 +1543,385 @@ func (v AnomaliesValue) AttributeTypes(ctx context.Context) map[string]attr.Type
 		"top3skus": basetypes.ListType{
 			ElemType: Top3skusValue{}.Type(ctx),
 		},
+	}
+}
+
+var _ basetypes.ObjectTypable = NotificationsType{}
+
+type NotificationsType struct {
+	basetypes.ObjectType
+}
+
+func (t NotificationsType) Equal(o attr.Type) bool {
+	other, ok := o.(NotificationsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t NotificationsType) String() string {
+	return "NotificationsType"
+}
+
+func (t NotificationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	channelAttribute, ok := attributes["channel"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`channel is missing from object`)
+
+		return nil, diags
+	}
+
+	channelVal, ok := channelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`channel expected to be basetypes.StringValue, was: %T`, channelAttribute))
+	}
+
+	timestampAttribute, ok := attributes["timestamp"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`timestamp is missing from object`)
+
+		return nil, diags
+	}
+
+	timestampVal, ok := timestampAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`timestamp expected to be basetypes.StringValue, was: %T`, timestampAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return NotificationsValue{
+		Channel:   channelVal,
+		Timestamp: timestampVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewNotificationsValueNull() NotificationsValue {
+	return NotificationsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewNotificationsValueUnknown() NotificationsValue {
+	return NotificationsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewNotificationsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (NotificationsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing NotificationsValue Attribute Value",
+				"While creating a NotificationsValue value, a missing attribute value was detected. "+
+					"A NotificationsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("NotificationsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid NotificationsValue Attribute Type",
+				"While creating a NotificationsValue value, an invalid attribute value was detected. "+
+					"A NotificationsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("NotificationsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("NotificationsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra NotificationsValue Attribute Value",
+				"While creating a NotificationsValue value, an extra attribute value was detected. "+
+					"A NotificationsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra NotificationsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	channelAttribute, ok := attributes["channel"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`channel is missing from object`)
+
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	channelVal, ok := channelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`channel expected to be basetypes.StringValue, was: %T`, channelAttribute))
+	}
+
+	timestampAttribute, ok := attributes["timestamp"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`timestamp is missing from object`)
+
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	timestampVal, ok := timestampAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`timestamp expected to be basetypes.StringValue, was: %T`, timestampAttribute))
+	}
+
+	if diags.HasError() {
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	return NotificationsValue{
+		Channel:   channelVal,
+		Timestamp: timestampVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewNotificationsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) NotificationsValue {
+	object, diags := NewNotificationsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewNotificationsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t NotificationsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewNotificationsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewNotificationsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewNotificationsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewNotificationsValueMust(NotificationsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t NotificationsType) ValueType(ctx context.Context) attr.Value {
+	return NotificationsValue{}
+}
+
+var _ basetypes.ObjectValuable = NotificationsValue{}
+
+type NotificationsValue struct {
+	Channel   basetypes.StringValue `tfsdk:"channel"`
+	Timestamp basetypes.StringValue `tfsdk:"timestamp"`
+	state     attr.ValueState
+}
+
+func (v NotificationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["channel"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["timestamp"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.Channel.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["channel"] = val
+
+		val, err = v.Timestamp.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["timestamp"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v NotificationsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v NotificationsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v NotificationsValue) String() string {
+	return "NotificationsValue"
+}
+
+func (v NotificationsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"channel":   basetypes.StringType{},
+		"timestamp": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"channel":   v.Channel,
+			"timestamp": v.Timestamp,
+		})
+
+	return objVal, diags
+}
+
+func (v NotificationsValue) Equal(o attr.Value) bool {
+	other, ok := o.(NotificationsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Channel.Equal(other.Channel) {
+		return false
+	}
+
+	if !v.Timestamp.Equal(other.Timestamp) {
+		return false
+	}
+
+	return true
+}
+
+func (v NotificationsValue) Type(ctx context.Context) attr.Type {
+	return NotificationsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v NotificationsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"channel":   basetypes.StringType{},
+		"timestamp": basetypes.StringType{},
 	}
 }
 

--- a/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
+++ b/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
@@ -58,6 +58,30 @@ func AnomalyDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "A unique identifier of the anomaly.",
 				MarkdownDescription: "A unique identifier of the anomaly.",
 			},
+			"notifications": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"channel": schema.StringAttribute{
+							Computed:            true,
+							Description:         "Dispatch channel.",
+							MarkdownDescription: "Dispatch channel.",
+						},
+						"timestamp": schema.StringAttribute{
+							Computed:            true,
+							Description:         "Dispatch timestamp in RFC3339 UTC.",
+							MarkdownDescription: "Dispatch timestamp in RFC3339 UTC.",
+						},
+					},
+					CustomType: NotificationsType{
+						ObjectType: types.ObjectType{
+							AttrTypes: NotificationsValue{}.AttributeTypes(ctx),
+						},
+					},
+				},
+				Computed:            true,
+				Description:         "Chronologically ordered notification dispatch events.",
+				MarkdownDescription: "Chronologically ordered notification dispatch events.",
+			},
 			"platform": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Cloud Provider name",
@@ -183,6 +207,7 @@ type AnomalyModel struct {
 	CostOfAnomaly  types.Float64 `tfsdk:"cost_of_anomaly"`
 	EndTime        types.Int64   `tfsdk:"end_time"`
 	Id             types.String  `tfsdk:"id"`
+	Notifications  types.List    `tfsdk:"notifications"`
 	Platform       types.String  `tfsdk:"platform"`
 	ResourceData   types.List    `tfsdk:"resource_data"`
 	Scope          types.String  `tfsdk:"scope"`
@@ -192,6 +217,385 @@ type AnomalyModel struct {
 	Status         types.String  `tfsdk:"status"`
 	TimeFrame      types.String  `tfsdk:"time_frame"`
 	Top3skus       types.List    `tfsdk:"top3skus"`
+}
+
+var _ basetypes.ObjectTypable = NotificationsType{}
+
+type NotificationsType struct {
+	basetypes.ObjectType
+}
+
+func (t NotificationsType) Equal(o attr.Type) bool {
+	other, ok := o.(NotificationsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t NotificationsType) String() string {
+	return "NotificationsType"
+}
+
+func (t NotificationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	channelAttribute, ok := attributes["channel"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`channel is missing from object`)
+
+		return nil, diags
+	}
+
+	channelVal, ok := channelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`channel expected to be basetypes.StringValue, was: %T`, channelAttribute))
+	}
+
+	timestampAttribute, ok := attributes["timestamp"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`timestamp is missing from object`)
+
+		return nil, diags
+	}
+
+	timestampVal, ok := timestampAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`timestamp expected to be basetypes.StringValue, was: %T`, timestampAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return NotificationsValue{
+		Channel:   channelVal,
+		Timestamp: timestampVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewNotificationsValueNull() NotificationsValue {
+	return NotificationsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewNotificationsValueUnknown() NotificationsValue {
+	return NotificationsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewNotificationsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (NotificationsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing NotificationsValue Attribute Value",
+				"While creating a NotificationsValue value, a missing attribute value was detected. "+
+					"A NotificationsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("NotificationsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid NotificationsValue Attribute Type",
+				"While creating a NotificationsValue value, an invalid attribute value was detected. "+
+					"A NotificationsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("NotificationsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("NotificationsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra NotificationsValue Attribute Value",
+				"While creating a NotificationsValue value, an extra attribute value was detected. "+
+					"A NotificationsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra NotificationsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	channelAttribute, ok := attributes["channel"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`channel is missing from object`)
+
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	channelVal, ok := channelAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`channel expected to be basetypes.StringValue, was: %T`, channelAttribute))
+	}
+
+	timestampAttribute, ok := attributes["timestamp"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`timestamp is missing from object`)
+
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	timestampVal, ok := timestampAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`timestamp expected to be basetypes.StringValue, was: %T`, timestampAttribute))
+	}
+
+	if diags.HasError() {
+		return NewNotificationsValueUnknown(), diags
+	}
+
+	return NotificationsValue{
+		Channel:   channelVal,
+		Timestamp: timestampVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewNotificationsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) NotificationsValue {
+	object, diags := NewNotificationsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewNotificationsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t NotificationsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewNotificationsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewNotificationsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewNotificationsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewNotificationsValueMust(NotificationsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t NotificationsType) ValueType(ctx context.Context) attr.Value {
+	return NotificationsValue{}
+}
+
+var _ basetypes.ObjectValuable = NotificationsValue{}
+
+type NotificationsValue struct {
+	Channel   basetypes.StringValue `tfsdk:"channel"`
+	Timestamp basetypes.StringValue `tfsdk:"timestamp"`
+	state     attr.ValueState
+}
+
+func (v NotificationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["channel"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["timestamp"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.Channel.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["channel"] = val
+
+		val, err = v.Timestamp.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["timestamp"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v NotificationsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v NotificationsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v NotificationsValue) String() string {
+	return "NotificationsValue"
+}
+
+func (v NotificationsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"channel":   basetypes.StringType{},
+		"timestamp": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"channel":   v.Channel,
+			"timestamp": v.Timestamp,
+		})
+
+	return objVal, diags
+}
+
+func (v NotificationsValue) Equal(o attr.Value) bool {
+	other, ok := o.(NotificationsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Channel.Equal(other.Channel) {
+		return false
+	}
+
+	if !v.Timestamp.Equal(other.Timestamp) {
+		return false
+	}
+
+	return true
+}
+
+func (v NotificationsValue) Type(ctx context.Context) attr.Type {
+	return NotificationsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v NotificationsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"channel":   basetypes.StringType{},
+		"timestamp": basetypes.StringType{},
+	}
 }
 
 var _ basetypes.ObjectTypable = ResourceDataType{}

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -2078,6 +2078,27 @@ func (e MetricFilterText) Valid() bool {
 	}
 }
 
+// Defines values for NotificationEventChannel.
+const (
+	Email   NotificationEventChannel = "email"
+	Msteams NotificationEventChannel = "msteams"
+	Slack   NotificationEventChannel = "slack"
+)
+
+// Valid indicates whether the value is a known member of the NotificationEventChannel enum.
+func (e NotificationEventChannel) Valid() bool {
+	switch e {
+	case Email:
+		return true
+	case Msteams:
+		return true
+	case Slack:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ReportType.
 const (
 	ReportTypeCustom ReportType = "custom"
@@ -3570,6 +3591,9 @@ type AnomalyItem struct {
 	// EndTime End of the anomaly.
 	EndTime *int    `json:"endTime,omitempty"`
 	Id      *string `json:"id,omitempty"`
+
+	// Notifications Chronologically ordered notification dispatch events.
+	Notifications NotificationEventArray `json:"notifications"`
 
 	// Platform Cloud Provider name.
 	Platform string `json:"platform"`
@@ -5533,6 +5557,9 @@ type GetAnomaly200Response struct {
 	// EndTime End of the anomaly
 	EndTime *int `json:"endTime,omitempty"`
 
+	// Notifications Chronologically ordered notification dispatch events.
+	Notifications NotificationEventArray `json:"notifications"`
+
 	// Platform Cloud Provider name
 	Platform string `json:"platform"`
 
@@ -6207,6 +6234,22 @@ type MetricFilterText string
 
 // MetricType Identifier for metric type (e.g., basic, custom, extended).
 type MetricType = string
+
+// NotificationEvent A successful notification dispatch for an anomaly.
+// This records that the API/worker sent the notification, not that delivery was confirmed.
+type NotificationEvent struct {
+	// Channel Dispatch channel.
+	Channel NotificationEventChannel `json:"channel"`
+
+	// Timestamp Dispatch timestamp in RFC3339 UTC.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// NotificationEventChannel Dispatch channel.
+type NotificationEventChannel string
+
+// NotificationEventArray Chronologically ordered notification dispatch events.
+type NotificationEventArray = []NotificationEvent
 
 // Organization Organization metadata returned by the API.
 type Organization struct {


### PR DESCRIPTION
### Summary
This PR adds support for the new `notifications` attribute to both the singular `doit_anomaly` and plural `doit_anomalies` data sources in the DoiT Terraform provider.

The `notifications` attribute tracks delivery details of anomaly notification alerts, capturing when the alert was fired (`timestamp`) and which medium was notified (`channel` e.g., email, slack, msteams).

### Changes
* **Singular Data Source (`doit_anomaly`):**
  * Added `mapAnomalyNotificationsForAnomaly` helper to parse the API response structure to `datasource_anomaly.NotificationsValue` objects.
  * Added initialization guards for `notifications` in the plan-time unknown-value logic (`IsUnknown()`).
* **Plural Data Source (`doit_anomalies`):**
  * Added `mapAnomalyNotifications` helper to map the notifications attribute for each individual anomaly in the list.
  * Correctly initialized the list of notifications inside the plurals plan guard.
* **OpenAPI Specs & Generated Models:**
  * Updated downstream OpenAPI spec with the `notifications` attribute.
  * Regenerated schema types and schemas (e.g. `docs/data-sources/anomaly.md`, `docs/data-sources/anomalies.md`, `internal/provider/datasource_anomaly/anomaly_data_source_gen.go`, `internal/provider/datasource_anomalies/anomalies_data_source_gen.go`).
* **Test Suites:**
  * Added validation in `anomaly_data_source_test.go` and `anomalies_data_source_test.go` checking the length and elements of `notifications` field via `resource.TestCheckResourceAttrSet`.

### Verification
* **Live API Test:** Verified on active anomaly with real notifications, confirming output payload format matches the mapped struct.
* **Acceptance Tests:** Ran all acceptance tests successfully:
  * `make testacc-run TEST=TestAccAnomalyDataSource` -> 3/3 passed.
  * `make testacc-run TEST=TestAccAnomaliesDataSource` -> 6/6 passed.
