### PR TITLE
refactor(provider): standardize helper function conventions across all resources

### DIFF
--- a/.agent/skills/implement-datasource/SKILL.md
+++ b/.agent/skills/implement-datasource/SKILL.md
@@ -55,8 +55,14 @@ var _ datasource.DataSourceWithConfigure = (*myDataSource)(nil)
 
 ## Step 4: Implement the Data Source
 
+### Mapping Convention
+
+Data sources map API responses to the model inline within the `Read` method. Unlike resources,
+data sources do not need a separate `mapXxxToModel` function or companion file.
+
+### Implementation
+
 - Use `*models.ClientWithResponses` for client type
-- Implement `mapXxxToModel()` for complex nested types
 - Use generated constructors (`NewXxxValue()`) for nested objects
 - Add timeout support (see [implementation-conventions](../implementation-conventions/SKILL.md#timeout-support))
 

--- a/.agent/skills/implement-datasource/SKILL.md
+++ b/.agent/skills/implement-datasource/SKILL.md
@@ -57,8 +57,12 @@ var _ datasource.DataSourceWithConfigure = (*myDataSource)(nil)
 
 ### Mapping Convention
 
-Data sources map API responses to the model inline within the `Read` method. Unlike resources,
-data sources do not need a separate `mapXxxToModel` function or companion file.
+Data sources that share an entity with a resource (e.g. `alert`, `report`) should reuse the
+`mapXxxToModel` helper from the companion `<name>.go` file. Data sources with their own unique
+mapping (e.g. list data sources) should place helpers in the `_data_source.go` file or in a
+companion file when the mapping is non-trivial.
+
+Simple data sources that only do a few scalar assignments may keep mapping logic inline in Read.
 
 ### Implementation
 

--- a/.agent/skills/implement-resource/SKILL.md
+++ b/.agent/skills/implement-resource/SKILL.md
@@ -43,23 +43,27 @@ var _ resource.ResourceWithImportState = (*myResource)(nil)
 
 ## Step 4: Implement CRUD Methods
 
-All resources use the **plan-first overlay pattern**. See [Overlay Pattern Reference](references/overlay-pattern.md) for the full deep-dive.
+All resources use the **plan-first overlay pattern** and the **standard helper functions** defined in [implementation-conventions](../implementation-conventions/SKILL.md#standard-helper-functions). See [Overlay Pattern Reference](references/overlay-pattern.md) for the overlay deep-dive.
 
-Summary:
+### Helper functions (in `<name>.go`)
 
-- **Create**: Build request from plan → call API → call `overlayComputedFields()` → set state
-- **Read**: Call `populateState()` / `mapResourceToModel()` → handle 404 with `RemoveResource()`
-- **Update**: Same as Create — overlay pattern
-- **Delete**: Treat 404 as success
-- **ImportState**: Use `ImportStatePassthroughID`
+Every resource must implement these in `<name>.go`:
+- `populateState` — wraps API GET + `mapXxxToModel`. Sets `state.Id = null` on 404.
+- `mapXxxToModel` — pure mapping from API response to TF model.
+- `overlayXxxComputedFields` — two-phase overlay for Create/Update.
+- `toXxxRequest` (or `toCreateRequest` / `toUpdateRequest`) — converts TF model to API request.
 
-```go
-func (r *myResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-    resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-```
+### CRUD flow
 
-**Invariant:** Create/Update = overlay wrapper. Read/Import = full mapping directly. Never mix these.
+| Method | Flow |
+|--------|------|
+| **Create** | `plan.toXxxRequest(ctx)` → API call → `overlayXxxComputedFields()` → `resp.State.Set()` |
+| **Read** | `r.populateState(ctx, &state)` → check `state.Id.IsNull()` → `RemoveResource()` or `resp.State.Set()` |
+| **Update** | Same as Create (get ID from state) |
+| **Delete** | Treat 404 as success |
+| **ImportState** | `ImportStatePassthroughID` |
+
+**Invariant:** Create/Update = overlay wrapper. Read/Import = full mapping via populateState. Never mix these.
 
 > **Linters:** `overlaycheck`, `overlayinvariant` — enforce overlay pattern correctness.
 

--- a/.agent/skills/implement-resource/references/overlay-pattern.md
+++ b/.agent/skills/implement-resource/references/overlay-pattern.md
@@ -26,10 +26,12 @@ Key rules:
 - **Optional+Computed when `IsUnknown()`**: user omitted the field — resolve from API response, fall back to null/false
 - **Optional+Computed when known**: user explicitly set it — never overwrite
 
-## Step 2: Implement overlayComputedFields
+## Step 2: Implement overlayXxxComputedFields
+
+Always include the resource name in the function name (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). This must be a **standalone function** (no receiver):
 
 ```go
-func overlayComputedFields(ctx context.Context, apiResp *models.MyResource, plan *myResourceModel) diag.Diagnostics {
+func overlayMyResourceComputedFields(ctx context.Context, apiResp *models.MyResource, plan *myResourceModel) diag.Diagnostics {
     var diags diag.Diagnostics
 
     // 1. Computed-only fields: ALWAYS set from API response.
@@ -62,12 +64,12 @@ func (r *myResource) Create(ctx context.Context, req resource.CreateRequest, res
     // ... build request from plan, call API ...
 
     // Plan-first: keep user values, overlay only computed fields
-    resp.Diagnostics.Append(overlayComputedFields(ctx, apiResp, &plan)...)
+    resp.Diagnostics.Append(overlayMyResourceComputedFields(ctx, apiResp, &plan)...)
     resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 ```
 
-Apply the same to Update. Read and ImportState continue using `mapResourceToModel` / `populateState` since they have no plan to preserve.
+Apply the same to Update. Read and ImportState continue using `populateState` (which calls `mapXxxToModel`) since they have no plan to preserve.
 
 ## Step 4: Handle Read-Path Reconciliation
 
@@ -87,7 +89,7 @@ The Read path detects **real** external changes while ignoring API normalization
 
 4. **Not testing the Update path separately.** Create and Update can have different API behaviors. Always test both.
 
-5. **Mixing overlay and full mapping.** Never call `mapResourceToModel`/`populateState` directly from Create/Update — always go through the overlay wrapper. Conversely, never use `overlayComputedFields` in Read/ImportState.
+5. **Mixing overlay and full mapping.** Never call `mapXxxToModel`/`populateState` directly from Create/Update — always go through the overlay wrapper. Conversely, never use `overlayXxxComputedFields` in Read/ImportState.
 
 6. **API-defaulted lists need API response, not null.** Some lists are auto-populated by the API when omitted (e.g. `collaborators` adds creator as owner). Resolving `IsUnknown()` to `null` causes drift. Resolve from the API response instead.
 

--- a/.agent/skills/implement-resource/references/overlay-pattern.md
+++ b/.agent/skills/implement-resource/references/overlay-pattern.md
@@ -28,7 +28,7 @@ Key rules:
 
 ## Step 2: Implement overlayXxxComputedFields
 
-Always include the resource name in the function name (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). This must be a **standalone function** (no receiver):
+Always include the resource name in the function name (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). This must be a **standalone function** (no receiver) unless `mapXxxToModel` makes additional API calls via `r.client` (e.g. allocation), in which case the receiver is allowed:
 
 ```go
 func overlayMyResourceComputedFields(ctx context.Context, apiResp *models.MyResource, plan *myResourceModel) diag.Diagnostics {

--- a/.agent/skills/implementation-conventions/SKILL.md
+++ b/.agent/skills/implementation-conventions/SKILL.md
@@ -59,7 +59,7 @@ Every resource must implement these four functions in `<name>.go`:
 
 | Function | Signature | Purpose |
 |----------|-----------|---------|
-| `populateState` | `(r *xResource) populateState(ctx, state *xResourceModel) diag.Diagnostics` | Fetches from API using the identifier in `state` (e.g. `state.Id`), calls `mapXxxToModel`. Sets `state.Id = types.StringNull()` on 404. Used by Read only. |
+| `populateState` | `(r *xResource) populateState(ctx, state *xResourceModel) diag.Diagnostics` | Fetches from API using the identifier in `state` (e.g. `state.Id`), calls `mapXxxToModel`. Sets `state.Id = types.StringNull()` on 404. Used by Read (and ImportState via Read). |
 | `mapXxxToModel` | `mapXxxToModel([ctx,] apiResp, state) [diag.Diagnostics]` | Pure mapping from API response to TF model. **Standalone function — no receiver.** Used by `populateState` and as Phase 1 of overlay. |
 | `overlayXxxComputedFields` | `overlayXxxComputedFields([ctx,] apiResp, plan) [diag.Diagnostics]` | Two-phase overlay. **Standalone function — no receiver. Always prefix with the resource name** (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). Used by Create/Update only. |
 | `toXxxRequest` | `(plan *xResourceModel) toXxxRequest([ctx]) (req[, diag.Diagnostics])` | **Method on the plan model**, converts TF model to API request. When create and update share a request type, name it `toUpdateRequest`. |

--- a/.agent/skills/implementation-conventions/SKILL.md
+++ b/.agent/skills/implementation-conventions/SKILL.md
@@ -25,6 +25,49 @@ func NewLabelResource() resource.Resource {
 
 > **Linter:** `constructor` — flags `new(type)` in constructor return statements.
 
+## File Structure & Code Organization
+
+### Resource File Layout
+
+Every resource splits into two files:
+
+| File | Contents |
+|------|----------|
+| `<name>_resource.go` | Type/model declarations, interface checks, `NewXxxResource()`, `Configure`, `Metadata`, `Schema`, `ImportState`, `ConfigValidators`, CRUD methods |
+| `<name>.go` | `populateState`, `mapXxxToModel`, `overlayXxxComputedFields`, `toXxxRequest`, and any helper functions |
+
+Additional files as needed: `<name>_validator.go`, `<name>_state_upgrader.go`.
+
+Data sources use a single file: `<name>_data_source.go` (mapping logic inline in Read).
+
+### Variable Initialization
+
+Always use `var` for plan/state variables, never `new()`:
+
+```go
+// CORRECT
+var plan myResourceModel
+resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+// WRONG — do not use new() for model variables
+plan := new(myResourceModel)
+```
+
+### Standard Helper Functions
+
+Every resource must implement these four functions in `<name>.go`:
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|--------|
+| `populateState` | `(r *xResource) populateState(ctx, state *xResourceModel) diag.Diagnostics` | Fetches from API using the identifier in `state` (e.g. `state.Id`), calls `mapXxxToModel`. Sets `state.Id = types.StringNull()` on 404. Used by Read only. |
+| `mapXxxToModel` | `mapXxxToModel(ctx, apiResp, state) diag.Diagnostics` | Pure mapping from API response to TF model. **Standalone function — no receiver.** Used by `populateState` and as Phase 1 of overlay. |
+| `overlayXxxComputedFields` | `overlayXxxComputedFields(ctx, apiResp, plan) diag.Diagnostics` | Two-phase overlay. **Standalone function — no receiver. Always prefix with the resource name** (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). Used by Create/Update only. |
+| `toXxxRequest` | `(plan *xResourceModel) toXxxRequest(ctx) (req, diag.Diagnostics)` | **Method on the plan model**, converts TF model to API request. When create and update share a request type, name it `toUpdateRequest`. |
+
+If create and update use different API request types, implement both `toCreateRequest` and `toUpdateRequest`.
+
+> **Receiver rule:** Only `populateState` has a receiver (it needs `r.client`). `mapXxxToModel` and `overlayXxxComputedFields` must be standalone functions. `toXxxRequest` / `toCreateRequest` / `toUpdateRequest` are methods on the plan model.
+
 ## Variable Naming
 
 Variable names must match their data source:
@@ -105,25 +148,7 @@ resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 > **Linter:** `read404` — flags Read methods that don't call `RemoveResource`.
 
-## Create/Update 404 Handling
 
-If a GET after Create/Update returns 404, that's an error (transient API issue), not an external deletion. Use `allowNotFound` to differentiate:
-
-```go
-func (r *myResource) populateState(ctx context.Context, state *myModel, allowNotFound bool) diag.Diagnostics {
-    if httpResp.StatusCode() == 404 {
-        if allowNotFound {
-            state.Id = types.StringNull()  // Read context
-            return nil
-        }
-        return diag.Diagnostics{diag.NewErrorDiagnostic(
-            "Resource not found after operation",
-            "Created/updated but could not be read back (404). Please retry.",
-        )}
-    }
-    // ...
-}
-```
 
 ## Configure Error Type
 

--- a/.agent/skills/implementation-conventions/SKILL.md
+++ b/.agent/skills/implementation-conventions/SKILL.md
@@ -58,15 +58,17 @@ plan := new(myResourceModel)
 Every resource must implement these four functions in `<name>.go`:
 
 | Function | Signature | Purpose |
-|----------|-----------|---------|--------|
+|----------|-----------|---------|
 | `populateState` | `(r *xResource) populateState(ctx, state *xResourceModel) diag.Diagnostics` | Fetches from API using the identifier in `state` (e.g. `state.Id`), calls `mapXxxToModel`. Sets `state.Id = types.StringNull()` on 404. Used by Read only. |
-| `mapXxxToModel` | `mapXxxToModel(ctx, apiResp, state) diag.Diagnostics` | Pure mapping from API response to TF model. **Standalone function — no receiver.** Used by `populateState` and as Phase 1 of overlay. |
-| `overlayXxxComputedFields` | `overlayXxxComputedFields(ctx, apiResp, plan) diag.Diagnostics` | Two-phase overlay. **Standalone function — no receiver. Always prefix with the resource name** (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). Used by Create/Update only. |
-| `toXxxRequest` | `(plan *xResourceModel) toXxxRequest(ctx) (req, diag.Diagnostics)` | **Method on the plan model**, converts TF model to API request. When create and update share a request type, name it `toUpdateRequest`. |
+| `mapXxxToModel` | `mapXxxToModel([ctx,] apiResp, state) [diag.Diagnostics]` | Pure mapping from API response to TF model. **Standalone function — no receiver.** Used by `populateState` and as Phase 1 of overlay. |
+| `overlayXxxComputedFields` | `overlayXxxComputedFields([ctx,] apiResp, plan) [diag.Diagnostics]` | Two-phase overlay. **Standalone function — no receiver. Always prefix with the resource name** (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). Used by Create/Update only. |
+| `toXxxRequest` | `(plan *xResourceModel) toXxxRequest([ctx]) (req[, diag.Diagnostics])` | **Method on the plan model**, converts TF model to API request. When create and update share a request type, name it `toUpdateRequest`. |
 
 If create and update use different API request types, implement both `toCreateRequest` and `toUpdateRequest`.
 
 > **Receiver rule:** Only `populateState` has a receiver (it needs `r.client`). `mapXxxToModel` and `overlayXxxComputedFields` must be standalone functions. `toXxxRequest` / `toCreateRequest` / `toUpdateRequest` are methods on the plan model.
+
+> **Signature flexibility:** The `ctx` and `diag.Diagnostics` parameters are required when the function maps nested objects (lists, objects) or can produce errors. Simple resources that only do scalar assignments (e.g. `types.StringValue`, `types.StringPointerValue`) may omit `ctx` and return nothing. Match the complexity of your resource.
 
 ## Variable Naming
 

--- a/.agent/skills/implementation-conventions/SKILL.md
+++ b/.agent/skills/implementation-conventions/SKILL.md
@@ -38,7 +38,14 @@ Every resource splits into two files:
 
 Additional files as needed: `<name>_validator.go`, `<name>_state_upgrader.go`.
 
-Data sources use a single file: `<name>_data_source.go` (mapping logic inline in Read).
+Data sources follow the same companion-file pattern when they have non-trivial helper functions:
+
+| File | Contents |
+|------|----------|
+| `<name>_data_source.go` | Type/model declarations, interface checks, `NewXxxDataSource()`, `Configure`, `Metadata`, `Schema`, Read method |
+| `<name>.go` | `mapXxxToModel` and any helper functions (shared with the resource if one exists) |
+
+Simple data sources that only do a few scalar assignments may keep mapping logic inline in Read.
 
 ### Variable Initialization
 
@@ -59,14 +66,14 @@ Every resource must implement these four functions in `<name>.go`:
 
 | Function | Signature | Purpose |
 |----------|-----------|---------|
-| `populateState` | `(r *xResource) populateState(ctx, state *xResourceModel) diag.Diagnostics` | Fetches from API using the identifier in `state` (e.g. `state.Id`), calls `mapXxxToModel`. Sets `state.Id = types.StringNull()` on 404. Used by Read (and ImportState via Read). |
+| `populateState` | `(r *xResource) populateState(ctx, state *xResourceModel) diag.Diagnostics` | Fetches from API using the identifier in `state` (e.g. `state.Id`, `state.Name`), calls `mapXxxToModel`. Sets the identifier attribute to `types.StringNull()` on 404. Used by Read (and ImportState via Read). |
 | `mapXxxToModel` | `mapXxxToModel([ctx,] apiResp, state) [diag.Diagnostics]` | Pure mapping from API response to TF model. **Standalone function — no receiver.** Used by `populateState` and as Phase 1 of overlay. |
 | `overlayXxxComputedFields` | `overlayXxxComputedFields([ctx,] apiResp, plan) [diag.Diagnostics]` | Two-phase overlay. **Standalone function — no receiver. Always prefix with the resource name** (e.g. `overlayReportComputedFields`, not `overlayComputedFields`). Used by Create/Update only. |
 | `toXxxRequest` | `(plan *xResourceModel) toXxxRequest([ctx]) (req[, diag.Diagnostics])` | **Method on the plan model**, converts TF model to API request. When create and update share a request type, name it `toUpdateRequest`. |
 
 If create and update use different API request types, implement both `toCreateRequest` and `toUpdateRequest`.
 
-> **Receiver rule:** Only `populateState` has a receiver (it needs `r.client`). `mapXxxToModel` and `overlayXxxComputedFields` must be standalone functions. `toXxxRequest` / `toCreateRequest` / `toUpdateRequest` are methods on the plan model.
+> **Receiver rule:** Only `populateState` has a receiver (it needs `r.client`). `mapXxxToModel` and `overlayXxxComputedFields` must be standalone functions. `toXxxRequest` / `toCreateRequest` / `toUpdateRequest` are methods on the plan model. **Exception:** If `mapXxxToModel` makes additional API calls (e.g. allocation fetches full rule details via `r.client`), it may retain the receiver, which propagates to `overlayXxxComputedFields`.
 
 > **Signature flexibility:** The `ctx` and `diag.Diagnostics` parameters are required when the function maps nested objects (lists, objects) or can produce errors. Simple resources that only do scalar assignments (e.g. `types.StringValue`, `types.StringPointerValue`) may omit `ctx` and return nothing. Match the complexity of your resource.
 

--- a/internal/provider/alert.go
+++ b/internal/provider/alert.go
@@ -22,7 +22,7 @@ import (
 // the resolved counterpart. Computed-only fields always come from resolved.
 //
 // Used by: Create, Update
-// NOT used by: Read, ImportState (which use populateState / mapAlertToModel directly).
+// NOT used by: Read, ImportState (which use populateState → mapAlertToModel).
 func overlayAlertComputedFields(ctx context.Context, apiResp *models.Alert, plan *alertResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -15,24 +15,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// overlayComputedFields uses the two-phase overlay pattern to reconcile
-// the Terraform plan with the API response after Create/Update.
+// overlayAllocationComputedFields uses the two-phase overlay pattern to reconcile
+// the Terraform plan with the API response after Create or Update.
 //
 // Phase 1 (Resolve): Build a fully-resolved state from the API response using
-// mapAllocationToModel — the same mapping function used by Read/ImportState.
-// This guarantees consistency between Create/Update and Read paths.
+// mapAllocationToModel — the same mapping function used by Read/ImportState. This
+// guarantees consistency between Create/Update and Read paths.
 //
 // Phase 2 (Overlay): Walk the plan field-by-field. Known (user-configured)
 // values are preserved as-is. Unknown (user-omitted) values are replaced with
 // the resolved counterpart. Computed-only fields always come from resolved.
 //
-// This prevents "Provider produced inconsistent result" errors caused by the API
-// normalizing user-provided values (e.g. stripping [Service N/A] sentinels,
-// renaming type aliases like "allocation_rule" to "attribution").
-//
 // Used by: Create, Update
 // NOT used by: Read, ImportState (which use populateState / mapAllocationToModel directly).
-func (r *allocationResource) overlayComputedFields(ctx context.Context, apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
+func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context, apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Phase 1: Build fully-resolved state from API response.
@@ -55,12 +51,6 @@ func (r *allocationResource) overlayComputedFields(ctx context.Context, apiResp 
 	plan.AllocationType = resolved.AllocationType
 
 	// ── Optional+Computed scalar fields: only when Unknown ──
-	if plan.Description.IsUnknown() {
-		plan.Description = resolved.Description
-	}
-	if plan.Name.IsUnknown() {
-		plan.Name = resolved.Name
-	}
 	if plan.UnallocatedCosts.IsUnknown() {
 		plan.UnallocatedCosts = resolved.UnallocatedCosts
 	}
@@ -292,23 +282,11 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 }
 
 // populateState fetches the allocation from the API and populates the Terraform state.
-// This is used by Read and ImportState. Create and Update use mapAllocationToModel
-// directly with the API response instead.
+// This is used by Read and ImportState. Create and Update use overlayAllocationComputedFields
+// with the API response instead.
 //
-// # 404 Handling Strategy
-//
-// The allowNotFound parameter controls how 404 responses are handled:
-//
-//   - allowNotFound=true (used by Read):
-//     404 means the resource was deleted externally (outside Terraform).
-//     We set state.Id to null, which signals Terraform to remove the resource
-//     from state. On next plan, Terraform will propose recreating it.
-//     This is the standard Terraform pattern for "externally deleted" resources.
-//
-//   - allowNotFound=false:
-//     404 is unexpected and indicates an error. This is kept as a safety measure
-//     but is not currently used since Create/Update no longer call populateState.
-func (r *allocationResource) populateState(ctx context.Context, state *allocationResourceModel, allowNotFound bool) (diags diag.Diagnostics) {
+// On 404, state.Id is set to null to signal Terraform to remove the resource from state.
+func (r *allocationResource) populateState(ctx context.Context, state *allocationResourceModel) (diags diag.Diagnostics) {
 	// Get refreshed allocation value from DoiT using the ID from the state.
 	httpResp, err := r.client.GetAllocationWithResponse(ctx, state.Id.ValueString())
 	if err != nil {
@@ -319,21 +297,9 @@ func (r *allocationResource) populateState(ctx context.Context, state *allocatio
 		return
 	}
 
-	// Handle 404 based on context
+	// Handle externally deleted resource
 	if httpResp.StatusCode() == 404 {
-		if allowNotFound {
-			// Read context: Resource was deleted externally, mark for removal from state
-			state.Id = types.StringNull()
-			return
-		}
-		// Create/Update context: Resource should exist, 404 is an error
-		diags.AddError(
-			"Resource not found after operation",
-			"The allocation was successfully created/updated but could not be read back (404). "+
-				"This may indicate a transient API issue. Please retry the operation. "+
-				"If the problem persists, the resource may need to be imported manually. "+
-				"Allocation ID: "+state.Id.ValueString(),
-		)
+		state.Id = types.StringNull()
 		return
 	}
 

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -27,7 +27,7 @@ import (
 // the resolved counterpart. Computed-only fields always come from resolved.
 //
 // Used by: Create, Update
-// NOT used by: Read, ImportState (which use populateState / mapAllocationToModel directly).
+// NOT used by: Read, ImportState (which use populateState → mapAllocationToModel).
 func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context, apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -28,6 +28,10 @@ import (
 //
 // Used by: Create, Update
 // NOT used by: Read, ImportState (which use populateState → mapAllocationToModel).
+//
+// NOTE: Unlike most resources, this overlay retains the receiver because
+// mapAllocationToModel makes additional API calls (r.client.GetAllocationWithResponse)
+// to fetch full allocation rule details for multi-rule allocations.
 func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context, apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 

--- a/internal/provider/allocation_resource.go
+++ b/internal/provider/allocation_resource.go
@@ -216,7 +216,7 @@ func (r *allocationResource) Create(ctx context.Context, req resource.CreateRequ
 	// This prevents "Provider produced inconsistent result" errors caused by the
 	// API normalizing user-provided values (stripping sentinels, renaming services).
 	// Read and ImportState still use mapAllocationToModel for the full API response.
-	resp.Diagnostics.Append(r.overlayComputedFields(ctx, allocationResp.JSON200, plan)...)
+	resp.Diagnostics.Append(r.overlayAllocationComputedFields(ctx, allocationResp.JSON200, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -240,8 +240,7 @@ func (r *allocationResource) Read(ctx context.Context, req resource.ReadRequest,
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// allowNotFound=true: 404 means resource was deleted externally, remove from state
-	diags = r.populateState(ctx, state, true)
+	diags = r.populateState(ctx, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -331,7 +330,7 @@ func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Plan-first state pattern: keep all user-configured values from the plan
 	// exactly as-is, and only overlay Computed-only fields from the API response.
-	resp.Diagnostics.Append(r.overlayComputedFields(ctx, updateResp.JSON200, plan)...)
+	resp.Diagnostics.Append(r.overlayAllocationComputedFields(ctx, updateResp.JSON200, plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/allocation_resource.go
+++ b/internal/provider/allocation_resource.go
@@ -154,9 +154,9 @@ func (r *allocationResource) ConfigValidators(_ context.Context) []resource.Conf
 }
 
 func (r *allocationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	plan := new(allocationResourceModel)
+	var plan allocationResourceModel
 
-	diags := req.Plan.Get(ctx, plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -216,17 +216,17 @@ func (r *allocationResource) Create(ctx context.Context, req resource.CreateRequ
 	// This prevents "Provider produced inconsistent result" errors caused by the
 	// API normalizing user-provided values (stripping sentinels, renaming services).
 	// Read and ImportState still use mapAllocationToModel for the full API response.
-	resp.Diagnostics.Append(r.overlayAllocationComputedFields(ctx, allocationResp.JSON200, plan)...)
+	resp.Diagnostics.Append(r.overlayAllocationComputedFields(ctx, allocationResp.JSON200, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *allocationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	state := new(allocationResourceModel)
-	diags := req.State.Get(ctx, state)
+	var state allocationResourceModel
+	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -240,7 +240,7 @@ func (r *allocationResource) Read(ctx context.Context, req resource.ReadRequest,
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	diags = r.populateState(ctx, state)
+	diags = r.populateState(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -252,12 +252,12 @@ func (r *allocationResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	plan := new(allocationResourceModel)
-	diags := req.Plan.Get(ctx, plan)
+	var plan allocationResourceModel
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -330,17 +330,17 @@ func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Plan-first state pattern: keep all user-configured values from the plan
 	// exactly as-is, and only overlay Computed-only fields from the API response.
-	resp.Diagnostics.Append(r.overlayAllocationComputedFields(ctx, updateResp.JSON200, plan)...)
+	resp.Diagnostics.Append(r.overlayAllocationComputedFields(ctx, updateResp.JSON200, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *allocationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	state := new(allocationResourceModel)
-	diags := req.State.Get(ctx, state)
+	var state allocationResourceModel
+	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/annotation.go
+++ b/internal/provider/annotation.go
@@ -1,0 +1,226 @@
+// Package provider implements the DoiT Terraform provider.
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// populateState fetches the annotation from the API and populates the Terraform state.
+// On 404, state.Id is set to null to signal Terraform to remove the resource from state.
+func (r *annotationResource) populateState(ctx context.Context, state *annotationResourceModel) diag.Diagnostics {
+	annotationResp, err := r.client.GetAnnotationWithResponse(ctx, state.Id.ValueString())
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Annotation", "Could not read annotation ID "+state.Id.ValueString()+": "+err.Error()),
+		}
+	}
+
+	if annotationResp.StatusCode() == 404 {
+		state.Id = types.StringNull()
+		return nil
+	}
+
+	if annotationResp.StatusCode() != 200 {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Annotation", fmt.Sprintf("Unexpected status code %d for annotation ID %s: %s", annotationResp.StatusCode(), state.Id.ValueString(), string(annotationResp.Body))),
+		}
+	}
+
+	if annotationResp.JSON200 == nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Annotation", "Received empty response body for annotation ID "+state.Id.ValueString()),
+		}
+	}
+
+	return mapAnnotationToModel(ctx, annotationResp.JSON200, state)
+}
+
+// mapAnnotationToModel maps the API response to the Terraform model.
+func mapAnnotationToModel(ctx context.Context, resp *models.AnnotationListItem, state *annotationResourceModel) (diags diag.Diagnostics) {
+	state.Id = types.StringValue(resp.Id)
+	state.Content = types.StringValue(resp.Content)
+
+	// Check if the timestamp has changed semantically before overwriting to preserve user formatting
+	existingTime, err := time.Parse(time.RFC3339, state.Timestamp.ValueString())
+	if err == nil && existingTime.Equal(resp.Timestamp) {
+		// Keep the existing string to avoid diffs if the time is the same
+	} else {
+		state.Timestamp = types.StringValue(resp.Timestamp.UTC().Format(time.RFC3339))
+	}
+
+	if resp.CreateTime != nil {
+		state.CreateTime = types.StringValue(resp.CreateTime.Format(time.RFC3339))
+	} else {
+		state.CreateTime = types.StringNull()
+	}
+
+	if resp.UpdateTime != nil {
+		state.UpdateTime = types.StringValue(resp.UpdateTime.Format(time.RFC3339))
+	} else {
+		state.UpdateTime = types.StringNull()
+	}
+
+	// Map labels - API returns []LabelInfo, but we store just the IDs
+	// Use resp.Labels != nil (not len check) to handle explicit empty lists correctly
+	if resp.Labels != nil {
+		labelIDs := make([]string, len(*resp.Labels))
+		for i, label := range *resp.Labels {
+			labelIDs[i] = label.Id
+		}
+		labelsList, d := types.ListValueFrom(ctx, types.StringType, labelIDs)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+		state.Labels = labelsList
+	} else {
+		var emptyDiags diag.Diagnostics
+		state.Labels, emptyDiags = types.ListValueFrom(ctx, types.StringType, []string{})
+		diags.Append(emptyDiags...)
+	}
+
+	// Map reports
+	// Use resp.Reports != nil (not len check) to handle explicit empty lists correctly
+	if resp.Reports != nil {
+		reportsList, d := types.ListValueFrom(ctx, types.StringType, *resp.Reports)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+		state.Reports = reportsList
+	} else {
+		var emptyDiags diag.Diagnostics
+		state.Reports, emptyDiags = types.ListValueFrom(ctx, types.StringType, []string{})
+		diags.Append(emptyDiags...)
+	}
+
+	return diags
+}
+
+// overlayAnnotationComputedFields uses the two-phase overlay pattern to reconcile
+// the Terraform plan with the API response after Create/Update.
+//
+// Phase 1 (Resolve): Build a fully-resolved state from the API response using
+// mapAnnotationToModel — the same mapping function used by Read.
+//
+// Phase 2 (Overlay): Walk the plan field-by-field. Known values are preserved.
+// Unknown values are replaced with the resolved counterpart.
+func overlayAnnotationComputedFields(ctx context.Context, apiResp *models.AnnotationListItem, plan *annotationResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Phase 1: Build fully-resolved state from API response.
+	resolved := *plan
+	diags.Append(mapAnnotationToModel(ctx, apiResp, &resolved)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Phase 2: Overlay known plan values on top of resolved state.
+
+	// ── Computed-only fields: always from resolved ──
+	plan.Id = resolved.Id
+	plan.CreateTime = resolved.CreateTime
+	plan.UpdateTime = resolved.UpdateTime
+
+	// ── Content, Timestamp: Required — never touch ──
+
+	// ── Labels: Optional+Computed list ──
+	if plan.Labels.IsUnknown() {
+		plan.Labels = resolved.Labels
+	}
+
+	// ── Reports: Optional+Computed list ──
+	if plan.Reports.IsUnknown() {
+		plan.Reports = resolved.Reports
+	}
+
+	return diags
+}
+
+// toCreateRequest converts the TF model to a CreateAnnotationRequest.
+func (plan *annotationResourceModel) toCreateRequest(ctx context.Context) (models.CreateAnnotationRequest, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	timestamp, err := time.Parse(time.RFC3339, plan.Timestamp.ValueString())
+	if err != nil {
+		diags.AddError(
+			"Error Parsing Timestamp",
+			fmt.Sprintf("Could not parse timestamp '%s': %s", plan.Timestamp.ValueString(), err.Error()),
+		)
+		return models.CreateAnnotationRequest{}, diags
+	}
+
+	req := models.CreateAnnotationRequest{
+		Content:   plan.Content.ValueString(),
+		Timestamp: timestamp,
+	}
+
+	// Handle optional labels list
+	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
+		var labels []string
+		diags.Append(plan.Labels.ElementsAs(ctx, &labels, false)...)
+		if diags.HasError() {
+			return req, diags
+		}
+		req.Labels = &labels
+	}
+
+	// Handle optional reports list
+	if !plan.Reports.IsNull() && !plan.Reports.IsUnknown() {
+		var reports []string
+		diags.Append(plan.Reports.ElementsAs(ctx, &reports, false)...)
+		if diags.HasError() {
+			return req, diags
+		}
+		req.Reports = &reports
+	}
+
+	return req, diags
+}
+
+// toUpdateRequest converts the TF model to an UpdateAnnotationRequest.
+func (plan *annotationResourceModel) toUpdateRequest(ctx context.Context) (models.UpdateAnnotationRequest, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	timestamp, err := time.Parse(time.RFC3339, plan.Timestamp.ValueString())
+	if err != nil {
+		diags.AddError(
+			"Error Parsing Timestamp",
+			fmt.Sprintf("Could not parse timestamp '%s': %s", plan.Timestamp.ValueString(), err.Error()),
+		)
+		return models.UpdateAnnotationRequest{}, diags
+	}
+
+	req := models.UpdateAnnotationRequest{
+		Content:   new(plan.Content.ValueString()),
+		Timestamp: &timestamp,
+	}
+
+	// Handle optional labels list
+	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
+		var labels []string
+		diags.Append(plan.Labels.ElementsAs(ctx, &labels, false)...)
+		if diags.HasError() {
+			return req, diags
+		}
+		req.Labels = &labels
+	}
+
+	// Handle optional reports list
+	if !plan.Reports.IsNull() && !plan.Reports.IsUnknown() {
+		var reports []string
+		diags.Append(plan.Reports.ElementsAs(ctx, &reports, false)...)
+		if diags.HasError() {
+			return req, diags
+		}
+		req.Reports = &reports
+	}
+
+	return req, diags
+}

--- a/internal/provider/annotation_resource.go
+++ b/internal/provider/annotation_resource.go
@@ -8,12 +8,10 @@ import (
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_annotation"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type (
@@ -96,46 +94,6 @@ func (r *annotationResource) Schema(ctx context.Context, _ resource.SchemaReques
 	resp.Schema = s
 }
 
-// overlayAnnotationComputedFields uses the two-phase overlay pattern to reconcile
-// the Terraform plan with the API response after Create/Update.
-//
-// Phase 1 (Resolve): Build a fully-resolved state from the API response using
-// mapAnnotationToModel — the same mapping function used by Read.
-//
-// Phase 2 (Overlay): Walk the plan field-by-field. Known values are preserved.
-// Unknown values are replaced with the resolved counterpart.
-func overlayAnnotationComputedFields(ctx context.Context, apiResp *models.AnnotationListItem, plan *annotationResourceModel) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	// Phase 1: Build fully-resolved state from API response.
-	resolved := *plan
-	diags.Append(mapAnnotationToModel(ctx, apiResp, &resolved)...)
-	if diags.HasError() {
-		return diags
-	}
-
-	// Phase 2: Overlay known plan values on top of resolved state.
-
-	// ── Computed-only fields: always from resolved ──
-	plan.Id = resolved.Id
-	plan.CreateTime = resolved.CreateTime
-	plan.UpdateTime = resolved.UpdateTime
-
-	// ── Content, Timestamp: Required — never touch ──
-
-	// ── Labels: Optional+Computed list ──
-	if plan.Labels.IsUnknown() {
-		plan.Labels = resolved.Labels
-	}
-
-	// ── Reports: Optional+Computed list ──
-	if plan.Reports.IsUnknown() {
-		plan.Reports = resolved.Reports
-	}
-
-	return diags
-}
-
 func (r *annotationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan annotationResourceModel
 
@@ -153,42 +111,11 @@ func (r *annotationResource) Create(ctx context.Context, req resource.CreateRequ
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	// Parse timestamp
-	timestamp, err := time.Parse(time.RFC3339, plan.Timestamp.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Parsing Timestamp",
-			fmt.Sprintf("Could not parse timestamp '%s': %s", plan.Timestamp.ValueString(), err.Error()),
-		)
+	// Build API request
+	apiReq, buildDiags := plan.toCreateRequest(ctx)
+	resp.Diagnostics.Append(buildDiags...)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-
-	// Convert model to API request type
-	apiReq := models.CreateAnnotationRequest{
-		Content:   plan.Content.ValueString(),
-		Timestamp: timestamp,
-	}
-
-	// Handle optional labels list
-	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
-		var labels []string
-		diags := plan.Labels.ElementsAs(ctx, &labels, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		apiReq.Labels = &labels
-	}
-
-	// Handle optional reports list
-	if !plan.Reports.IsNull() && !plan.Reports.IsUnknown() {
-		var reports []string
-		diags := plan.Reports.ElementsAs(ctx, &reports, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		apiReq.Reports = &reports
 	}
 
 	// Create new annotation via API
@@ -246,43 +173,15 @@ func (r *annotationResource) Read(ctx context.Context, req resource.ReadRequest,
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// Get refreshed annotation value from API
-	annotationResp, err := r.client.GetAnnotationWithResponse(ctx, state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Annotation",
-			"Could not read annotation ID "+state.Id.ValueString()+": "+err.Error(),
-		)
-		return
-	}
-
-	// Handle externally deleted resource - remove from state
-	if annotationResp.StatusCode() == 404 {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	// Check for successful response
-	if annotationResp.StatusCode() != 200 {
-		resp.Diagnostics.AddError(
-			"Error Reading Annotation",
-			fmt.Sprintf("Unexpected status code %d for annotation ID %s: %s", annotationResp.StatusCode(), state.Id.ValueString(), string(annotationResp.Body)),
-		)
-		return
-	}
-
-	if annotationResp.JSON200 == nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Annotation",
-			"Received empty response body for annotation ID "+state.Id.ValueString(),
-		)
-		return
-	}
-
-	// Map response to state
-	diags := mapAnnotationToModel(ctx, annotationResp.JSON200, &state)
+	diags := r.populateState(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Handle externally deleted resource (populateState sets Id to null on 404)
+	if state.Id.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -315,42 +214,11 @@ func (r *annotationResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 	annotationID := state.Id.ValueString()
 
-	// Parse timestamp
-	timestamp, err := time.Parse(time.RFC3339, plan.Timestamp.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Parsing Timestamp",
-			fmt.Sprintf("Could not parse timestamp '%s': %s", plan.Timestamp.ValueString(), err.Error()),
-		)
+	// Build API request
+	apiReq, buildDiags := plan.toUpdateRequest(ctx)
+	resp.Diagnostics.Append(buildDiags...)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-
-	// Convert model to API request type
-	apiReq := models.UpdateAnnotationRequest{
-		Content:   new(plan.Content.ValueString()),
-		Timestamp: &timestamp,
-	}
-
-	// Handle optional labels list
-	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
-		var labels []string
-		diags := plan.Labels.ElementsAs(ctx, &labels, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		apiReq.Labels = &labels
-	}
-
-	// Handle optional reports list
-	if !plan.Reports.IsNull() && !plan.Reports.IsUnknown() {
-		var reports []string
-		diags := plan.Reports.ElementsAs(ctx, &reports, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		apiReq.Reports = &reports
 	}
 
 	// Update annotation via API
@@ -426,66 +294,4 @@ func (r *annotationResource) Delete(ctx context.Context, req resource.DeleteRequ
 		)
 		return
 	}
-}
-
-// mapAnnotationToModel maps the API response to the Terraform model.
-func mapAnnotationToModel(ctx context.Context, resp *models.AnnotationListItem, state *annotationResourceModel) (diags diag.Diagnostics) {
-	state.Id = types.StringValue(resp.Id)
-	state.Content = types.StringValue(resp.Content)
-
-	// Check if the timestamp has changed semantically before overwriting to preserve user formatting
-	existingTime, err := time.Parse(time.RFC3339, state.Timestamp.ValueString())
-	if err == nil && existingTime.Equal(resp.Timestamp) {
-		// Keep the existing string to avoid diffs if the time is the same
-	} else {
-		state.Timestamp = types.StringValue(resp.Timestamp.UTC().Format(time.RFC3339))
-	}
-
-	if resp.CreateTime != nil {
-		state.CreateTime = types.StringValue(resp.CreateTime.Format(time.RFC3339))
-	} else {
-		state.CreateTime = types.StringNull()
-	}
-
-	if resp.UpdateTime != nil {
-		state.UpdateTime = types.StringValue(resp.UpdateTime.Format(time.RFC3339))
-	} else {
-		state.UpdateTime = types.StringNull()
-	}
-
-	// Map labels - API returns []LabelInfo, but we store just the IDs
-	// Use resp.Labels != nil (not len check) to handle explicit empty lists correctly
-	if resp.Labels != nil {
-		labelIDs := make([]string, len(*resp.Labels))
-		for i, label := range *resp.Labels {
-			labelIDs[i] = label.Id
-		}
-		labelsList, d := types.ListValueFrom(ctx, types.StringType, labelIDs)
-		diags.Append(d...)
-		if diags.HasError() {
-			return diags
-		}
-		state.Labels = labelsList
-	} else {
-		var emptyDiags diag.Diagnostics
-		state.Labels, emptyDiags = types.ListValueFrom(ctx, types.StringType, []string{})
-		diags.Append(emptyDiags...)
-	}
-
-	// Map reports
-	// Use resp.Reports != nil (not len check) to handle explicit empty lists correctly
-	if resp.Reports != nil {
-		reportsList, d := types.ListValueFrom(ctx, types.StringType, *resp.Reports)
-		diags.Append(d...)
-		if diags.HasError() {
-			return diags
-		}
-		state.Reports = reportsList
-	} else {
-		var emptyDiags diag.Diagnostics
-		state.Reports, emptyDiags = types.ListValueFrom(ctx, types.StringType, []string{})
-		diags.Append(emptyDiags...)
-	}
-
-	return diags
 }

--- a/internal/provider/asset.go
+++ b/internal/provider/asset.go
@@ -1,0 +1,212 @@
+// Package provider implements the DoiT Terraform provider.
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_asset"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// populateState fetches the asset from the API and populates the Terraform state.
+// On 404, state.Id is set to null to signal Terraform to remove the resource from state.
+func (r *assetResource) populateState(ctx context.Context, state *assetResourceModel) diag.Diagnostics {
+	assetResp, err := r.client.GetAssetWithResponse(ctx, state.Id.ValueString())
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Asset", "Could not read asset ID "+state.Id.ValueString()+": "+err.Error()),
+		}
+	}
+
+	if assetResp.StatusCode() == 404 {
+		state.Id = types.StringNull()
+		return nil
+	}
+
+	if assetResp.StatusCode() != 200 || assetResp.JSON200 == nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Asset", fmt.Sprintf("Unexpected status: %d, body: %s", assetResp.StatusCode(), string(assetResp.Body))),
+		}
+	}
+
+	return mapAssetToModel(ctx, assetResp.JSON200, state)
+}
+
+// mapAssetToModel maps the API response to the Terraform resource model.
+func mapAssetToModel(ctx context.Context, asset *models.AssetItemDetailed, state *assetResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	state.Id = types.StringPointerValue(asset.Id)
+	state.Name = types.StringPointerValue(asset.Name)
+	state.Type = types.StringPointerValue(asset.Type)
+	state.Url = types.StringPointerValue(asset.Url)
+	state.Quantity = types.Int64PointerValue(asset.Quantity)
+	state.CreateTime = types.Int64PointerValue(asset.CreateTime)
+
+	if asset.Properties == nil {
+		state.Properties = resource_asset.NewPropertiesValueNull()
+		return diags
+	}
+
+	props := asset.Properties
+
+	subscriptionVal, d := mapSubscriptionToValue(ctx, props.Subscription)
+	diags.Append(d...)
+
+	propsVal, d := resource_asset.NewPropertiesValue(
+		resource_asset.PropertiesValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"customer_domain": types.StringPointerValue(props.CustomerDomain),
+			"customer_id":     types.StringPointerValue(props.CustomerID),
+			"reseller":        types.StringPointerValue(props.Reseller),
+			"subscription":    subscriptionVal,
+		},
+	)
+	diags.Append(d...)
+
+	state.Properties = propsVal
+
+	return diags
+}
+
+func mapSubscriptionToValue(ctx context.Context, sub *models.Subscription) (resource_asset.SubscriptionValue, diag.Diagnostics) {
+	if sub == nil {
+		return resource_asset.NewSubscriptionValueNull(), nil
+	}
+
+	var diags diag.Diagnostics
+
+	planVal, d := mapPlanToValue(ctx, sub.Plan)
+	diags.Append(d...)
+
+	renewalVal, d := mapRenewalSettingsToValue(ctx, sub.RenewalSettings)
+	diags.Append(d...)
+
+	seatsVal, d := mapSeatsToValue(ctx, sub.Seats)
+	diags.Append(d...)
+
+	val, d := resource_asset.NewSubscriptionValue(
+		resource_asset.SubscriptionValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"billing_method":    types.StringPointerValue(sub.BillingMethod),
+			"creation_time":     types.Int64PointerValue(sub.CreationTime),
+			"id":                types.StringPointerValue(sub.Id),
+			"plan":              planVal,
+			"purchase_order_id": types.StringPointerValue(sub.PurchaseOrderID),
+			"renewal_settings":  renewalVal,
+			"resource_uiurl":    types.StringPointerValue(sub.ResourceUIURL),
+			"seats":             seatsVal,
+			"sku_id":            types.StringPointerValue(sub.SkuID),
+			"sku_name":          types.StringPointerValue(sub.SkuName),
+			"status":            types.StringPointerValue(sub.Status),
+		},
+	)
+	diags.Append(d...)
+
+	return val, diags
+}
+
+func mapPlanToValue(ctx context.Context, plan *models.SubscriptionPlan) (resource_asset.PlanValue, diag.Diagnostics) {
+	if plan == nil {
+		return resource_asset.NewPlanValueNull(), nil
+	}
+
+	var diags diag.Diagnostics
+
+	commitmentVal, d := mapCommitmentIntervalToValue(ctx, plan.CommitmentInterval)
+	diags.Append(d...)
+
+	val, d := resource_asset.NewPlanValue(
+		resource_asset.PlanValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"commitment_interval": commitmentVal,
+			"is_commitment_plan":  types.BoolPointerValue(plan.IsCommitmentPlan),
+			"plan_name":           types.StringPointerValue(plan.PlanName),
+		},
+	)
+	diags.Append(d...)
+
+	return val, diags
+}
+
+func mapCommitmentIntervalToValue(ctx context.Context, ci *models.SubscriptionPlanCommitmentInterval) (resource_asset.CommitmentIntervalValue, diag.Diagnostics) {
+	if ci == nil {
+		return resource_asset.NewCommitmentIntervalValueNull(), nil
+	}
+
+	val, d := resource_asset.NewCommitmentIntervalValue(
+		resource_asset.CommitmentIntervalValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"end_time":   types.Int64PointerValue(ci.EndTime),
+			"start_time": types.Int64PointerValue(ci.StartTime),
+		},
+	)
+
+	return val, d
+}
+
+func mapRenewalSettingsToValue(ctx context.Context, rs *models.RenewalSettings) (resource_asset.RenewalSettingsValue, diag.Diagnostics) {
+	if rs == nil {
+		return resource_asset.NewRenewalSettingsValueNull(), nil
+	}
+
+	val, d := resource_asset.NewRenewalSettingsValue(
+		resource_asset.RenewalSettingsValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"renewal_type": types.StringPointerValue(rs.RenewalType),
+		},
+	)
+
+	return val, d
+}
+
+func mapSeatsToValue(ctx context.Context, seats *models.Seats) (resource_asset.SeatsValue, diag.Diagnostics) {
+	if seats == nil {
+		return resource_asset.NewSeatsValueNull(), nil
+	}
+
+	val, d := resource_asset.NewSeatsValue(
+		resource_asset.SeatsValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"licensed_number_of_seats": types.Int64PointerValue(seats.LicensedNumberOfSeats),
+			"maximum_number_of_seats":  types.Int64PointerValue(seats.MaximumNumberOfSeats),
+			"number_of_seats":          types.Int64PointerValue(seats.NumberOfSeats),
+		},
+	)
+
+	return val, d
+}
+
+// overlayAssetComputedFields uses the two-phase overlay pattern to reconcile
+// the Terraform plan with the API response after Update.
+//
+// Asset is import-only (no Create). Only quantity is user-configurable;
+// all other fields are Computed-only.
+func overlayAssetComputedFields(ctx context.Context, apiResp *models.AssetItemDetailed, plan *assetResourceModel) diag.Diagnostics {
+	// Phase 1: Build fully-resolved state from API response.
+	resolved := *plan
+	diags := mapAssetToModel(ctx, apiResp, &resolved)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Phase 2: Overlay.
+	// Id: Computed-only, but safely preserved from the plan's prior state.
+	// Quantity: Optional+Computed — resolve when Unknown.
+	if plan.Quantity.IsUnknown() {
+		plan.Quantity = resolved.Quantity
+	}
+
+	// All other fields are Computed-only — always from resolved.
+	plan.Name = resolved.Name
+	plan.Type = resolved.Type
+	plan.Url = resolved.Url
+	plan.CreateTime = resolved.CreateTime
+	plan.Properties = resolved.Properties
+
+	return diags
+}

--- a/internal/provider/asset_resource.go
+++ b/internal/provider/asset_resource.go
@@ -8,15 +8,12 @@ import (
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_asset"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type (
@@ -145,66 +142,18 @@ func (r *assetResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// Get refreshed asset value from API
-	assetResp, err := r.client.GetAssetWithResponse(ctx, state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Asset",
-			"Could not read asset ID "+state.Id.ValueString()+": "+err.Error(),
-		)
-		return
-	}
-
-	// Handle externally deleted resource
-	if assetResp.StatusCode() == 404 {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	if assetResp.StatusCode() != 200 || assetResp.JSON200 == nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Asset",
-			fmt.Sprintf("Unexpected status: %d, body: %s", assetResp.StatusCode(), string(assetResp.Body)),
-		)
-		return
-	}
-
-	resp.Diagnostics.Append(mapAssetToModel(ctx, assetResp.JSON200, &state)...)
+	resp.Diagnostics.Append(r.populateState(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// Handle externally deleted resource (populateState sets Id to null on 404)
+	if state.Id.IsNull() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-}
-
-// overlayAssetComputedFields uses the two-phase overlay pattern to reconcile
-// the Terraform plan with the API response after Update.
-//
-// Asset is import-only (no Create). Only quantity is user-configurable;
-// all other fields are Computed-only.
-func overlayAssetComputedFields(ctx context.Context, apiResp *models.AssetItemDetailed, plan *assetResourceModel) diag.Diagnostics {
-	// Phase 1: Build fully-resolved state from API response.
-	resolved := *plan
-	diags := mapAssetToModel(ctx, apiResp, &resolved)
-	if diags.HasError() {
-		return diags
-	}
-
-	// Phase 2: Overlay.
-	// Id: Computed-only, but safely preserved from the plan's prior state.
-	// Quantity: Optional+Computed — resolve when Unknown.
-	if plan.Quantity.IsUnknown() {
-		plan.Quantity = resolved.Quantity
-	}
-
-	// All other fields are Computed-only — always from resolved.
-	plan.Name = resolved.Name
-	plan.Type = resolved.Type
-	plan.Url = resolved.Url
-	plan.CreateTime = resolved.CreateTime
-	plan.Properties = resolved.Properties
-
-	return diags
 }
 
 func (r *assetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -299,149 +248,4 @@ func (r *assetResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		"doit_asset does not support deletion via the API. "+
 			"The asset has been removed from Terraform state but continues to exist in DoiT.",
 	)
-}
-
-// mapAssetToModel maps the API response to the Terraform resource model.
-func mapAssetToModel(ctx context.Context, asset *models.AssetItemDetailed, state *assetResourceModel) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	state.Id = types.StringPointerValue(asset.Id)
-	state.Name = types.StringPointerValue(asset.Name)
-	state.Type = types.StringPointerValue(asset.Type)
-	state.Url = types.StringPointerValue(asset.Url)
-	state.Quantity = types.Int64PointerValue(asset.Quantity)
-	state.CreateTime = types.Int64PointerValue(asset.CreateTime)
-
-	if asset.Properties == nil {
-		state.Properties = resource_asset.NewPropertiesValueNull()
-		return diags
-	}
-
-	props := asset.Properties
-
-	subscriptionVal, d := mapSubscriptionToValue(ctx, props.Subscription)
-	diags.Append(d...)
-
-	propsVal, d := resource_asset.NewPropertiesValue(
-		resource_asset.PropertiesValue{}.AttributeTypes(ctx),
-		map[string]attr.Value{
-			"customer_domain": types.StringPointerValue(props.CustomerDomain),
-			"customer_id":     types.StringPointerValue(props.CustomerID),
-			"reseller":        types.StringPointerValue(props.Reseller),
-			"subscription":    subscriptionVal,
-		},
-	)
-	diags.Append(d...)
-
-	state.Properties = propsVal
-
-	return diags
-}
-
-func mapSubscriptionToValue(ctx context.Context, sub *models.Subscription) (resource_asset.SubscriptionValue, diag.Diagnostics) {
-	if sub == nil {
-		return resource_asset.NewSubscriptionValueNull(), nil
-	}
-
-	var diags diag.Diagnostics
-
-	planVal, d := mapPlanToValue(ctx, sub.Plan)
-	diags.Append(d...)
-
-	renewalVal, d := mapRenewalSettingsToValue(ctx, sub.RenewalSettings)
-	diags.Append(d...)
-
-	seatsVal, d := mapSeatsToValue(ctx, sub.Seats)
-	diags.Append(d...)
-
-	val, d := resource_asset.NewSubscriptionValue(
-		resource_asset.SubscriptionValue{}.AttributeTypes(ctx),
-		map[string]attr.Value{
-			"billing_method":    types.StringPointerValue(sub.BillingMethod),
-			"creation_time":     types.Int64PointerValue(sub.CreationTime),
-			"id":                types.StringPointerValue(sub.Id),
-			"plan":              planVal,
-			"purchase_order_id": types.StringPointerValue(sub.PurchaseOrderID),
-			"renewal_settings":  renewalVal,
-			"resource_uiurl":    types.StringPointerValue(sub.ResourceUIURL),
-			"seats":             seatsVal,
-			"sku_id":            types.StringPointerValue(sub.SkuID),
-			"sku_name":          types.StringPointerValue(sub.SkuName),
-			"status":            types.StringPointerValue(sub.Status),
-		},
-	)
-	diags.Append(d...)
-
-	return val, diags
-}
-
-func mapPlanToValue(ctx context.Context, plan *models.SubscriptionPlan) (resource_asset.PlanValue, diag.Diagnostics) {
-	if plan == nil {
-		return resource_asset.NewPlanValueNull(), nil
-	}
-
-	var diags diag.Diagnostics
-
-	commitmentVal, d := mapCommitmentIntervalToValue(ctx, plan.CommitmentInterval)
-	diags.Append(d...)
-
-	val, d := resource_asset.NewPlanValue(
-		resource_asset.PlanValue{}.AttributeTypes(ctx),
-		map[string]attr.Value{
-			"commitment_interval": commitmentVal,
-			"is_commitment_plan":  types.BoolPointerValue(plan.IsCommitmentPlan),
-			"plan_name":           types.StringPointerValue(plan.PlanName),
-		},
-	)
-	diags.Append(d...)
-
-	return val, diags
-}
-
-func mapCommitmentIntervalToValue(ctx context.Context, ci *models.SubscriptionPlanCommitmentInterval) (resource_asset.CommitmentIntervalValue, diag.Diagnostics) {
-	if ci == nil {
-		return resource_asset.NewCommitmentIntervalValueNull(), nil
-	}
-
-	val, d := resource_asset.NewCommitmentIntervalValue(
-		resource_asset.CommitmentIntervalValue{}.AttributeTypes(ctx),
-		map[string]attr.Value{
-			"end_time":   types.Int64PointerValue(ci.EndTime),
-			"start_time": types.Int64PointerValue(ci.StartTime),
-		},
-	)
-
-	return val, d
-}
-
-func mapRenewalSettingsToValue(ctx context.Context, rs *models.RenewalSettings) (resource_asset.RenewalSettingsValue, diag.Diagnostics) {
-	if rs == nil {
-		return resource_asset.NewRenewalSettingsValueNull(), nil
-	}
-
-	val, d := resource_asset.NewRenewalSettingsValue(
-		resource_asset.RenewalSettingsValue{}.AttributeTypes(ctx),
-		map[string]attr.Value{
-			"renewal_type": types.StringPointerValue(rs.RenewalType),
-		},
-	)
-
-	return val, d
-}
-
-func mapSeatsToValue(ctx context.Context, seats *models.Seats) (resource_asset.SeatsValue, diag.Diagnostics) {
-	if seats == nil {
-		return resource_asset.NewSeatsValueNull(), nil
-	}
-
-	val, d := resource_asset.NewSeatsValue(
-		resource_asset.SeatsValue{}.AttributeTypes(ctx),
-		map[string]attr.Value{
-			"licensed_number_of_seats": types.Int64PointerValue(seats.LicensedNumberOfSeats),
-			"maximum_number_of_seats":  types.Int64PointerValue(seats.MaximumNumberOfSeats),
-			"number_of_seats":          types.Int64PointerValue(seats.NumberOfSeats),
-		},
-	)
-
-	return val, d
 }

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -27,7 +27,7 @@ import (
 // renaming alias types like allocation_rule → attribution).
 //
 // Used by: Create, Update
-// NOT used by: Read, ImportState (which use populateState / mapBudgetToModel directly).
+// NOT used by: Read, ImportState (which use populateState → mapBudgetToModel).
 func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI, plan *budgetResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 

--- a/internal/provider/datahub_dataset.go
+++ b/internal/provider/datahub_dataset.go
@@ -1,0 +1,91 @@
+// Package provider implements the DoiT Terraform provider.
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// populateState fetches the dataset from the API and populates the Terraform state.
+// On 404, state.Name is set to null to signal Terraform to remove the resource from state.
+func (r *datahubDatasetResource) populateState(ctx context.Context, state *datahubDatasetResourceModel) diag.Diagnostics {
+	datasetResp, err := r.client.GetDatahubDatasetWithResponse(ctx, state.Name.ValueString())
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading DataHub Dataset", "Could not read dataset "+state.Name.ValueString()+": "+err.Error()),
+		}
+	}
+
+	if datasetResp.StatusCode() == 404 {
+		state.Name = types.StringNull()
+		return nil
+	}
+
+	if datasetResp.StatusCode() != 200 {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading DataHub Dataset", fmt.Sprintf("Unexpected status code %d for dataset %s: %s", datasetResp.StatusCode(), state.Name.ValueString(), string(datasetResp.Body))),
+		}
+	}
+
+	if datasetResp.JSON200 == nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading DataHub Dataset", "Received empty response body for dataset "+state.Name.ValueString()),
+		}
+	}
+
+	mapDatahubDatasetToModel(datasetResp.JSON200.Name, datasetResp.JSON200.Description, datasetResp.JSON200.Records, datasetResp.JSON200.UpdatedBy, datasetResp.JSON200.LastUpdated, state)
+	return nil
+}
+
+// mapDatahubDatasetToModel maps the API response to the Terraform model.
+func mapDatahubDatasetToModel(name, description *string, records *int64, updatedBy, lastUpdated *string, state *datahubDatasetResourceModel) {
+	state.Name = types.StringPointerValue(name)
+	state.Description = types.StringPointerValue(description)
+	state.Records = types.Int64PointerValue(records)
+	state.UpdatedBy = types.StringPointerValue(updatedBy)
+	state.LastUpdated = types.StringPointerValue(lastUpdated)
+}
+
+// overlayDatahubDatasetComputedFields uses the two-phase overlay pattern to
+// reconcile the Terraform plan with the API response after Create/Update.
+func overlayDatahubDatasetComputedFields(name, description *string, records *int64, updatedBy, lastUpdated *string, plan *datahubDatasetResourceModel) {
+	// Phase 1: Build fully-resolved state from API response.
+	resolved := *plan
+	mapDatahubDatasetToModel(name, description, records, updatedBy, lastUpdated, &resolved)
+
+	// Phase 2: Overlay.
+	// Name: Required — never touch.
+	// Records, UpdatedBy, LastUpdated: Computed-only — always from resolved.
+	plan.Records = resolved.Records
+	plan.UpdatedBy = resolved.UpdatedBy
+	plan.LastUpdated = resolved.LastUpdated
+
+	// Description: Optional+Computed — resolve when Unknown.
+	if plan.Description.IsUnknown() {
+		plan.Description = resolved.Description
+	}
+}
+
+// toCreateRequest converts the TF model to a CreateDatahubDatasetRequestBody.
+func (plan *datahubDatasetResourceModel) toCreateRequest() models.CreateDatahubDatasetRequestBody {
+	req := models.CreateDatahubDatasetRequestBody{
+		Name: plan.Name.ValueString(),
+	}
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		req.Description = new(plan.Description.ValueString())
+	}
+	return req
+}
+
+// toUpdateRequest converts the TF model to an UpdateDatahubDatasetRequestBody.
+func (plan *datahubDatasetResourceModel) toUpdateRequest() models.UpdateDatahubDatasetRequestBody {
+	req := models.UpdateDatahubDatasetRequestBody{}
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		req.Description = new(plan.Description.ValueString())
+	}
+	return req
+}

--- a/internal/provider/datahub_dataset_resource.go
+++ b/internal/provider/datahub_dataset_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type (
@@ -79,26 +78,6 @@ func (r *datahubDatasetResource) Schema(ctx context.Context, _ resource.SchemaRe
 	})
 }
 
-// overlayDatahubDatasetComputedFields uses the two-phase overlay pattern to
-// reconcile the Terraform plan with the API response after Create/Update.
-func overlayDatahubDatasetComputedFields(name, description *string, records *int64, updatedBy, lastUpdated *string, plan *datahubDatasetResourceModel) {
-	// Phase 1: Build fully-resolved state from API response.
-	resolved := *plan
-	mapDatahubDatasetToModel(name, description, records, updatedBy, lastUpdated, &resolved)
-
-	// Phase 2: Overlay.
-	// Name: Required — never touch.
-	// Records, UpdatedBy, LastUpdated: Computed-only — always from resolved.
-	plan.Records = resolved.Records
-	plan.UpdatedBy = resolved.UpdatedBy
-	plan.LastUpdated = resolved.LastUpdated
-
-	// Description: Optional+Computed — resolve when Unknown.
-	if plan.Description.IsUnknown() {
-		plan.Description = resolved.Description
-	}
-}
-
 func (r *datahubDatasetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan datahubDatasetResourceModel
 
@@ -115,12 +94,7 @@ func (r *datahubDatasetResource) Create(ctx context.Context, req resource.Create
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	apiReq := models.CreateDatahubDatasetRequestBody{
-		Name: plan.Name.ValueString(),
-	}
-	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
-		apiReq.Description = new(plan.Description.ValueString())
-	}
+	apiReq := plan.toCreateRequest()
 
 	createResp, err := r.client.CreateDatahubDatasetWithResponse(ctx, apiReq)
 	if err != nil {
@@ -147,8 +121,6 @@ func (r *datahubDatasetResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	// Plan-first state pattern: overlay Computed-only fields and resolve
-	// Optional+Computed fields (description) from the API when unknown.
 	overlayDatahubDatasetComputedFields(createResp.JSON201.Name, createResp.JSON201.Description, createResp.JSON201.Records, createResp.JSON201.UpdatedBy, createResp.JSON201.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -170,37 +142,17 @@ func (r *datahubDatasetResource) Read(ctx context.Context, req resource.ReadRequ
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	datasetResp, err := r.client.GetDatahubDatasetWithResponse(ctx, state.Name.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading DataHub Dataset",
-			"Could not read dataset "+state.Name.ValueString()+": "+err.Error(),
-		)
+	diags = r.populateState(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if datasetResp.StatusCode() == 404 {
+	// Handle externally deleted resource (populateState sets Name to null on 404)
+	if state.Name.IsNull() {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-
-	if datasetResp.StatusCode() != 200 {
-		resp.Diagnostics.AddError(
-			"Error Reading DataHub Dataset",
-			fmt.Sprintf("Unexpected status code %d for dataset %s: %s", datasetResp.StatusCode(), state.Name.ValueString(), string(datasetResp.Body)),
-		)
-		return
-	}
-
-	if datasetResp.JSON200 == nil {
-		resp.Diagnostics.AddError(
-			"Error Reading DataHub Dataset",
-			"Received empty response body for dataset "+state.Name.ValueString(),
-		)
-		return
-	}
-
-	mapDatahubDatasetToModel(datasetResp.JSON200.Name, datasetResp.JSON200.Description, datasetResp.JSON200.Records, datasetResp.JSON200.UpdatedBy, datasetResp.JSON200.LastUpdated, &state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -222,16 +174,12 @@ func (r *datahubDatasetResource) Update(ctx context.Context, req resource.Update
 	defer cancel()
 
 	var state datahubDatasetResourceModel
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	apiReq := models.UpdateDatahubDatasetRequestBody{}
-	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
-		apiReq.Description = new(plan.Description.ValueString())
-	}
+	apiReq := plan.toUpdateRequest()
 
 	updateResp, err := r.client.UpdateDatahubDatasetWithResponse(ctx, state.Name.ValueString(), apiReq)
 	if err != nil {
@@ -258,8 +206,6 @@ func (r *datahubDatasetResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// Plan-first state pattern: overlay Computed-only fields and resolve
-	// Optional+Computed fields (description) from the API when unknown.
 	overlayDatahubDatasetComputedFields(updateResp.JSON200.Name, updateResp.JSON200.Description, updateResp.JSON200.Records, updateResp.JSON200.UpdatedBy, updateResp.JSON200.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -297,12 +243,4 @@ func (r *datahubDatasetResource) Delete(ctx context.Context, req resource.Delete
 		)
 		return
 	}
-}
-
-func mapDatahubDatasetToModel(name, description *string, records *int64, updatedBy, lastUpdated *string, state *datahubDatasetResourceModel) {
-	state.Name = types.StringPointerValue(name)
-	state.Description = types.StringPointerValue(description)
-	state.Records = types.Int64PointerValue(records)
-	state.UpdatedBy = types.StringPointerValue(updatedBy)
-	state.LastUpdated = types.StringPointerValue(lastUpdated)
 }

--- a/internal/provider/folder.go
+++ b/internal/provider/folder.go
@@ -2,9 +2,44 @@
 package provider
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// populateState fetches the folder from the API and populates the Terraform state.
+// On 404, state.Id is set to null to signal Terraform to remove the resource from state.
+func (r *folderResource) populateState(ctx context.Context, state *folderResourceModel) diag.Diagnostics {
+	folderResp, err := r.client.GetFolderWithResponse(ctx, state.Id.ValueString())
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Folder", "Could not read folder ID "+state.Id.ValueString()+": "+err.Error()),
+		}
+	}
+
+	if folderResp.StatusCode() == 404 {
+		state.Id = types.StringNull()
+		return nil
+	}
+
+	if folderResp.StatusCode() != 200 {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Folder", fmt.Sprintf("Unexpected status code %d for folder ID %s: %s", folderResp.StatusCode(), state.Id.ValueString(), string(folderResp.Body))),
+		}
+	}
+
+	if folderResp.JSON200 == nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Folder", "Received empty response body for folder ID "+state.Id.ValueString()),
+		}
+	}
+
+	mapFolderToModel(folderResp.JSON200, state)
+	return nil
+}
 
 // mapFolderToModel maps the API response to the Terraform model.
 // Used by Read and ImportState (full mapping from API response).
@@ -60,4 +95,42 @@ func overlayFolderComputedFields(apiResp *models.Folder, plan *folderResourceMod
 	}
 
 	// name: Required — never touch.
+}
+
+// toCreateRequest converts the TF model to a CreateFolderRequest.
+func (plan *folderResourceModel) toCreateRequest() models.CreateFolderRequest {
+	req := models.CreateFolderRequest{
+		Name: plan.Name.ValueString(),
+	}
+
+	if !plan.ParentFolderId.IsNull() && !plan.ParentFolderId.IsUnknown() {
+		req.ParentFolderId = new(plan.ParentFolderId.ValueString())
+	} else {
+		req.ParentFolderId = new("root")
+	}
+
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		req.Description = new(plan.Description.ValueString())
+	}
+
+	return req
+}
+
+// toUpdateRequest converts the TF model to an UpdateFolderRequest.
+func (plan *folderResourceModel) toUpdateRequest() models.UpdateFolderRequest {
+	req := models.UpdateFolderRequest{
+		Name: new(plan.Name.ValueString()),
+	}
+
+	if !plan.ParentFolderId.IsNull() && !plan.ParentFolderId.IsUnknown() {
+		req.ParentFolderId = new(plan.ParentFolderId.ValueString())
+	} else {
+		req.ParentFolderId = new("root")
+	}
+
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		req.Description = new(plan.Description.ValueString())
+	}
+
+	return req
 }

--- a/internal/provider/folder_resource.go
+++ b/internal/provider/folder_resource.go
@@ -108,21 +108,8 @@ func (r *folderResource) Create(ctx context.Context, req resource.CreateRequest,
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	// Build API request. The API defaults to the root level when
-	// parent_folder_id is omitted; we send "root" explicitly for clarity.
-	apiReq := models.CreateFolderRequest{
-		Name: plan.Name.ValueString(),
-	}
-
-	if !plan.ParentFolderId.IsNull() && !plan.ParentFolderId.IsUnknown() {
-		apiReq.ParentFolderId = new(plan.ParentFolderId.ValueString())
-	} else {
-		apiReq.ParentFolderId = new("root")
-	}
-
-	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
-		apiReq.Description = new(plan.Description.ValueString())
-	}
+	// Build API request
+	apiReq := plan.toCreateRequest()
 
 	// Create new folder via API
 	folderResp, err := r.client.CreateFolderWithResponse(ctx, apiReq)
@@ -174,41 +161,17 @@ func (r *folderResource) Read(ctx context.Context, req resource.ReadRequest, res
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// Get refreshed folder from API
-	folderResp, err := r.client.GetFolderWithResponse(ctx, state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Folder",
-			"Could not read folder ID "+state.Id.ValueString()+": "+err.Error(),
-		)
+	diags = r.populateState(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Handle externally deleted resource - remove from state
-	if folderResp.StatusCode() == 404 {
+	// Handle externally deleted resource (populateState sets Id to null on 404)
+	if state.Id.IsNull() {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-
-	// Check for successful response
-	if folderResp.StatusCode() != 200 {
-		resp.Diagnostics.AddError(
-			"Error Reading Folder",
-			fmt.Sprintf("Unexpected status code %d for folder ID %s: %s", folderResp.StatusCode(), state.Id.ValueString(), string(folderResp.Body)),
-		)
-		return
-	}
-
-	if folderResp.JSON200 == nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Folder",
-			"Received empty response body for folder ID "+state.Id.ValueString(),
-		)
-		return
-	}
-
-	// Map response to state (full mapping for Read path)
-	mapFolderToModel(folderResp.JSON200, &state)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -239,20 +202,8 @@ func (r *folderResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 	folderID := state.Id.ValueString()
 
-	// Build API request. Default parent_folder_id to "root" when unset.
-	apiReq := models.UpdateFolderRequest{
-		Name: new(plan.Name.ValueString()),
-	}
-
-	if !plan.ParentFolderId.IsNull() && !plan.ParentFolderId.IsUnknown() {
-		apiReq.ParentFolderId = new(plan.ParentFolderId.ValueString())
-	} else {
-		apiReq.ParentFolderId = new("root")
-	}
-
-	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
-		apiReq.Description = new(plan.Description.ValueString())
-	}
+	// Build API request
+	apiReq := plan.toUpdateRequest()
 
 	// Update folder via API
 	updateResp, err := r.client.UpdateFolderWithResponse(ctx, folderID, apiReq)

--- a/internal/provider/insight.go
+++ b/internal/provider/insight.go
@@ -1,0 +1,46 @@
+// Package provider implements the DoiT Terraform provider.
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// populateState fetches the insight from the API and populates the Terraform state.
+// On 404, state.InsightKey is set to null to signal Terraform to remove the resource from state.
+func (r *insightResource) populateState(ctx context.Context, state *insightResourceModel) diag.Diagnostics {
+	sourceID := state.SourceId.ValueString()
+	insightKey := state.InsightKey.ValueString()
+
+	// Handle import: derive defaults when fields are empty
+	if sourceID == "" {
+		sourceID = string(models.PostInsightResultParamsSourceIDPublicApi)
+	}
+	if insightKey == "" {
+		insightKey = state.Key.ValueString()
+	}
+
+	getResp, err := r.client.GetInsightResultWithResponse(ctx, sourceID, insightKey)
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Insight", fmt.Sprintf("Could not read insight %s/%s: %s", sourceID, insightKey, err.Error())),
+		}
+	}
+
+	if getResp.StatusCode() == 404 {
+		state.InsightKey = types.StringNull()
+		return nil
+	}
+
+	if getResp.StatusCode() != 200 || getResp.JSON200 == nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Insight", fmt.Sprintf("Unexpected status %d for insight %s/%s: %s", getResp.StatusCode(), sourceID, insightKey, string(getResp.Body))),
+		}
+	}
+
+	return mapInsightRespToResourceModel(ctx, getResp.JSON200, state)
+}

--- a/internal/provider/insight_resource.go
+++ b/internal/provider/insight_resource.go
@@ -113,9 +113,9 @@ func (r *insightResource) Schema(ctx context.Context, _ resource.SchemaRequest, 
 	resp.Schema = s
 }
 
-// buildInsightRequest constructs the API request body from the Terraform plan.
+// toInsightRequest constructs the API request body from the Terraform plan.
 // Resource results are now managed by the separate doit_insight_resource_results resource.
-func buildInsightRequest(ctx context.Context, plan *insightResourceModel) (*models.InsightMetadataRequest, diag.Diagnostics) {
+func (plan *insightResourceModel) toInsightRequest(ctx context.Context) (*models.InsightMetadataRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	req := models.InsightMetadataRequest{
@@ -245,7 +245,7 @@ func (r *insightResource) Create(ctx context.Context, req resource.CreateRequest
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	apiReq, buildDiags := buildInsightRequest(ctx, &plan)
+	apiReq, buildDiags := plan.toInsightRequest(ctx)
 	resp.Diagnostics.Append(buildDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -305,43 +305,15 @@ func (r *insightResource) Read(ctx context.Context, req resource.ReadRequest, re
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	sourceID := state.SourceId.ValueString()
-	insightKey := state.InsightKey.ValueString()
-
-	// Handle import: if source_id or insight_key is missing, derive from key
-	if sourceID == "" {
-		sourceID = string(models.PostInsightResultParamsSourceIDPublicApi)
-	}
-	if insightKey == "" {
-		insightKey = state.Key.ValueString()
-	}
-
-	getResp, err := r.client.GetInsightResultWithResponse(ctx, sourceID, insightKey)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Insight",
-			fmt.Sprintf("Could not read insight %s/%s: %s", sourceID, insightKey, err.Error()),
-		)
-		return
-	}
-
-	// Handle externally deleted resource
-	if getResp.StatusCode() == 404 {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	if getResp.StatusCode() != 200 || getResp.JSON200 == nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Insight",
-			fmt.Sprintf("Unexpected status %d for insight %s/%s: %s", getResp.StatusCode(), sourceID, insightKey, string(getResp.Body)),
-		)
-		return
-	}
-
-	// Map full response to state — Read uses full mapping, not overlay
-	resp.Diagnostics.Append(mapInsightRespToResourceModel(ctx, getResp.JSON200, &state)...)
+	diags := r.populateState(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Handle externally deleted resource (populateState sets InsightKey to null on 404)
+	if state.InsightKey.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -364,7 +336,7 @@ func (r *insightResource) Update(ctx context.Context, req resource.UpdateRequest
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	apiReq, buildDiags := buildInsightRequest(ctx, &plan)
+	apiReq, buildDiags := plan.toInsightRequest(ctx)
 	resp.Diagnostics.Append(buildDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/insight_resource_results_resource.go
+++ b/internal/provider/insight_resource_results_resource.go
@@ -124,8 +124,8 @@ func (r *insightResourceResultsResource) Schema(ctx context.Context, _ resource.
 	resp.Schema = s
 }
 
-// buildResourceResultsRequest builds the API request body from the plan.
-func buildResourceResultsRequest(ctx context.Context, plan *insightResourceResultsModel) (*models.CreateResourceResultsBody, diag.Diagnostics) {
+// toResourceResultsRequest builds the API request body from the plan.
+func (plan *insightResourceResultsModel) toResourceResultsRequest(ctx context.Context) (*models.CreateResourceResultsBody, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var elements []rr.ResourceResultsValue
@@ -619,7 +619,7 @@ func (r *insightResourceResultsResource) Create(ctx context.Context, req resourc
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	apiReq, buildDiags := buildResourceResultsRequest(ctx, &plan)
+	apiReq, buildDiags := plan.toResourceResultsRequest(ctx)
 	resp.Diagnostics.Append(buildDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -725,7 +725,7 @@ func (r *insightResourceResultsResource) Update(ctx context.Context, req resourc
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	apiReq, buildDiags := buildResourceResultsRequest(ctx, &plan)
+	apiReq, buildDiags := plan.toResourceResultsRequest(ctx)
 	resp.Diagnostics.Append(buildDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/label.go
+++ b/internal/provider/label.go
@@ -2,11 +2,45 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// populateState fetches the label from the API and populates the Terraform state.
+// On 404, state.Id is set to null to signal Terraform to remove the resource from state.
+func (r *labelResource) populateState(ctx context.Context, state *labelResourceModel) diag.Diagnostics {
+	labelResp, err := r.client.GetLabelWithResponse(ctx, state.Id.ValueString())
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Label", "Could not read label ID "+state.Id.ValueString()+": "+err.Error()),
+		}
+	}
+
+	if labelResp.StatusCode() == 404 {
+		state.Id = types.StringNull()
+		return nil
+	}
+
+	if labelResp.StatusCode() != 200 {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Label", fmt.Sprintf("Unexpected status code %d for label ID %s: %s", labelResp.StatusCode(), state.Id.ValueString(), string(labelResp.Body))),
+		}
+	}
+
+	if labelResp.JSON200 == nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("Error Reading Label", "Received empty response body for label ID "+state.Id.ValueString()),
+		}
+	}
+
+	mapLabelToModel(labelResp.JSON200, state)
+	return nil
+}
 
 // mapLabelToModel maps the API response to the Terraform model.
 func mapLabelToModel(resp *models.LabelListItem, state *labelResourceModel) {
@@ -51,4 +85,20 @@ func overlayLabelComputedFields(apiResp *models.LabelListItem, plan *labelResour
 	plan.UpdateTime = resolved.UpdateTime
 
 	// Name, Color: Required — never touch.
+}
+
+// toCreateRequest converts the TF model to a CreateLabelRequest.
+func (plan *labelResourceModel) toCreateRequest() models.CreateLabelRequest {
+	return models.CreateLabelRequest{
+		Color: models.CreateLabelRequestColor(plan.Color.ValueString()),
+		Name:  plan.Name.ValueString(),
+	}
+}
+
+// toUpdateRequest converts the TF model to an UpdateLabelRequest.
+func (plan *labelResourceModel) toUpdateRequest() models.UpdateLabelRequest {
+	return models.UpdateLabelRequest{
+		Color: new(models.UpdateLabelRequestColor(plan.Color.ValueString())),
+		Name:  new(plan.Name.ValueString()),
+	}
 }

--- a/internal/provider/label_resource.go
+++ b/internal/provider/label_resource.go
@@ -108,11 +108,7 @@ func (r *labelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	defer cancel()
 
 	// Convert model to API request type
-	color := models.CreateLabelRequestColor(plan.Color.ValueString())
-	apiReq := models.CreateLabelRequest{
-		Color: color,
-		Name:  plan.Name.ValueString(),
-	}
+	apiReq := plan.toCreateRequest()
 
 	// Create new label via API
 	labelResp, err := r.client.CreateLabelWithResponse(ctx, apiReq)
@@ -164,41 +160,17 @@ func (r *labelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// Get refreshed label value from API
-	labelResp, err := r.client.GetLabelWithResponse(ctx, state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Label",
-			"Could not read label ID "+state.Id.ValueString()+": "+err.Error(),
-		)
+	diags = r.populateState(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Handle externally deleted resource - remove from state
-	if labelResp.StatusCode() == 404 {
+	// Handle externally deleted resource (populateState sets Id to null on 404)
+	if state.Id.IsNull() {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-
-	// Check for successful response
-	if labelResp.StatusCode() != 200 {
-		resp.Diagnostics.AddError(
-			"Error Reading Label",
-			fmt.Sprintf("Unexpected status code %d for label ID %s: %s", labelResp.StatusCode(), state.Id.ValueString(), string(labelResp.Body)),
-		)
-		return
-	}
-
-	if labelResp.JSON200 == nil {
-		resp.Diagnostics.AddError(
-			"Error Reading Label",
-			"Received empty response body for label ID "+state.Id.ValueString(),
-		)
-		return
-	}
-
-	// Map response to state
-	mapLabelToModel(labelResp.JSON200, &state)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -229,14 +201,8 @@ func (r *labelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	labelID := state.Id.ValueString()
 
-	// Convert model to API request type.
-	// Both color and name are required fields in the schema, so they will always
-	// be present. We use pointers here because UpdateLabelRequest uses pointer
-	// types for PATCH semantics, but we always send both fields.
-	apiReq := models.UpdateLabelRequest{
-		Color: new(models.UpdateLabelRequestColor(plan.Color.ValueString())),
-		Name:  new(plan.Name.ValueString()),
-	}
+	// Convert model to API request type
+	apiReq := plan.toUpdateRequest()
 
 	// Update label via API
 	updateResp, err := r.client.UpdateLabelWithResponse(ctx, labelID, apiReq)

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -18,7 +18,7 @@ import (
 // plan and selectively resolves only Unknown (Optional+Computed) fields from the API response.
 //
 // Strategy: Two-phase approach
-//  1. Use populateState to build a fully-resolved state from the API response.
+//  1. Use mapReportToModel to build a fully-resolved state from the API response.
 //     This resolves all Optional+Computed fields that the user omitted (Unknown).
 //  2. Walk the plan and overlay all Known values on top of the resolved state.
 //     This ensures user-configured values are preserved exactly as specified,
@@ -27,18 +27,18 @@ import (
 //
 // This eliminates the entire class of "Provider produced inconsistent result" errors
 // for Create/Update operations. Sentinel restoration, alias normalization, and timestamp
-// preservation in populateState are harmless here — they only affect Unknown values
+// preservation in mapReportToModel are harmless here — they only affect Unknown values
 // that the user didn't configure, where the API's normalized form is acceptable.
 //
 // Used by: Create, Update
-// NOT used by: Read, ImportState (which use populateState / populateStateFromAPI directly).
-func (r *reportResource) overlayReportComputedFields(ctx context.Context, apiResp *models.ExternalReport, plan *reportResourceModel) diag.Diagnostics {
+// NOT used by: Read, ImportState (which use mapReportToModel directly).
+func overlayReportComputedFields(ctx context.Context, apiResp *models.ExternalReport, plan *reportResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Phase 1: Build fully-resolved state from API response.
 	// This gives us known values for every Optional+Computed field the user omitted.
 	var resolved reportResourceModel
-	diags.Append(r.populateState(ctx, &resolved, apiResp)...)
+	diags.Append(mapReportToModel(ctx, apiResp, &resolved)...)
 	if diags.HasError() {
 		return diags
 	}
@@ -541,66 +541,23 @@ func mergeSentinelValues(apiValues []string, stateVals []string, apiIncludeNull 
 	return result
 }
 
-// populateStateFromAPI fetches the report from the API and populates the Terraform state.
+// populateState fetches the report from the API and populates the Terraform state.
+// This is used by Read and ImportState. Create and Update use overlayReportComputedFields
+// with the API response instead.
 //
-// # 404 Handling Strategy
-//
-// The allowNotFound parameter controls how 404 responses are handled:
-//
-//   - allowNotFound=true (used by Read):
-//     404 means the resource was deleted externally (outside Terraform).
-//     We set state.Id to null, which signals Terraform to remove the resource
-//     from state. On next plan, Terraform will propose recreating it.
-//     This is the standard Terraform pattern for "externally deleted" resources.
-//
-//   - allowNotFound=false (used by Create and Update):
-//     404 is unexpected and indicates an error. After a successful Create or
-//     Update API call, the resource MUST exist. A 404 here could indicate:
-//
-//   - A transient API issue (rare, but possible)
-//
-//   - An eventual consistency problem
-//
-//   - A bug in the provider or API
-//     In these cases, we return an error so the user knows something went wrong
-//     and can retry. This prevents silent resource orphaning.
-//
-// # Why This Matters
-//
-// Without this distinction, a transient 404 during Create would:
-//  1. Create the resource successfully (API returns 201 with ID)
-//  2. GET returns 404 (transient issue)
-//  3. populateStateFromAPI sets state.Id = null (no error!)
-//  4. Terraform "succeeds" but loses track of the resource
-//  5. Resource is orphaned - exists in API but not in Terraform state
-//
-// With allowNotFound=false for Create/Update, step 3 returns an error,
-// the user sees the failure, and can retry or investigate.
-func (r *reportResource) populateStateFromAPI(ctx context.Context, id string, state *reportResourceModel, allowNotFound bool) diag.Diagnostics {
-	reportResp, err := r.client.GetReportConfigWithResponse(ctx, id)
+// On 404, state.Id is set to null to signal Terraform to remove the resource from state.
+func (r *reportResource) populateState(ctx context.Context, state *reportResourceModel) diag.Diagnostics {
+	reportResp, err := r.client.GetReportConfigWithResponse(ctx, state.Id.ValueString())
 	if err != nil {
 		return diag.Diagnostics{
 			diag.NewErrorDiagnostic("Error reading report", "Could not read report config, unexpected error: "+err.Error()),
 		}
 	}
 
-	// Handle 404 based on context
+	// Handle externally deleted resource
 	if reportResp.StatusCode() == 404 {
-		if allowNotFound {
-			// Read context: Resource was deleted externally, mark for removal from state
-			state.Id = types.StringNull()
-			return nil
-		}
-		// Create/Update context: Resource should exist, 404 is an error
-		return diag.Diagnostics{
-			diag.NewErrorDiagnostic(
-				"Resource not found after operation",
-				"The report was successfully created/updated but could not be read back (404). "+
-					"This may indicate a transient API issue. Please retry the operation. "+
-					"If the problem persists, the resource may need to be imported manually. "+
-					"Report ID: "+id,
-			),
-		}
+		state.Id = types.StringNull()
+		return nil
 	}
 
 	if reportResp.StatusCode() != 200 {
@@ -615,7 +572,7 @@ func (r *reportResource) populateStateFromAPI(ctx context.Context, id string, st
 		}
 	}
 
-	return r.populateState(ctx, state, reportResp.JSON200)
+	return mapReportToModel(ctx, reportResp.JSON200, state)
 }
 
 func (plan *reportResourceModel) toCreateRequest(ctx context.Context) (req models.CreateReportJSONRequestBody, diags diag.Diagnostics) {
@@ -952,7 +909,7 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	return externalConfig, diags
 }
 
-func (r *reportResource) populateState(ctx context.Context, state *reportResourceModel, resp *models.ExternalReport) diag.Diagnostics {
+func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *reportResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	state.Id = types.StringPointerValue(resp.Id)

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -31,7 +31,7 @@ import (
 // that the user didn't configure, where the API's normalized form is acceptable.
 //
 // Used by: Create, Update
-// NOT used by: Read, ImportState (which use mapReportToModel directly).
+// NOT used by: Read, ImportState (which use populateState → mapReportToModel).
 func overlayReportComputedFields(ctx context.Context, apiResp *models.ExternalReport, plan *reportResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 

--- a/internal/provider/report_resource.go
+++ b/internal/provider/report_resource.go
@@ -26,14 +26,15 @@ func NewReportResource() resource.Resource {
 	return &reportResource{}
 }
 
-type reportResource struct {
-	client *models.ClientWithResponses
-}
-
-type reportResourceModel struct {
-	resource_report.ReportModel
-	Timeouts timeouts.Value `tfsdk:"timeouts"`
-}
+type (
+	reportResource struct {
+		client *models.ClientWithResponses
+	}
+	reportResourceModel struct {
+		resource_report.ReportModel
+		Timeouts timeouts.Value `tfsdk:"timeouts"`
+	}
+)
 
 func (r *reportResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_report"
@@ -154,7 +155,7 @@ func (r *reportResource) Create(ctx context.Context, req resource.CreateRequest,
 	// fields from the API response (id, type, labels, name, description, and nested
 	// config fields). This avoids API normalization drift (sentinel stripping, alias
 	// renaming, etc.) for all user-configured values.
-	diags = r.overlayReportComputedFields(ctx, reportResp.JSON201, &plan)
+	diags = overlayReportComputedFields(ctx, reportResp.JSON201, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,14 +180,13 @@ func (r *reportResource) Read(ctx context.Context, req resource.ReadRequest, res
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// allowNotFound=true: 404 means resource was deleted externally, remove from state
-	diags = r.populateStateFromAPI(ctx, state.Id.ValueString(), &state, true)
+	diags = r.populateState(ctx, &state)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 
-	// Handle externally deleted resource (populateStateFromAPI sets Id to null on 404)
+	// Handle externally deleted resource (populateState sets Id to null on 404)
 	if state.Id.IsNull() {
 		resp.State.RemoveResource(ctx)
 		return
@@ -258,7 +258,7 @@ func (r *reportResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// fields from the API response (id, type, labels, name, description, and nested
 	// config fields). This avoids API normalization drift (sentinel stripping, alias
 	// renaming, etc.) for all user-configured values.
-	diags = r.overlayReportComputedFields(ctx, reportResp.JSON200, &plan)
+	diags = overlayReportComputedFields(ctx, reportResp.JSON200, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/user.go
+++ b/internal/provider/user.go
@@ -12,6 +12,25 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+// populateState fetches the user from the API and populates the Terraform state.
+// On nil user (not found), state.Id is set to null to signal Terraform to remove the resource.
+func (r *userResource) populateState(ctx context.Context, state *userResourceModel) diag.Diagnostics {
+	email := state.Id.ValueString()
+
+	user, diags := r.lookupUser(ctx, email)
+	if diags.HasError() {
+		return diags
+	}
+
+	if user == nil {
+		state.Id = types.StringNull()
+		return nil
+	}
+
+	mapUserToModel(user, state)
+	return nil
+}
+
 // normalizePhone restores the "+" prefix that the API strips from phone
 // country codes. The spec accepts "^\+[0-9]+$" but stores without the "+".
 func normalizePhone(phone *string) types.String {
@@ -173,4 +192,58 @@ func (r *userResource) lookupUser(ctx context.Context, email string) (*models.Us
 
 	users := *listResp.JSON200.Users
 	return &users[0], diags
+}
+
+// toInviteRequest converts the TF model to an InviteUserRequest (Create path).
+func (plan *userResourceModel) toInviteRequest() models.InviteUserRequest {
+	req := models.InviteUserRequest{
+		Email: openapi_types.Email(plan.Email.ValueString()),
+	}
+
+	if !plan.FirstName.IsNull() && !plan.FirstName.IsUnknown() {
+		req.FirstName = plan.FirstName.ValueStringPointer()
+	}
+	if !plan.LastName.IsNull() && !plan.LastName.IsUnknown() {
+		req.LastName = plan.LastName.ValueStringPointer()
+	}
+	if !plan.JobTitle.IsNull() && !plan.JobTitle.IsUnknown() {
+		req.JobTitle = new(models.InviteUserRequestJobTitle(plan.JobTitle.ValueString()))
+	}
+	if !plan.RoleId.IsNull() && !plan.RoleId.IsUnknown() {
+		req.RoleId = plan.RoleId.ValueStringPointer()
+	}
+	if !plan.OrganizationId.IsNull() && !plan.OrganizationId.IsUnknown() {
+		req.OrganizationId = plan.OrganizationId.ValueStringPointer()
+	}
+
+	return req
+}
+
+// toUpdateRequest converts the TF model to an UpdateUserRequest (Update path).
+func (plan *userResourceModel) toUpdateRequest() models.UpdateUserRequest {
+	req := models.UpdateUserRequest{}
+
+	if !plan.FirstName.IsNull() && !plan.FirstName.IsUnknown() {
+		req.FirstName = plan.FirstName.ValueStringPointer()
+	}
+	if !plan.LastName.IsNull() && !plan.LastName.IsUnknown() {
+		req.LastName = plan.LastName.ValueStringPointer()
+	}
+	if !plan.JobTitle.IsNull() && !plan.JobTitle.IsUnknown() {
+		req.JobTitle = new(models.UpdateUserRequestJobTitle(plan.JobTitle.ValueString()))
+	}
+	if !plan.RoleId.IsNull() && !plan.RoleId.IsUnknown() {
+		req.RoleId = plan.RoleId.ValueStringPointer()
+	}
+	if !plan.Phone.IsNull() && !plan.Phone.IsUnknown() {
+		req.Phone = plan.Phone.ValueStringPointer()
+	}
+	if !plan.PhoneExtension.IsNull() && !plan.PhoneExtension.IsUnknown() {
+		req.PhoneExtension = plan.PhoneExtension.ValueStringPointer()
+	}
+	if !plan.Language.IsNull() && !plan.Language.IsUnknown() {
+		req.Language = new(models.UpdateUserRequestLanguage(plan.Language.ValueString()))
+	}
+
+	return req
 }

--- a/internal/provider/user.go
+++ b/internal/provider/user.go
@@ -24,11 +24,11 @@ func (r *userResource) populateState(ctx context.Context, state *userResourceMod
 
 	if user == nil {
 		state.Id = types.StringNull()
-		return nil
+		return diags
 	}
 
 	mapUserToModel(user, state)
-	return nil
+	return diags
 }
 
 // normalizePhone restores the "+" prefix that the API strips from phone

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 type (
@@ -199,25 +198,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	defer cancel()
 
 	// Build invite request from plan.
-	apiReq := models.InviteUserRequest{
-		Email: openapi_types.Email(plan.Email.ValueString()),
-	}
-
-	if !plan.FirstName.IsNull() && !plan.FirstName.IsUnknown() {
-		apiReq.FirstName = plan.FirstName.ValueStringPointer()
-	}
-	if !plan.LastName.IsNull() && !plan.LastName.IsUnknown() {
-		apiReq.LastName = plan.LastName.ValueStringPointer()
-	}
-	if !plan.JobTitle.IsNull() && !plan.JobTitle.IsUnknown() {
-		apiReq.JobTitle = new(models.InviteUserRequestJobTitle(plan.JobTitle.ValueString()))
-	}
-	if !plan.RoleId.IsNull() && !plan.RoleId.IsUnknown() {
-		apiReq.RoleId = plan.RoleId.ValueStringPointer()
-	}
-	if !plan.OrganizationId.IsNull() && !plan.OrganizationId.IsUnknown() {
-		apiReq.OrganizationId = plan.OrganizationId.ValueStringPointer()
-	}
+	apiReq := plan.toInviteRequest()
 
 	// Invite the user.
 	inviteResp, err := r.client.InviteUserWithResponse(ctx, apiReq)
@@ -344,23 +325,17 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// id = email, use it to look up the user.
-	email := state.Id.ValueString()
-
-	user, lookupDiags := r.lookupUser(ctx, email)
-	resp.Diagnostics.Append(lookupDiags...)
+	diags = r.populateState(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Handle externally deleted resource — remove from state.
-	if user == nil {
+	// Handle externally deleted resource (populateState sets Id to null when not found)
+	if state.Id.IsNull() {
 		resp.State.RemoveResource(ctx)
 		return
 	}
-
-	// Full mapping from API response to state.
-	mapUserToModel(user, &state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -389,31 +364,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Build the update request from plan values.
-	// All Optional fields are sent — PATCH semantics with omitempty means
-	// null values won't be serialized.
-	patchReq := models.UpdateUserRequest{}
-
-	if !plan.FirstName.IsNull() && !plan.FirstName.IsUnknown() {
-		patchReq.FirstName = plan.FirstName.ValueStringPointer()
-	}
-	if !plan.LastName.IsNull() && !plan.LastName.IsUnknown() {
-		patchReq.LastName = plan.LastName.ValueStringPointer()
-	}
-	if !plan.JobTitle.IsNull() && !plan.JobTitle.IsUnknown() {
-		patchReq.JobTitle = new(models.UpdateUserRequestJobTitle(plan.JobTitle.ValueString()))
-	}
-	if !plan.RoleId.IsNull() && !plan.RoleId.IsUnknown() {
-		patchReq.RoleId = plan.RoleId.ValueStringPointer()
-	}
-	if !plan.Phone.IsNull() && !plan.Phone.IsUnknown() {
-		patchReq.Phone = plan.Phone.ValueStringPointer()
-	}
-	if !plan.PhoneExtension.IsNull() && !plan.PhoneExtension.IsUnknown() {
-		patchReq.PhoneExtension = plan.PhoneExtension.ValueStringPointer()
-	}
-	if !plan.Language.IsNull() && !plan.Language.IsUnknown() {
-		patchReq.Language = new(models.UpdateUserRequestLanguage(plan.Language.ValueString()))
-	}
+	patchReq := plan.toUpdateRequest()
 
 	updateResp, err := r.client.UpdateUserWithResponse(ctx, internalID, patchReq)
 	if err != nil {


### PR DESCRIPTION
## What Changed

Standardizes all provider resources to follow a consistent helper function pattern, making mechanical edits easier and reducing drift between resources.

### Code Changes

**Companion file extraction** (new files):
- `annotation.go`, `asset.go`, `datahub_dataset.go`, `insight.go` — extract `populateState`, `mapXxxToModel`, `overlayXxxComputedFields`, `toXxxRequest` helpers from `_resource.go` files
- `label.go`, `folder.go`, `user.go` — extended with additional helpers

**Signature/naming fixes**:
- `report.go`: Remove unnecessary receiver from `mapReportToModel` and `overlayReportComputedFields` (pure mapping, no `r.client` usage)
- `report.go`: Fix `mapReportToModel` parameter order `(state, resp)` → `(resp, state)` to match convention
- `report.go`: Remove extra `id string` parameter from `populateState` — reads from `state.Id` internally like all other resources
- `allocation.go`: Rename `overlayComputedFields` → `overlayAllocationComputedFields` (resource name prefix)
- `allocation.go`: Remove dead Required-field assignments flagged by `overlaycheck` linter
- `insight_resource.go`: Convert `buildInsightRequest(ctx, plan)` → `plan.toInsightRequest(ctx)`
- `insight_resource_results_resource.go`: Convert `buildResourceResultsRequest(ctx, plan)` → `plan.toResourceResultsRequest(ctx)`

### Skill Documentation Updates

- `implementation-conventions/SKILL.md`: Add receiver rule callout, strengthen helper function table
- `implement-resource/references/overlay-pattern.md`: Use resource-name-prefixed function names, standalone signatures
- `implement-resource/SKILL.md` and `implement-datasource/SKILL.md`: Updated for consistency

### Convention Summary

| Function | Receiver | Naming |
|----------|----------|--------|
| `populateState` | `(r *xResource)` ✅ needs `r.client` | — |
| `mapXxxToModel` | Standalone ❌ no receiver | Always prefixed: `mapReportToModel` |
| `overlayXxxComputedFields` | Standalone ❌ no receiver | Always prefixed: `overlayReportComputedFields` |
| `toXxxRequest` | `(plan *xModel)` ✅ method on plan | `toCreateRequest` / `toUpdateRequest` |

## How Validated

- `go build ./...` ✅
- `go vet ./internal/provider/...` ✅
- `golangci-lint` (pre-commit hooks) ✅
- `make testacc` — all resource tests pass (only pre-existing flaky `TestAccReportsDataSource_PageTokenOnly` failure)