### PR TITLE
feat(linters): add diagdrop linter to detect leaked diagnostics

### DIFF
--- a/.agent/skills/go-conventions/SKILL.md
+++ b/.agent/skills/go-conventions/SKILL.md
@@ -7,7 +7,7 @@ description: Go code style rules for the Terraform provider. Covers diagnostics 
 
 Code style rules that apply to **all** Go code in this provider. These are actively enforced by custom linters in `tools/linters/`.
 
-## Diagnostics Must Never Be Suppressed
+## Diagnostics Must Never Be Suppressed or Dropped
 
 **CRITICAL:** Never suppress `diag.Diagnostics` return values with `_`. All diagnostics must be properly handled:
 
@@ -29,6 +29,26 @@ This applies to all Terraform Framework functions that return diagnostics:
 - Any other function returning `diag.Diagnostics`
 
 > **Linter:** `diagsuppressed` — flags suppressed diagnostics.
+
+**Also:** never return `nil` when a `diag.Diagnostics` variable has been captured — this silently drops non-error diagnostics (e.g. warnings):
+
+```go
+// BAD — non-error diagnostics (warnings) silently lost
+func populateState(...) diag.Diagnostics {
+    user, diags := r.lookupUser(ctx, email)
+    if diags.HasError() { return diags }
+    return nil  // ← drops warnings in diags
+}
+
+// GOOD — all diagnostics propagated
+func populateState(...) diag.Diagnostics {
+    user, diags := r.lookupUser(ctx, email)
+    if diags.HasError() { return diags }
+    return diags
+}
+```
+
+> **Linter:** `diagdrop` — flags `return nil` that drops captured diagnostics.
 
 ## Generated Constructors (NewXxxValue)
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - gosec
     # Custom Terraform provider linters (tools/linters)
     - diagsuppressed
+    - diagdrop
     - structliteral
     - overlayinvariant
     - overlaycheck
@@ -90,6 +91,7 @@ linters:
           - constructor
           - newexpr
           - unknownguard
+          - diagdrop
       # Test files — exclude custom linters (except paralleltest which only applies to tests)
       - path: _test\.go
         linters:
@@ -107,6 +109,7 @@ linters:
           - constructor
           - newexpr
           - unknownguard
+          - diagdrop
       # Data sources — exclude resource-only linters
       - path: _data_source\.go
         linters:
@@ -210,6 +213,9 @@ linters:
       unknownguard:
         type: "module"
         description: "Ensures data source Read() checks for unknown inputs before API calls."
+      diagdrop:
+        type: "module"
+        description: "Detects return nil that drops captured diag.Diagnostics variables."
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/tools/linters/diagdrop/analyzer.go
+++ b/tools/linters/diagdrop/analyzer.go
@@ -47,8 +47,9 @@ const diagType = "github.com/hashicorp/terraform-plugin-framework/diag.Diagnosti
 
 // diagVarInfo holds information about a named diag.Diagnostics variable.
 type diagVarInfo struct {
-	name string
-	pos  token.Pos
+	name          string
+	pos           token.Pos
+	isAccumulator bool // true for named returns and var declarations, false for := temporaries
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -112,7 +113,7 @@ func checkFunc(pass *analysis.Pass, funcType *ast.FuncType, body *ast.BlockStmt)
 		}
 
 		// Find the first diag variable assigned before this return.
-		varName := firstDiagVarBefore(diagVars, ret.Pos())
+		varName := latestDiagVarBefore(diagVars, ret.Pos())
 		if varName == "" {
 			// No diag variable assigned before this return — safe early return.
 			return true
@@ -162,41 +163,61 @@ func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.Bloc
 			if typ != nil && isDiagnosticsType(typ) {
 				for _, name := range field.Names {
 					if name.Name != "" && name.Name != "_" {
-						vars = append(vars, diagVarInfo{name: name.Name, pos: 0})
+						vars = append(vars, diagVarInfo{name: name.Name, pos: 0, isAccumulator: true})
 					}
 				}
 			}
 		}
 	}
 
-	// Scan function body for assignments that capture diag.Diagnostics.
+	// Scan function body for var declarations (e.g. var diags diag.Diagnostics)
+	// and assignments (e.g. diags := lookupUser(...)) that capture diag.Diagnostics.
 	ast.Inspect(body, func(n ast.Node) bool {
-		assign, ok := n.(*ast.AssignStmt)
-		if !ok {
-			return true
-		}
-
-		for i, lhs := range assign.Lhs {
-			ident, ok := lhs.(*ast.Ident)
-			if !ok || ident.Name == "_" {
-				continue
+		switch node := n.(type) {
+		case *ast.GenDecl:
+			// Handle: var diags diag.Diagnostics
+			if node.Tok != token.VAR {
+				return true
 			}
-
-			var typ types.Type
-			if len(assign.Rhs) == 1 {
-				// Multi-return: check tuple position.
-				rhsType := pass.TypesInfo.TypeOf(assign.Rhs[0])
-				if tuple, ok := rhsType.(*types.Tuple); ok && i < tuple.Len() {
-					typ = tuple.At(i).Type()
-				} else if i == 0 {
-					typ = rhsType
+			for _, spec := range node.Specs {
+				vSpec, ok := spec.(*ast.ValueSpec)
+				if !ok || vSpec.Type == nil {
+					continue
 				}
-			} else if i < len(assign.Rhs) {
-				typ = pass.TypesInfo.TypeOf(assign.Rhs[i])
+				typ := pass.TypesInfo.TypeOf(vSpec.Type)
+				if typ != nil && isDiagnosticsType(typ) {
+					for _, name := range vSpec.Names {
+						if name.Name != "" && name.Name != "_" {
+							vars = append(vars, diagVarInfo{name: name.Name, pos: node.Pos(), isAccumulator: true})
+						}
+					}
+				}
 			}
 
-			if typ != nil && isDiagnosticsType(typ) {
-				vars = append(vars, diagVarInfo{name: ident.Name, pos: assign.Pos()})
+		case *ast.AssignStmt:
+			// Handle: diags := lookupUser(...) or d := mapToModel()
+			for i, lhs := range node.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || ident.Name == "_" {
+					continue
+				}
+
+				var typ types.Type
+				if len(node.Rhs) == 1 {
+					// Multi-return: check tuple position.
+					rhsType := pass.TypesInfo.TypeOf(node.Rhs[0])
+					if tuple, ok := rhsType.(*types.Tuple); ok && i < tuple.Len() {
+						typ = tuple.At(i).Type()
+					} else if i == 0 {
+						typ = rhsType
+					}
+				} else if i < len(node.Rhs) {
+					typ = pass.TypesInfo.TypeOf(node.Rhs[i])
+				}
+
+				if typ != nil && isDiagnosticsType(typ) {
+					vars = append(vars, diagVarInfo{name: ident.Name, pos: node.Pos()})
+				}
 			}
 		}
 		return true
@@ -205,15 +226,26 @@ func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.Bloc
 	return vars
 }
 
-// firstDiagVarBefore returns the name of the first diag variable assigned
-// before the given position, or "" if none.
-func firstDiagVarBefore(vars []diagVarInfo, pos token.Pos) string {
+// latestDiagVarBefore returns the name of the best diag variable to suggest
+// returning, among those declared or assigned before the given position.
+// It prefers accumulators (named returns, var declarations) over assignment
+// temporaries. Among equal-priority variables, it picks the latest.
+func latestDiagVarBefore(vars []diagVarInfo, pos token.Pos) string {
+	var best string
+	var bestPos token.Pos
+	var bestIsAccum bool
 	for _, v := range vars {
-		if v.pos < pos {
-			return v.name
+		if v.pos >= pos {
+			continue
+		}
+		// Prefer accumulators over temporaries; among same kind, prefer latest.
+		if best == "" || (v.isAccumulator && !bestIsAccum) || (v.isAccumulator == bestIsAccum && v.pos >= bestPos) {
+			best = v.name
+			bestPos = v.pos
+			bestIsAccum = v.isAccumulator
 		}
 	}
-	return ""
+	return best
 }
 
 // isNilLiteral checks if an expression is the nil identifier.

--- a/tools/linters/diagdrop/analyzer.go
+++ b/tools/linters/diagdrop/analyzer.go
@@ -1,0 +1,236 @@
+// Package diagdrop detects leaked diagnostics: functions that capture
+// diag.Diagnostics into a named variable but return nil on some paths,
+// silently dropping non-error diagnostics (e.g. warnings).
+//
+// Bad:
+//
+//	func populateState(...) diag.Diagnostics {
+//	    user, diags := r.lookupUser(ctx, email)
+//	    if diags.HasError() { return diags }
+//	    return nil  // ← drops non-error diags
+//	}
+//
+// Good:
+//
+//	func populateState(...) diag.Diagnostics {
+//	    user, diags := r.lookupUser(ctx, email)
+//	    if diags.HasError() { return diags }
+//	    return diags  // ← propagates all diags
+//	}
+//
+// Functions that never capture diagnostics into a named variable are excluded
+// (e.g. overlay helpers that return nil because they truly produce no diagnostics).
+//
+// Early-return nil guards that precede any diag variable assignment are also
+// excluded (e.g. `if x == nil { return NullValue(), nil }`).
+package diagdrop
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Analyzer is the go/analysis Analyzer for diagdrop.
+var Analyzer = &analysis.Analyzer{
+	Name:     "diagdrop",
+	Doc:      "Detects return nil that drops captured diag.Diagnostics (non-error diagnostics silently lost).",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+const diagType = "github.com/hashicorp/terraform-plugin-framework/diag.Diagnostics"
+
+// diagVarInfo holds information about a named diag.Diagnostics variable.
+type diagVarInfo struct {
+	name string
+	pos  token.Pos
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil), (*ast.FuncLit)(nil)}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		switch fn := n.(type) {
+		case *ast.FuncDecl:
+			if fn.Body != nil && fn.Type != nil {
+				checkFunc(pass, fn.Type, fn.Body)
+			}
+		case *ast.FuncLit:
+			if fn.Body != nil && fn.Type != nil {
+				checkFunc(pass, fn.Type, fn.Body)
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+// checkFunc analyzes a single function for the diagdrop pattern.
+func checkFunc(pass *analysis.Pass, funcType *ast.FuncType, body *ast.BlockStmt) {
+	// Step 1: Find which return-value position (if any) is diag.Diagnostics.
+	diagPos := findDiagReturnPos(pass, funcType)
+	if diagPos < 0 {
+		return
+	}
+
+	// Step 2: Collect all named diag.Diagnostics variables with their positions.
+	// Named return parameters are treated as having position 0 (always in scope).
+	diagVars := collectDiagVars(pass, funcType, body)
+	if len(diagVars) == 0 {
+		// No named diag.Diagnostics variable — function constructs diags inline.
+		// return nil is intentional (no diags to propagate).
+		return
+	}
+
+	// Step 3: Walk all return statements and flag return nil at the diag position
+	// only if a diag variable assignment precedes the return.
+	ast.Inspect(body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+
+		// Bare return (named returns) — not flagged; the named variable is implicitly returned.
+		if len(ret.Results) == 0 {
+			return true
+		}
+
+		// Find the expression at the diag.Diagnostics position.
+		if diagPos >= len(ret.Results) {
+			return true
+		}
+		expr := ret.Results[diagPos]
+
+		if !isNilLiteral(expr) {
+			return true
+		}
+
+		// Find the first diag variable assigned before this return.
+		varName := firstDiagVarBefore(diagVars, ret.Pos())
+		if varName == "" {
+			// No diag variable assigned before this return — safe early return.
+			return true
+		}
+
+		pass.Reportf(expr.Pos(),
+			"return nil drops captured diag.Diagnostics variable %q; return %s instead",
+			varName, varName)
+
+		return true
+	})
+}
+
+// findDiagReturnPos returns the 0-based index of the diag.Diagnostics return
+// value, or -1 if the function doesn't return diag.Diagnostics.
+func findDiagReturnPos(pass *analysis.Pass, funcType *ast.FuncType) int {
+	if funcType.Results == nil {
+		return -1
+	}
+
+	pos := 0
+	for _, field := range funcType.Results.List {
+		typ := pass.TypesInfo.TypeOf(field.Type)
+		if typ != nil && isDiagnosticsType(typ) {
+			return pos
+		}
+		// A field with multiple names (e.g. "a, b int") counts for each name.
+		names := len(field.Names)
+		if names == 0 {
+			names = 1
+		}
+		pos += names
+	}
+	return -1
+}
+
+// collectDiagVars returns all named diag.Diagnostics variables found in the
+// function signature (named return params) and body (assignments).
+// Named return parameters use position 0 to indicate they are always in scope.
+func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.BlockStmt) []diagVarInfo {
+	var vars []diagVarInfo
+
+	// Check named return parameters — always in scope (position 0).
+	if funcType.Results != nil {
+		for _, field := range funcType.Results.List {
+			typ := pass.TypesInfo.TypeOf(field.Type)
+			if typ != nil && isDiagnosticsType(typ) {
+				for _, name := range field.Names {
+					if name.Name != "" && name.Name != "_" {
+						vars = append(vars, diagVarInfo{name: name.Name, pos: 0})
+					}
+				}
+			}
+		}
+	}
+
+	// Scan function body for assignments that capture diag.Diagnostics.
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+
+		for i, lhs := range assign.Lhs {
+			ident, ok := lhs.(*ast.Ident)
+			if !ok || ident.Name == "_" {
+				continue
+			}
+
+			var typ types.Type
+			if len(assign.Rhs) == 1 {
+				// Multi-return: check tuple position.
+				rhsType := pass.TypesInfo.TypeOf(assign.Rhs[0])
+				if tuple, ok := rhsType.(*types.Tuple); ok && i < tuple.Len() {
+					typ = tuple.At(i).Type()
+				} else if i == 0 {
+					typ = rhsType
+				}
+			} else if i < len(assign.Rhs) {
+				typ = pass.TypesInfo.TypeOf(assign.Rhs[i])
+			}
+
+			if typ != nil && isDiagnosticsType(typ) {
+				vars = append(vars, diagVarInfo{name: ident.Name, pos: assign.Pos()})
+			}
+		}
+		return true
+	})
+
+	return vars
+}
+
+// firstDiagVarBefore returns the name of the first diag variable assigned
+// before the given position, or "" if none.
+func firstDiagVarBefore(vars []diagVarInfo, pos token.Pos) string {
+	for _, v := range vars {
+		if v.pos < pos {
+			return v.name
+		}
+	}
+	return ""
+}
+
+// isNilLiteral checks if an expression is the nil identifier.
+func isNilLiteral(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "nil"
+}
+
+// isDiagnosticsType checks if a type is diag.Diagnostics.
+func isDiagnosticsType(t types.Type) bool {
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path()+"."+obj.Name() == diagType
+}

--- a/tools/linters/diagdrop/analyzer.go
+++ b/tools/linters/diagdrop/analyzer.go
@@ -50,6 +50,7 @@ type diagVarInfo struct {
 	name          string
 	pos           token.Pos
 	isAccumulator bool // true for named returns and var declarations, false for := temporaries
+	obj           types.Object
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -92,6 +93,10 @@ func checkFunc(pass *analysis.Pass, funcType *ast.FuncType, body *ast.BlockStmt)
 	// Step 3: Walk all return statements and flag return nil at the diag position
 	// only if a diag variable assignment precedes the return.
 	ast.Inspect(body, func(n ast.Node) bool {
+		switch n.(type) {
+		case *ast.FuncDecl, *ast.FuncLit:
+			return false
+		}
 		ret, ok := n.(*ast.ReturnStmt)
 		if !ok {
 			return true
@@ -113,7 +118,7 @@ func checkFunc(pass *analysis.Pass, funcType *ast.FuncType, body *ast.BlockStmt)
 		}
 
 		// Find the first diag variable assigned before this return.
-		varName := latestDiagVarBefore(diagVars, ret.Pos())
+		varName := latestDiagVarBefore(pass, diagVars, ret.Pos())
 		if varName == "" {
 			// No diag variable assigned before this return — safe early return.
 			return true
@@ -163,7 +168,7 @@ func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.Bloc
 			if typ != nil && isDiagnosticsType(typ) {
 				for _, name := range field.Names {
 					if name.Name != "" && name.Name != "_" {
-						vars = append(vars, diagVarInfo{name: name.Name, pos: 0, isAccumulator: true})
+						vars = append(vars, diagVarInfo{name: name.Name, pos: 0, isAccumulator: true, obj: pass.TypesInfo.Defs[name]})
 					}
 				}
 			}
@@ -174,6 +179,8 @@ func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.Bloc
 	// and assignments (e.g. diags := lookupUser(...)) that capture diag.Diagnostics.
 	ast.Inspect(body, func(n ast.Node) bool {
 		switch node := n.(type) {
+		case *ast.FuncDecl, *ast.FuncLit:
+			return false
 		case *ast.GenDecl:
 			// Handle: var diags diag.Diagnostics
 			if node.Tok != token.VAR {
@@ -188,7 +195,7 @@ func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.Bloc
 				if typ != nil && isDiagnosticsType(typ) {
 					for _, name := range vSpec.Names {
 						if name.Name != "" && name.Name != "_" {
-							vars = append(vars, diagVarInfo{name: name.Name, pos: node.Pos(), isAccumulator: true})
+							vars = append(vars, diagVarInfo{name: name.Name, pos: node.Pos(), isAccumulator: true, obj: pass.TypesInfo.Defs[name]})
 						}
 					}
 				}
@@ -216,7 +223,11 @@ func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.Bloc
 				}
 
 				if typ != nil && isDiagnosticsType(typ) {
-					vars = append(vars, diagVarInfo{name: ident.Name, pos: node.Pos()})
+					obj := pass.TypesInfo.Defs[ident]
+					if obj == nil {
+						obj = pass.TypesInfo.Uses[ident]
+					}
+					vars = append(vars, diagVarInfo{name: ident.Name, pos: node.Pos(), obj: obj})
 				}
 			}
 		}
@@ -230,13 +241,25 @@ func collectDiagVars(pass *analysis.Pass, funcType *ast.FuncType, body *ast.Bloc
 // returning, among those declared or assigned before the given position.
 // It prefers accumulators (named returns, var declarations) over assignment
 // temporaries. Among equal-priority variables, it picks the latest.
-func latestDiagVarBefore(vars []diagVarInfo, pos token.Pos) string {
+func latestDiagVarBefore(pass *analysis.Pass, vars []diagVarInfo, pos token.Pos) string {
+	innerScope := findInnermostScope(pass, pos)
+	if innerScope == nil {
+		innerScope = pass.Pkg.Scope()
+	}
+
 	var best string
 	var bestPos token.Pos
 	var bestIsAccum bool
 	for _, v := range vars {
 		if v.pos >= pos {
 			continue
+		}
+		// Verify that the variable is still in scope at 'pos' and resolves to the same object.
+		if v.obj != nil {
+			_, lookupObj := innerScope.LookupParent(v.name, pos)
+			if lookupObj != v.obj {
+				continue
+			}
 		}
 		// Prefer accumulators over temporaries; among same kind, prefer latest.
 		if best == "" || (v.isAccumulator && !bestIsAccum) || (v.isAccumulator == bestIsAccum && v.pos >= bestPos) {
@@ -246,6 +269,19 @@ func latestDiagVarBefore(vars []diagVarInfo, pos token.Pos) string {
 		}
 	}
 	return best
+}
+
+// findInnermostScope returns the innermost types.Scope containing the given position by searching pass.TypesInfo.Scopes.
+func findInnermostScope(pass *analysis.Pass, pos token.Pos) *types.Scope {
+	var innermost *types.Scope
+	for _, scope := range pass.TypesInfo.Scopes {
+		if scope.Pos() <= pos && pos <= scope.End() {
+			if innermost == nil || scope.End()-scope.Pos() < innermost.End()-innermost.Pos() {
+				innermost = scope
+			}
+		}
+	}
+	return innermost
 }
 
 // isNilLiteral checks if an expression is the nil identifier.

--- a/tools/linters/diagdrop/analyzer_test.go
+++ b/tools/linters/diagdrop/analyzer_test.go
@@ -1,0 +1,13 @@
+package diagdrop_test
+
+import (
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/tools/linters/diagdrop"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestDiagDrop(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, diagdrop.Analyzer, "diagdroptest")
+}

--- a/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
+++ b/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
@@ -1,0 +1,153 @@
+package diagdroptest
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// Stub helpers to simulate Terraform framework calls.
+func lookupUser() (string, diag.Diagnostics) {
+	return "", nil
+}
+
+func mapToModel() diag.Diagnostics {
+	return nil
+}
+
+type NullValue struct{}
+
+func newNullValue() (NullValue, diag.Diagnostics) {
+	return NullValue{}, nil
+}
+
+// --- BAD: return nil after capturing diags ---
+
+// badReturnNilAfterCapture captures diags then returns nil on success.
+func badReturnNilAfterCapture() diag.Diagnostics {
+	user, diags := lookupUser()
+	if diags.HasError() {
+		return diags
+	}
+	if user == "" {
+		return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+	}
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// badReturnNilMultiCapture captures diags via multiple assignments.
+func badReturnNilMultiCapture() diag.Diagnostics {
+	_, diags := lookupUser()
+	if diags.HasError() {
+		return diags
+	}
+	diags = mapToModel()
+	if diags.HasError() {
+		return diags
+	}
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// badNamedReturnExplicitNil uses a named return but explicitly returns nil.
+func badNamedReturnExplicitNil() (diags diag.Diagnostics) {
+	_, d := lookupUser()
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// badSingleReturnDiags has only diag.Diagnostics as the return type.
+func badSingleReturnDiags() diag.Diagnostics {
+	diags := mapToModel()
+	if diags.HasError() {
+		return diags
+	}
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// badMultiReturn has multiple return values including diags.
+func badMultiReturn() (string, diag.Diagnostics) {
+	user, diags := lookupUser()
+	if diags.HasError() {
+		return "", diags
+	}
+	return user, nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// --- GOOD: diagnostics properly returned ---
+
+// goodReturnDiagsAlways returns diags on all paths.
+func goodReturnDiagsAlways() diag.Diagnostics {
+	user, diags := lookupUser()
+	if diags.HasError() {
+		return diags
+	}
+	if user == "" {
+		return diags
+	}
+	return diags
+}
+
+// goodNoCaptureInlineConstruct never captures diags — constructs inline.
+func goodNoCaptureInlineConstruct() diag.Diagnostics {
+	return nil
+}
+
+// goodNoCaptureInlineError returns inline-constructed diagnostics.
+func goodNoCaptureInlineError() diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+// goodOverlayHelper never captures diags, returns nil intentionally.
+func goodOverlayHelper() diag.Diagnostics {
+	// Simulates overlay helpers that do field assignments and return nil.
+	_ = "do something"
+	return nil
+}
+
+// goodNamedReturnBareReturn uses named return with bare return.
+func goodNamedReturnBareReturn() (diags diag.Diagnostics) {
+	_, d := lookupUser()
+	diags.Append(d...)
+	return
+}
+
+// goodNotDiagsReturn is a function that returns error, not diags.
+func goodNotDiagsReturn() error {
+	return nil
+}
+
+// goodMultiReturnProper returns diags in multi-return on all paths.
+func goodMultiReturnProper() (string, diag.Diagnostics) {
+	user, diags := lookupUser()
+	if diags.HasError() {
+		return "", diags
+	}
+	return user, diags
+}
+
+// goodEarlyReturnBeforeCapture returns nil before any diag variable is assigned.
+// This is the common nil-guard pattern in mapping helpers.
+func goodEarlyReturnBeforeCapture() (NullValue, diag.Diagnostics) {
+	// Early return — no diag variable exists yet.
+	if true {
+		return NullValue{}, nil
+	}
+
+	// diags variable appears later.
+	val, d := newNullValue()
+	_ = d
+	return val, d
+}
+
+// goodMultiEarlyReturnBeforeCapture has multiple early returns before capture.
+func goodMultiEarlyReturnBeforeCapture() (NullValue, diag.Diagnostics) {
+	if true {
+		return NullValue{}, nil
+	}
+	if false {
+		return NullValue{}, nil
+	}
+	var diags diag.Diagnostics
+	return NullValue{}, diags
+}

--- a/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
+++ b/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
@@ -185,3 +185,27 @@ func badAccumulatorPreferred() diag.Diagnostics {
 	}
 	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
 }
+
+// badClosureFalsePositive returns diag.Diagnostics but contains a closure that returns error/nil.
+func badClosureFalsePositive() diag.Diagnostics {
+	_, diags := lookupUser()
+	if diags.HasError() {
+		return diags
+	}
+	fn := func() error {
+		return nil // Should NOT be flagged
+	}
+	_ = fn()
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// goodInnerBlockScope returns nil at the end, but the diags variable was only in an inner scope.
+func goodInnerBlockScope() diag.Diagnostics {
+	if true {
+		diags := mapToModel()
+		if diags.HasError() {
+			return diags
+		}
+	}
+	return nil // Should NOT be flagged
+}

--- a/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
+++ b/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
@@ -151,3 +151,37 @@ func goodMultiEarlyReturnBeforeCapture() (NullValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	return NullValue{}, diags
 }
+
+// --- BAD: var declaration patterns ---
+
+// badVarDeclaration uses var declaration instead of :=.
+func badVarDeclaration() diag.Diagnostics {
+	var diags diag.Diagnostics
+	_, d := lookupUser()
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// badVarDeclarationOnly uses only var declaration, no assignments.
+func badVarDeclarationOnly() diag.Diagnostics {
+	var diags diag.Diagnostics
+	_ = diags.HasError()
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}
+
+// --- BAD: accumulator preference ---
+
+// badAccumulatorPreferred has both a temporary d and an accumulator diags.
+// The suggestion should name "diags" (the accumulator), not "d" (the temporary).
+func badAccumulatorPreferred() diag.Diagnostics {
+	_, d := lookupUser()
+	var diags diag.Diagnostics
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
+}

--- a/tools/linters/diagdrop/testdata/src/github.com/hashicorp/terraform-plugin-framework/diag/diag.go
+++ b/tools/linters/diagdrop/testdata/src/github.com/hashicorp/terraform-plugin-framework/diag/diag.go
@@ -1,0 +1,22 @@
+// Package diag is a stub of github.com/hashicorp/terraform-plugin-framework/diag
+// for use in analysistest test fixtures.
+package diag
+
+// Diagnostics is a collection of diagnostic messages.
+type Diagnostics []Diagnostic
+
+// Diagnostic is a single diagnostic message.
+type Diagnostic interface {
+	Severity() string
+	Summary() string
+	Detail() string
+}
+
+// Append adds diagnostics.
+func (d *Diagnostics) Append(in ...Diagnostic) {
+}
+
+// HasError returns true if any diagnostic has error severity.
+func (d Diagnostics) HasError() bool {
+	return false
+}

--- a/tools/linters/plugin.go
+++ b/tools/linters/plugin.go
@@ -6,6 +6,7 @@ import (
 	"github.com/doitintl/terraform-provider-doit/tools/linters/constructor"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/crudnaming"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/delete404"
+	"github.com/doitintl/terraform-provider-doit/tools/linters/diagdrop"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/diagsuppressed"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/errformat"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/interfacestyle"
@@ -102,5 +103,9 @@ func init() {
 
 	register.Plugin("unknownguard", func(_ any) (register.LinterPlugin, error) {
 		return &analyzerPlugin{analyzers: []*analysis.Analyzer{unknownguard.Analyzer}}, nil
+	})
+
+	register.Plugin("diagdrop", func(_ any) (register.LinterPlugin, error) {
+		return &analyzerPlugin{analyzers: []*analysis.Analyzer{diagdrop.Analyzer}}, nil
 	})
 }


### PR DESCRIPTION
## Summary

Add a new custom linter `diagdrop` that detects a subtle diagnostics leak pattern: capturing `diag.Diagnostics` into a named variable but returning `nil` on some paths, silently dropping non-error diagnostics (e.g., warnings).

This was identified by Copilot during PR #199 review — the linter prevents regressions.

## Pattern Detected

```go
// BAD — non-error diagnostics silently lost
func populateState(...) diag.Diagnostics {
    user, diags := r.lookupUser(ctx, email)
    if diags.HasError() { return diags }
    return nil  // ← drops warnings in diags
}

// GOOD — all diagnostics propagated
func populateState(...) diag.Diagnostics {
    user, diags := r.lookupUser(ctx, email)
    if diags.HasError() { return diags }
    return diags
}
```

## Design

The analyzer is **position-aware**: early-return nil guards that precede any `diag.Diagnostics` variable assignment are excluded to avoid false positives on the common mapping-helper pattern:

```go
// NOT flagged — no diag variable exists yet
func mapToValue(...) (Value, diag.Diagnostics) {
    if x == nil {
        return NewNullValue(), nil  // safe: before any diag var
    }
    val, d := NewValue(...)  // d declared AFTER the early return
    return val, d
}
```

## Changes

- **New:** `tools/linters/diagdrop/` — analyzer, tests, 11 test cases
- **Modified:** `plugin.go` — register analyzer
- **Modified:** `.golangci.yml` — enable linter, add exclusions
- **Modified:** `go-conventions/SKILL.md` — document the rule

## Validation

- Unit tests pass (`go test ./diagdrop/...`)
- Full linter test suite: 19/19 packages pass
- Provider scan: 0 findings on current codebase
- Smoke test: reintroduced original user.go bug → linter caught both instances

---

> AI-assisted development (Antigravity IDE)