### PR TITLE
test(folder): add test proving update preserves parent_folder_id

### DIFF
--- a/internal/provider/folder_resource_test.go
+++ b/internal/provider/folder_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -371,6 +372,75 @@ func TestAccFolder_MoveFolder(t *testing.T) {
 	})
 }
 
+// TestAccFolder_UpdateNamePreservesParent verifies that updating an unrelated
+// field (name) on a nested folder does NOT move it to root. This disproves the
+// concern that toUpdateRequest() defaults parent_folder_id to "root" when the
+// user only changes another field.
+// Ref: https://github.com/doitintl/terraform-provider-doit/pull/199#discussion_r3302936367
+func TestAccFolder_UpdateNamePreservesParent(t *testing.T) {
+	rParent := acctest.RandomWithPrefix("tf-acc-parent")
+	rChild := acctest.RandomWithPrefix("tf-acc-child")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create parent + child nested under parent
+			{
+				Config: testAccFolderNested(rParent, rChild),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_folder.child",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(rChild)),
+				},
+			},
+			// Step 2: Update only the child's name — parent_folder_id stays the same
+			{
+				Config: testAccFolderNestedRenamed(rParent, rChild+"-renamed"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_folder.child",
+							plancheck.ResourceActionUpdate,
+						),
+						// Parent folder should NOT be planned for update
+						plancheck.ExpectResourceAction(
+							"doit_folder.parent",
+							plancheck.ResourceActionNoop,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_folder.child",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(rChild+"-renamed")),
+					// The key assertion: parent_folder_id must NOT have changed to "root"
+					statecheck.CompareValuePairs(
+						"doit_folder.parent",
+						tfjsonpath.New("id"),
+						"doit_folder.child",
+						tfjsonpath.New("parent_folder_id"),
+						compare.ValuesSame(),
+					),
+				},
+			},
+			// Step 3: Drift check — no changes expected
+			{
+				Config: testAccFolderNestedRenamed(rParent, rChild+"-renamed"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 // --- Config helpers ---
 
 func testAccFolderMinimal(name string) string {
@@ -420,6 +490,20 @@ resource "doit_folder" "this" {
 }
 
 func testAccFolderNested(parentName, childName string) string {
+	return fmt.Sprintf(`
+resource "doit_folder" "parent" {
+  name             = %q
+  parent_folder_id = "root"
+}
+
+resource "doit_folder" "child" {
+  name             = %q
+  parent_folder_id = doit_folder.parent.id
+}
+`, parentName, childName)
+}
+
+func testAccFolderNestedRenamed(parentName, childName string) string {
 	return fmt.Sprintf(`
 resource "doit_folder" "parent" {
   name             = %q

--- a/internal/provider/folder_resource_test.go
+++ b/internal/provider/folder_resource_test.go
@@ -398,7 +398,7 @@ func TestAccFolder_UpdateNamePreservesParent(t *testing.T) {
 			},
 			// Step 2: Update only the child's name — parent_folder_id stays the same
 			{
-				Config: testAccFolderNestedRenamed(rParent, rChild+"-renamed"),
+				Config: testAccFolderNested(rParent, rChild+"-renamed"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectNonEmptyPlan(),
@@ -430,7 +430,7 @@ func TestAccFolder_UpdateNamePreservesParent(t *testing.T) {
 			},
 			// Step 3: Drift check — no changes expected
 			{
-				Config: testAccFolderNestedRenamed(rParent, rChild+"-renamed"),
+				Config: testAccFolderNested(rParent, rChild+"-renamed"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -490,20 +490,6 @@ resource "doit_folder" "this" {
 }
 
 func testAccFolderNested(parentName, childName string) string {
-	return fmt.Sprintf(`
-resource "doit_folder" "parent" {
-  name             = %q
-  parent_folder_id = "root"
-}
-
-resource "doit_folder" "child" {
-  name             = %q
-  parent_folder_id = doit_folder.parent.id
-}
-`, parentName, childName)
-}
-
-func testAccFolderNestedRenamed(parentName, childName string) string {
 	return fmt.Sprintf(`
 resource "doit_folder" "parent" {
   name             = %q


### PR DESCRIPTION
## What

Adds `TestAccFolder_UpdateNamePreservesParent` — an acceptance test that proves updating an unrelated field (name) on a nested folder does **not** move it to root.

## Why

Copilot flagged a potential issue in [PR #199](https://github.com/doitintl/terraform-provider-doit/pull/199#discussion_r3302936367), claiming that `toUpdateRequest()` defaults `ParentFolderId` to `"root"` when the attribute is null/unknown, which would silently move folders to root during unrelated updates.

This is a **false positive** — Terraform populates the plan from prior state for Optional+Computed fields when the user's config still references them, so `parent_folder_id` is always known during an update of a sibling field. The `"root"` default only activates when the user explicitly removes `parent_folder_id` from config, which matches the documented semantics.

This test proves the behavior is correct against the live API.

## Test details

The test:
1. Creates a parent folder + child folder nested under the parent
2. Updates **only the child's name** — asserts:
   - Child gets an `Update` action
   - Parent gets a `Noop` action
   - `parent_folder_id` still equals the parent's `id` (via `compare.ValuesSame()`)
3. Drift check — re-applying produces an empty plan

**Passed locally** in 21s against the live API.