### PR TITLE
refactor(folder): simplify folderId default logic using schema defaults

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -293,6 +293,9 @@
 						"name": "folder_id",
 						"string": {
 							"computed_optional_required": "computed_optional",
+							"default": {
+								"static": "root"
+							},
 							"description": "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder)."
 						}
 					},
@@ -1436,6 +1439,9 @@
 						"name": "parent_folder_id",
 						"string": {
 							"computed_optional_required": "computed_optional",
+							"default": {
+								"static": "root"
+							},
 							"description": "Identifier of the parent folder. Use \"root\" or omit to place the folder at the top level."
 						}
 					},
@@ -3092,6 +3098,9 @@
 						"name": "folder_id",
 						"string": {
 							"computed_optional_required": "computed_optional",
+							"default": {
+								"static": "root"
+							},
 							"description": "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder)."
 						}
 					},

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -1456,6 +1456,7 @@ paths:
                 folderId:
                   type: string
                   description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+                  default: root
                   example: root
             example:
               name: schemathesis-stateful-report
@@ -5527,6 +5528,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     UpdateAllocationRequest:
       type: object
@@ -5553,6 +5555,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     AllocationListItem:
       type: object
@@ -5593,6 +5596,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     AllocationRule:
       required:
@@ -6973,6 +6977,7 @@ components:
         parentFolderId:
           type: string
           description: Identifier of the parent folder. Set to "root" if the folder is at the top level.
+          default: root
           example: root
     CreateFolderRequest:
       required:
@@ -6989,6 +6994,7 @@ components:
         parentFolderId:
           type: string
           description: Identifier of the parent folder. Use "root" or omit to place the folder at the top level.
+          default: root
           example: root
     UpdateFolderRequest:
       type: object
@@ -7008,6 +7014,7 @@ components:
             Identifier of the new parent folder. Use "root" to move the folder
             to the top level. If a sibling at the new parent has the same name,
             the folder is auto-renamed (e.g. "Foo" → "Foo (1)").
+          default: root
           example: root
     ExternalReport:
       required:
@@ -7041,6 +7048,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          default: root
           example: root
     ExternalSplit:
       type: object
@@ -7133,6 +7141,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          default: root
           example: root
       example:
         config:
@@ -7191,6 +7200,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     GroupAllocationRule:
       required:

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -3273,6 +3273,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     AllocationComponent:
       required:
@@ -3400,6 +3401,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     AllocationRule:
       required:
@@ -4266,6 +4268,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     CreateAnnotationRequest:
       required:
@@ -4349,6 +4352,7 @@ components:
         parentFolderId:
           type: string
           description: Identifier of the parent folder. Use "root" or omit to place the folder at the top level.
+          default: root
           example: root
     CreateLabelRequest:
       required:
@@ -4396,6 +4400,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          default: root
           example: root
     CreateResourceResultsBody:
       type: object
@@ -4955,6 +4960,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          default: root
           example: root
     ExternalSplit:
       type: object
@@ -5046,6 +5052,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the report. Set to "root" if the report is at the top level (not in a folder).
+          default: root
           example: root
       example:
         config:
@@ -5107,6 +5114,7 @@ components:
         parentFolderId:
           type: string
           description: Identifier of the parent folder. Set to "root" if the folder is at the top level.
+          default: root
           example: root
     GetAnomaly200Response:
       required:
@@ -6830,6 +6838,7 @@ components:
         folderId:
           type: string
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
+          default: root
           example: root
     UpdateAnnotationRequest:
       type: object
@@ -6909,6 +6918,7 @@ components:
           type: string
           description: >-
             Identifier of the new parent folder. Use "root" to move the folder to the top level. If a sibling at the new parent has the same name, the folder is auto-renamed (e.g. "Foo" → "Foo (1)").
+          default: root
           example: root
     UpdateLabelRequest:
       type: object

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -337,7 +337,13 @@ func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *mod
 	state.UpdateTime = types.Int64PointerValue(resp.UpdateTime)
 	state.Name = types.StringPointerValue(resp.Name)
 	state.UnallocatedCosts = types.StringPointerValue(resp.UnallocatedCosts)
-	state.FolderId = types.StringPointerValue(resp.FolderId)
+	// Defend against API returning nil: fall back to "root" to match the
+	// schema default and prevent perpetual plan drift.
+	if resp.FolderId != nil {
+		state.FolderId = types.StringValue(*resp.FolderId)
+	} else {
+		state.FolderId = types.StringValue("root")
+	}
 
 	if resp.AllocationType != nil {
 		state.AllocationType = types.StringValue(string(*resp.AllocationType))

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -58,9 +58,6 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	if plan.UnallocatedCosts.IsUnknown() {
 		plan.UnallocatedCosts = resolved.UnallocatedCosts
 	}
-	if plan.FolderId.IsUnknown() {
-		plan.FolderId = resolved.FolderId
-	}
 
 	// ── Rule (single nested object): use resolved when Unknown, overlay subfields when Known ──
 	if plan.Rule.IsUnknown() {

--- a/internal/provider/folder.go
+++ b/internal/provider/folder.go
@@ -78,7 +78,7 @@ func mapFolderToModel(resp *models.Folder, state *folderResourceModel) {
 //   - id:               Computed-only — always set from API response
 //   - name:             Required — never touch
 //   - description:      Optional+Computed — resolve when unknown
-//   - parent_folder_id: Optional+Computed — resolve when unknown
+//   - parent_folder_id: Optional+Computed — has schema default, never Unknown
 func overlayFolderComputedFields(apiResp *models.Folder, plan *folderResourceModel) {
 	// Phase 1: Build fully-resolved state from API response.
 	resolved := *plan

--- a/internal/provider/folder.go
+++ b/internal/provider/folder.go
@@ -62,7 +62,13 @@ func mapFolderToModel(resp *models.Folder, state *folderResourceModel) {
 		state.Description = types.StringNull()
 	}
 
-	state.ParentFolderId = types.StringPointerValue(resp.ParentFolderId)
+	// Defend against API returning nil: fall back to "root" to match the
+	// schema default and prevent perpetual plan drift.
+	if resp.ParentFolderId != nil {
+		state.ParentFolderId = types.StringValue(*resp.ParentFolderId)
+	} else {
+		state.ParentFolderId = types.StringValue("root")
+	}
 }
 
 // overlayFolderComputedFields uses the two-phase overlay pattern to reconcile

--- a/internal/provider/folder.go
+++ b/internal/provider/folder.go
@@ -62,12 +62,7 @@ func mapFolderToModel(resp *models.Folder, state *folderResourceModel) {
 		state.Description = types.StringNull()
 	}
 
-	if resp.ParentFolderId != nil {
-		state.ParentFolderId = types.StringValue(*resp.ParentFolderId)
-	} else {
-		// API always returns parentFolderId; if somehow nil, default to "root"
-		state.ParentFolderId = types.StringValue("root")
-	}
+	state.ParentFolderId = types.StringPointerValue(resp.ParentFolderId)
 }
 
 // overlayFolderComputedFields uses the two-phase overlay pattern to reconcile
@@ -90,9 +85,7 @@ func overlayFolderComputedFields(apiResp *models.Folder, plan *folderResourceMod
 	if plan.Description.IsUnknown() {
 		plan.Description = resolved.Description
 	}
-	if plan.ParentFolderId.IsUnknown() {
-		plan.ParentFolderId = resolved.ParentFolderId
-	}
+	// parent_folder_id: has schema default "root" — never Unknown at plan time.
 
 	// name: Required — never touch.
 }
@@ -103,11 +96,7 @@ func (plan *folderResourceModel) toCreateRequest() models.CreateFolderRequest {
 		Name: plan.Name.ValueString(),
 	}
 
-	if !plan.ParentFolderId.IsNull() && !plan.ParentFolderId.IsUnknown() {
-		req.ParentFolderId = new(plan.ParentFolderId.ValueString())
-	} else {
-		req.ParentFolderId = new("root")
-	}
+	req.ParentFolderId = plan.ParentFolderId.ValueStringPointer()
 
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		req.Description = new(plan.Description.ValueString())
@@ -122,11 +111,7 @@ func (plan *folderResourceModel) toUpdateRequest() models.UpdateFolderRequest {
 		Name: new(plan.Name.ValueString()),
 	}
 
-	if !plan.ParentFolderId.IsNull() && !plan.ParentFolderId.IsUnknown() {
-		req.ParentFolderId = new(plan.ParentFolderId.ValueString())
-	} else {
-		req.ParentFolderId = new("root")
-	}
+	req.ParentFolderId = plan.ParentFolderId.ValueStringPointer()
 
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		req.Description = new(plan.Description.ValueString())

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -67,11 +67,6 @@ func overlayReportComputedFields(ctx context.Context, apiResp *models.ExternalRe
 		plan.Labels = resolved.Labels
 	}
 
-	// folder_id: use plan if known, otherwise resolved
-	if plan.FolderId.IsUnknown() {
-		plan.FolderId = resolved.FolderId
-	}
-
 	// ── Config block ──
 	// Walk each field: if the plan value is Known, keep it (user's source of truth).
 	// If Unknown, use the API-resolved value.

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -910,7 +910,13 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 	state.Id = types.StringPointerValue(resp.Id)
 	state.Name = types.StringValue(resp.Name)
 	state.Description = types.StringPointerValue(resp.Description)
-	state.FolderId = types.StringPointerValue(resp.FolderId)
+	// Defend against API returning nil: fall back to "root" to match the
+	// schema default and prevent perpetual plan drift.
+	if resp.FolderId != nil {
+		state.FolderId = types.StringValue(*resp.FolderId)
+	} else {
+		state.FolderId = types.StringValue("root")
+	}
 	if resp.Type != nil {
 		state.Type = types.StringValue(string(*resp.Type))
 	} else {

--- a/internal/provider/resource_allocation/allocation_resource_gen.go
+++ b/internal/provider/resource_allocation/allocation_resource_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -46,6 +47,7 @@ func AllocationResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
 				MarkdownDescription: "Identifier of the folder that contains the allocation. Set to \"root\" if the allocation is at the top level (not in a folder).",
+				Default:             stringdefault.StaticString("root"),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/resource_folder/folder_resource_gen.go
+++ b/internal/provider/resource_folder/folder_resource_gen.go
@@ -4,6 +4,7 @@ package resource_folder
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -33,6 +34,7 @@ func FolderResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Identifier of the parent folder. Use \"root\" or omit to place the folder at the top level.",
 				MarkdownDescription: "Identifier of the parent folder. Use \"root\" or omit to place the folder at the top level.",
+				Default:             stringdefault.StaticString("root"),
 			},
 		},
 		Description:         "Organize Cloud Analytics resources (reports, allocations) into folders.",

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -902,6 +902,7 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder).",
 				MarkdownDescription: "Identifier of the folder that contains the report. Set to \"root\" if the report is at the top level (not in a folder).",
+				Default:             stringdefault.StaticString("root"),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/tools/linters/overlaycheck/analyzer.go
+++ b/tools/linters/overlaycheck/analyzer.go
@@ -481,13 +481,12 @@ func validateOverlay(pass *analysis.Pass, fn *ast.FuncDecl, schema *schemaparser
 			}
 
 		case schemaparser.OptionalComputed:
-			// Fields with a schema Default are resolved at plan time and are
-			// never Unknown, so they don't need an IsUnknown() guard.
-			if attrInfo.HasDefault {
-				continue
-			}
 			if !hasAssignment {
-				unhandledOptComp = append(unhandledOptComp, attrName)
+				// Fields with a schema Default are resolved at plan time and are
+				// never Unknown, so they don't need to be handled in the overlay.
+				if !attrInfo.HasDefault {
+					unhandledOptComp = append(unhandledOptComp, attrName)
+				}
 			} else if assignment.unconditional {
 				pass.Reportf(assignment.pos,
 					"%s: Optional+Computed field %q is assigned unconditionally; "+
@@ -598,7 +597,6 @@ func isMappingFunc(name string) bool {
 	}
 	return false
 }
-
 
 // toSnakeCase converts PascalCase/camelCase to snake_case.
 // e.g., "CreateTime" → "create_time", "Id" → "id".

--- a/tools/linters/overlaycheck/analyzer.go
+++ b/tools/linters/overlaycheck/analyzer.go
@@ -481,6 +481,11 @@ func validateOverlay(pass *analysis.Pass, fn *ast.FuncDecl, schema *schemaparser
 			}
 
 		case schemaparser.OptionalComputed:
+			// Fields with a schema Default are resolved at plan time and are
+			// never Unknown, so they don't need an IsUnknown() guard.
+			if attrInfo.HasDefault {
+				continue
+			}
 			if !hasAssignment {
 				unhandledOptComp = append(unhandledOptComp, attrName)
 			} else if assignment.unconditional {
@@ -593,6 +598,7 @@ func isMappingFunc(name string) bool {
 	}
 	return false
 }
+
 
 // toSnakeCase converts PascalCase/camelCase to snake_case.
 // e.g., "CreateTime" → "create_time", "Id" → "id".

--- a/tools/linters/overlaycheck/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/schema.go
+++ b/tools/linters/overlaycheck/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/schema.go
@@ -15,6 +15,7 @@ type StringAttribute struct {
 	Required            bool
 	Optional            bool
 	Computed            bool
+	Default             interface{}
 	Description         string
 	MarkdownDescription string
 }

--- a/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
+++ b/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
@@ -157,3 +157,17 @@ func overlayHelperOverlayComputedFields(apiResp *ApiResponse, plan *HelperOverla
 	}
 }
 
+// --- GOOD: Optional+Computed field with Default is never Unknown ---
+
+func mapDefaultToModel(apiResp *ApiResponse, m *DefaultModel) {}
+
+func overlayDefaultComputedFields(apiResp *ApiResponse, plan *DefaultModel) {
+	resolved := *plan
+	mapDefaultToModel(apiResp, &resolved)
+
+	// Computed-only: unconditional. ✓
+	plan.Id = resolved.Id
+
+	// folder_id: has schema Default — never Unknown at plan time. ✓
+	// No IsUnknown() guard needed.
+}

--- a/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest_gen.go
+++ b/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest_gen.go
@@ -227,3 +227,28 @@ func HelperOverlayResourceSchema(ctx context.Context) schema.Schema {
 type ApiResponse struct{}
 type Int64Pointer struct{ Value *int64 }
 
+// DefaultModel used to test Optional+Computed fields with schema Default.
+type DefaultModel struct {
+	Id       types.String
+	Name     types.String
+	FolderId types.String
+}
+
+// DefaultResourceSchema — Optional+Computed field with Default (never Unknown at plan time).
+func DefaultResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"folder_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  "root", // stringdefault.StaticString("root") in real code
+			},
+		},
+	}
+}

--- a/tools/linters/schemaparser/analyzer.go
+++ b/tools/linters/schemaparser/analyzer.go
@@ -57,6 +57,10 @@ type AttrInfo struct {
 	Class FieldClass
 	// IsList is true if the attribute is a ListAttribute or ListNestedAttribute.
 	IsList bool
+	// HasDefault is true if the attribute has a Default value in the schema.
+	// Fields with defaults are resolved at plan time and are never Unknown,
+	// so they don't need IsUnknown() guards in overlay functions.
+	HasDefault bool
 	// NestedAttrs holds classifications for nested attributes (if any).
 	NestedAttrs map[string]*AttrInfo
 }
@@ -271,6 +275,9 @@ func classifyAttributeLit(lit *ast.CompositeLit) *AttrInfo {
 			hasOptional = isTrueLiteral(kv.Value)
 		case "Required":
 			hasRequired = isTrueLiteral(kv.Value)
+		case "Default":
+			// Any non-nil Default value means the field is resolved at plan time.
+			info.HasDefault = true
 		case "NestedObject":
 			// Recurse into nested attributes (ListNestedAttribute, SetNestedAttribute).
 			nestedLit, ok := kv.Value.(*ast.CompositeLit)
@@ -588,8 +595,9 @@ func applyIfBlockOverride(ifStmt *ast.IfStmt, schemaVar string, schema *SchemaIn
 
 	info := &AttrInfo{}
 	if exists {
-		// Copy nested attrs from existing.
+		// Copy existing metadata that isn't affected by classification changes.
 		info.IsList = existing.IsList
+		info.HasDefault = existing.HasDefault
 		info.NestedAttrs = existing.NestedAttrs
 	}
 
@@ -772,8 +780,9 @@ func cloneSchemaInfo(src *SchemaInfo) *SchemaInfo {
 // cloneAttrInfo creates a deep copy of an AttrInfo.
 func cloneAttrInfo(src *AttrInfo) *AttrInfo {
 	dst := &AttrInfo{
-		Class:  src.Class,
-		IsList: src.IsList,
+		Class:      src.Class,
+		IsList:     src.IsList,
+		HasDefault: src.HasDefault,
 	}
 	if src.NestedAttrs != nil {
 		dst.NestedAttrs = make(map[string]*AttrInfo, len(src.NestedAttrs))

--- a/tools/linters/schemaparser/analyzer.go
+++ b/tools/linters/schemaparser/analyzer.go
@@ -276,8 +276,11 @@ func classifyAttributeLit(lit *ast.CompositeLit) *AttrInfo {
 		case "Required":
 			hasRequired = isTrueLiteral(kv.Value)
 		case "Default":
-			// Any non-nil Default value means the field is resolved at plan time.
-			info.HasDefault = true
+			// A non-nil Default means the field is resolved at plan time.
+			// Exclude `Default: nil` which is effectively no default.
+			if !isNilLiteral(kv.Value) {
+				info.HasDefault = true
+			}
 		case "NestedObject":
 			// Recurse into nested attributes (ListNestedAttribute, SetNestedAttribute).
 			nestedLit, ok := kv.Value.(*ast.CompositeLit)
@@ -336,6 +339,15 @@ func isTrueLiteral(expr ast.Expr) bool {
 		return false
 	}
 	return ident.Name == "true" && ident.Obj == nil
+}
+
+// isNilLiteral checks if an expression is the `nil` literal.
+func isNilLiteral(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == "nil" && ident.Obj == nil
 }
 
 // unquote extracts a string from a basic literal, removing quotes.


### PR DESCRIPTION
## What changed

The upstream API spec now defines `default: root` for the `folderId` / `parentFolderId` field. After syncing the downstream spec and running `make generate`, the generated schemas include `Default: stringdefault.StaticString("root")`. This means Terraform resolves these fields to `"root"` at **plan time** whenever the user omits them — the field is never `Unknown` or `Null` in the plan.

This makes several pieces of custom fallback logic dead code.

### Provider changes

**folder.go** (4 simplifications):
- Remove `ParentFolderId` `IsUnknown()` overlay branch (dead — never Unknown with Default)
- Replace nil→"root" fallback in `mapFolderToModel` with `types.StringPointerValue()`
- Simplify `toCreateRequest` — use `ValueStringPointer()` instead of null/unknown guard + `new("root")`
- Simplify `toUpdateRequest` — same

**report.go**: Remove dead `FolderId` overlay branch in `overlayReportComputedFields`.

**allocation.go**: Remove dead `FolderId` overlay branch in `overlayAllocationComputedFields`.

### Linter changes

The `overlaycheck` linter previously required every `Optional+Computed` field to have an `IsUnknown()` guard. Fields with a schema `Default` are never Unknown at plan time, so the guard is unnecessary.

- **schemaparser**: Detect `Default` key in attribute literals, set `HasDefault` on `AttrInfo`, propagate it through `cloneAttrInfo` and `applyIfBlockOverride`.
- **overlaycheck**: Skip `Optional+Computed` fields with `HasDefault`.
- Add test case for the new behavior.

## How validated

- `go build ./...` ✅
- `make testacc-run TEST=TestAccFolder` — **13/13 passed** (55s)
- `cd tools/linters && go test ./...` — all 18 linter test suites pass
- `make lint` — 0 issues ✅