### PR TITLE
feat(linters): extend overlaycheck to validate nested attribute overlays

### DIFF
--- a/.agent/skills/implement-resource/references/overlay-pattern.md
+++ b/.agent/skills/implement-resource/references/overlay-pattern.md
@@ -55,6 +55,49 @@ func overlayMyResourceComputedFields(ctx context.Context, apiResp *models.MyReso
 }
 ```
 
+### Nested Attributes (ListNestedAttribute / SingleNestedAttribute)
+
+For fields with nested attributes (e.g., `alerts`, `config`, `rules`), use **sub-overlay helper functions** rather than inline field handling. The `overlaycheck` linter validates sub-overlay functions against their nested schemas.
+
+**Pattern: `overlayListElements` with sub-overlay callback**
+
+```go
+// In the top-level overlay:
+if plan.Alerts.IsUnknown() {
+    plan.Alerts = resolved.Alerts
+} else if !plan.Alerts.IsNull() {
+    diags.Append(overlayListElements(ctx, &resolved.Alerts, &plan.Alerts, overlayMyResourceAlert)...)
+}
+
+// Sub-overlay helper — validated by overlaycheck against the nested schema:
+func overlayMyResourceAlert(_ context.Context, resolved, plan *resource_myresource.AlertsValue) diag.Diagnostics {
+    // Computed-only nested fields: unconditional
+    plan.Triggered = resolved.Triggered
+
+    // Optional+Computed nested fields: guarded by IsUnknown
+    if plan.Percentage.IsUnknown() {
+        plan.Percentage = resolved.Percentage
+    }
+
+    // Required nested fields: not mentioned
+    return nil
+}
+```
+
+**Pattern: direct sub-overlay for SingleNestedAttribute**
+
+```go
+if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
+    diags.Append(overlayConfigFields(ctx, &resolved.Config, &plan.Config)...)
+} else if plan.Config.IsUnknown() {
+    plan.Config = resolved.Config
+}
+```
+
+**Multi-level nesting**: Sub-overlays can call deeper sub-overlays. The linter recursively validates the entire chain.
+
+> **Linter:** `overlaycheck` **enforces** that nested attributes with computed fields use sub-overlay helper functions — inline handling is not allowed. The linter validates both top-level overlay functions and all sub-overlay helpers reachable via `overlayListElements` callbacks or direct `overlay*` calls with `&plan.X` arguments.
+
 ## Step 3: Wire Into Create and Update
 
 ```go

--- a/internal/provider/alert.go
+++ b/internal/provider/alert.go
@@ -109,21 +109,14 @@ func overlayAlertScope(_ context.Context, resolved, plan *resource_alert.ScopesV
 	if plan.CaseInsensitive.IsUnknown() {
 		plan.CaseInsensitive = resolved.CaseInsensitive
 	}
-	if plan.Id.IsUnknown() {
-		plan.Id = resolved.Id
-	}
+
 	if plan.IncludeNull.IsUnknown() {
 		plan.IncludeNull = resolved.IncludeNull
 	}
 	if plan.Inverse.IsUnknown() {
 		plan.Inverse = resolved.Inverse
 	}
-	if plan.Mode.IsUnknown() {
-		plan.Mode = resolved.Mode
-	}
-	if plan.ScopesType.IsUnknown() {
-		plan.ScopesType = resolved.ScopesType
-	}
+
 	if plan.Values.IsUnknown() {
 		plan.Values = resolved.Values
 	}

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -76,7 +76,9 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	return diags
 }
 
-// overlayAllocationRuleFields resolves Unknown subfields in the "rule" SingleNestedAttribute.
+// overlayAllocationRuleFields overlays the "components" subfield of the "rule"
+// SingleNestedAttribute. The only other subfield, "formula", is Required and
+// never Unknown at overlay time.
 func overlayAllocationRuleFields(ctx context.Context, resolved, plan *resource_allocation.RuleValue) diag.Diagnostics {
 	if plan.Components.IsUnknown() {
 		plan.Components = resolved.Components

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -63,14 +63,7 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	if plan.Rule.IsUnknown() {
 		plan.Rule = resolved.Rule
 	} else if !plan.Rule.IsNull() {
-		if plan.Rule.Formula.IsUnknown() {
-			plan.Rule.Formula = resolved.Rule.Formula
-		}
-		if plan.Rule.Components.IsUnknown() {
-			plan.Rule.Components = resolved.Rule.Components
-		} else if !plan.Rule.Components.IsNull() {
-			diags.Append(overlayListElements(ctx, &resolved.Rule.Components, &plan.Rule.Components, overlayAllocationComponent)...)
-		}
+		diags.Append(overlayAllocationRuleFields(ctx, &resolved.Rule, &plan.Rule)...)
 	}
 
 	// ── Rules (list): resolve whole list when Unknown, overlay elements when Known ──
@@ -83,14 +76,22 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	return diags
 }
 
+// overlayAllocationRuleFields resolves Unknown subfields in the "rule" SingleNestedAttribute.
+func overlayAllocationRuleFields(ctx context.Context, resolved, plan *resource_allocation.RuleValue) diag.Diagnostics {
+	if plan.Components.IsUnknown() {
+		plan.Components = resolved.Components
+	} else if !plan.Components.IsNull() {
+		return overlayListElements(ctx, &resolved.Components, &plan.Components, overlayAllocationComponent)
+	}
+	return nil
+}
+
 // ── Allocation list element overlay helpers ──
 // Each helper resolves Unknown subfields from the resolved element.
 // Known values are never touched — the user's plan is the source of truth.
 
 func overlayAllocationRule(ctx context.Context, resolved, plan *resource_allocation.RulesValue) diag.Diagnostics {
-	if plan.Action.IsUnknown() {
-		plan.Action = resolved.Action
-	}
+
 	if plan.Description.IsUnknown() {
 		plan.Description = resolved.Description
 	}
@@ -125,18 +126,7 @@ func overlayAllocationComponent(_ context.Context, resolved, plan *resource_allo
 	if plan.InverseSelection.IsUnknown() {
 		plan.InverseSelection = resolved.InverseSelection
 	}
-	if plan.ComponentsType.IsUnknown() {
-		plan.ComponentsType = resolved.ComponentsType
-	}
-	if plan.Key.IsUnknown() {
-		plan.Key = resolved.Key
-	}
-	if plan.Mode.IsUnknown() {
-		plan.Mode = resolved.Mode
-	}
-	if plan.Values.IsUnknown() {
-		plan.Values = resolved.Values
-	}
+
 	return nil
 }
 

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -179,21 +179,14 @@ func overlayBudgetScope(_ context.Context, resolved, plan *resource_budget.Scope
 	if plan.CaseInsensitive.IsUnknown() {
 		plan.CaseInsensitive = resolved.CaseInsensitive
 	}
-	if plan.Id.IsUnknown() {
-		plan.Id = resolved.Id
-	}
+
 	if plan.IncludeNull.IsUnknown() {
 		plan.IncludeNull = resolved.IncludeNull
 	}
 	if plan.Inverse.IsUnknown() {
 		plan.Inverse = resolved.Inverse
 	}
-	if plan.Mode.IsUnknown() {
-		plan.Mode = resolved.Mode
-	}
-	if plan.ScopesType.IsUnknown() {
-		plan.ScopesType = resolved.ScopesType
-	}
+
 	if plan.Values.IsUnknown() {
 		plan.Values = resolved.Values
 	}

--- a/internal/provider/insight_resource.go
+++ b/internal/provider/insight_resource.go
@@ -224,9 +224,21 @@ func overlayInsightComputedFields(ctx context.Context, apiResp *models.InsightRe
 	}
 	if plan.DismissalDetails.IsUnknown() {
 		plan.DismissalDetails = resolved.DismissalDetails
+	} else if !plan.DismissalDetails.IsNull() {
+		overlayInsightDismissalDetails(&resolved.DismissalDetails, &plan.DismissalDetails)
 	}
 
 	return diags
+}
+
+// overlayInsightDismissalDetails resolves Unknown subfields in the "dismissal_details" SingleNestedAttribute.
+func overlayInsightDismissalDetails(resolved, plan *resource_insight.DismissalDetailsValue) {
+	if plan.Comment.IsUnknown() {
+		plan.Comment = resolved.Comment
+	}
+	if plan.Reason.IsUnknown() {
+		plan.Reason = resolved.Reason
+	}
 }
 
 func (r *insightResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/insight_resource_test.go
+++ b/internal/provider/insight_resource_test.go
@@ -700,8 +700,9 @@ func TestAccInsightResource_DismissedPartial(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"doit_insight.test",
 						tfjsonpath.New("dismissal_details"),
-						knownvalue.ObjectPartial(map[string]knownvalue.Check{
-							"reason": knownvalue.StringExact("not relevant"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"reason":  knownvalue.StringExact("not relevant"),
+							"comment": knownvalue.Null(),
 						})),
 				},
 			},

--- a/internal/provider/insight_resource_test.go
+++ b/internal/provider/insight_resource_test.go
@@ -677,3 +677,60 @@ resource "doit_insight" "test" {
 }
 `, key)
 }
+
+// TestAccInsightResource_DismissedPartial tests creating an insight with
+// "dismissed" status and only reason set (comment omitted). The omitted
+// comment subfield is Optional+Computed and should be resolved by the overlay.
+func TestAccInsightResource_DismissedPartial(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-insight")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with status = "dismissed" + partial dismissal_details (only reason)
+			{
+				Config: testAccInsightResourceDismissedPartialConfig(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_insight.test",
+						tfjsonpath.New("status"),
+						knownvalue.StringExact("dismissed")),
+					statecheck.ExpectKnownValue(
+						"doit_insight.test",
+						tfjsonpath.New("dismissal_details"),
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"reason": knownvalue.StringExact("not relevant"),
+						})),
+				},
+			},
+			// Step 2: Drift check — plan should be empty
+			{
+				Config: testAccInsightResourceDismissedPartialConfig(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccInsightResourceDismissedPartialConfig(key string) string {
+	return fmt.Sprintf(`
+resource "doit_insight" "test" {
+  key               = %[1]q
+  title             = "Dismissed Partial Test"
+  short_description = "Testing dismissal with reason only"
+  cloud_provider    = "aws"
+  categories        = ["FinOps"]
+  status            = "dismissed"
+
+  dismissal_details = {
+    reason = "not relevant"
+  }
+}
+`, key)
+}

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -354,21 +354,14 @@ func overlayFilter(_ context.Context, resolved, plan *resource_report.FiltersVal
 	if plan.CaseInsensitive.IsUnknown() {
 		plan.CaseInsensitive = resolved.CaseInsensitive
 	}
-	if plan.Id.IsUnknown() {
-		plan.Id = resolved.Id
-	}
+
 	if plan.IncludeNull.IsUnknown() {
 		plan.IncludeNull = resolved.IncludeNull
 	}
 	if plan.Inverse.IsUnknown() {
 		plan.Inverse = resolved.Inverse
 	}
-	if plan.Mode.IsUnknown() {
-		plan.Mode = resolved.Mode
-	}
-	if plan.FiltersType.IsUnknown() {
-		plan.FiltersType = resolved.FiltersType
-	}
+
 	if plan.Values.IsUnknown() {
 		plan.Values = resolved.Values
 	}

--- a/tools/linters/overlaycheck/analyzer.go
+++ b/tools/linters/overlaycheck/analyzer.go
@@ -16,6 +16,7 @@ import (
 	"go/token"
 	"go/types"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/doitintl/terraform-provider-doit/tools/linters/schemaparser"
@@ -786,6 +787,9 @@ func validateOverlay(pass *analysis.Pass, fn *ast.FuncDecl, schema *schemaparser
 // or Optional+Computed children use sub-overlay helper functions (e.g.,
 // overlayListElements callbacks or direct overlay* calls) rather than inline
 // handling. This ensures consistent patterns across all overlay functions.
+//
+// Missing attributes are aggregated into a single diagnostic to avoid
+// golangci-lint's --uniq-by-line deduplication hiding findings.
 func enforceSubOverlayHelpers(
 	pass *analysis.Pass,
 	fn *ast.FuncDecl,
@@ -798,6 +802,7 @@ func enforceSubOverlayHelpers(
 		coveredFields[call.fieldName] = true
 	}
 
+	var missing []string
 	for attrName, attrInfo := range schema.Attrs {
 		if attrInfo.NestedAttrs == nil {
 			continue
@@ -815,10 +820,14 @@ func enforceSubOverlayHelpers(
 		if coveredFields[attrName] {
 			continue
 		}
+		missing = append(missing, attrName)
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
 		pass.Reportf(fn.Pos(),
-			"%s: nested attribute %q has computed fields that need overlay; "+
-				"extract a sub-overlay helper function (e.g., overlayListElements or overlay%sXxx)",
-			fn.Name.Name, attrName, strings.Title(attrName)) //nolint:staticcheck // strings.Title is fine for diagnostics
+			"%s: nested attribute(s) with computed fields need sub-overlay helpers: %s",
+			fn.Name.Name, strings.Join(missing, ", "))
 	}
 }
 

--- a/tools/linters/overlaycheck/analyzer.go
+++ b/tools/linters/overlaycheck/analyzer.go
@@ -14,6 +14,8 @@ package overlaycheck
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
+	"reflect"
 	"strings"
 
 	"github.com/doitintl/terraform-provider-doit/tools/linters/schemaparser"
@@ -40,6 +42,19 @@ type fieldAssignment struct {
 	pos token.Pos
 }
 
+// subOverlayCall records a call to a sub-overlay function and the field it operates on.
+type subOverlayCall struct {
+	funcName  string // e.g., "overlayBudgetAlert"
+	fieldName string // e.g., "alerts" (snake_case)
+	pos       token.Pos
+}
+
+// overlayBodyResult holds the results of analyzing an overlay function body.
+type overlayBodyResult struct {
+	assignments map[string]*fieldAssignment
+	subOverlays []subOverlayCall
+}
+
 func run(pass *analysis.Pass) (any, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
@@ -51,6 +66,9 @@ func run(pass *analysis.Pass) (any, error) {
 	if len(facts.Schemas) == 0 {
 		return nil, nil
 	}
+
+	// Build a map of all function declarations for sub-overlay lookups.
+	funcDecls := buildFuncDeclMap(insp)
 
 	// Find overlay functions. These are functions whose name starts with "overlay"
 	// and ends with "ComputedFields" (top-level overlays).
@@ -82,14 +100,98 @@ func run(pass *analysis.Pass) (any, error) {
 			return
 		}
 
-		// Analyze the function body for field assignments.
-		assignments := analyzeOverlayBody(fn.Body, planParamName)
+		// Analyze the function body for field assignments and sub-overlay calls.
+		bodyResult := analyzeOverlayBody(fn.Body, planParamName)
+
+		// Resolve Go field names to schema keys via tfsdk struct tags.
+		tagMap := buildTagMap(pass, fn)
+		resolveFieldNames(&bodyResult, tagMap)
 
 		// Cross-reference assignments against schema classification.
-		validateOverlay(pass, fn, schemaInfo, assignments, planParamName)
+		validateOverlay(pass, fn, schemaInfo, bodyResult.assignments, planParamName)
+
+		// Enforce that nested attributes with computed fields use sub-overlay helpers.
+		enforceSubOverlayHelpers(pass, fn, schemaInfo, bodyResult.subOverlays)
+
+		// Recursively validate sub-overlay functions against nested schemas.
+		validateSubOverlays(pass, schemaInfo, bodyResult.subOverlays, funcDecls, nil)
 	})
 
 	return nil, nil
+}
+
+// buildFuncDeclMap collects all function declarations in the package,
+// keyed by function name. Used for looking up sub-overlay functions.
+func buildFuncDeclMap(insp *inspector.Inspector) map[string]*ast.FuncDecl {
+	result := make(map[string]*ast.FuncDecl)
+	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil)}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Name != nil && fn.Body != nil {
+			result[fn.Name.Name] = fn
+		}
+	})
+	return result
+}
+
+// validateSubOverlays recursively validates sub-overlay functions against
+// the nested schemas of their parent fields.
+func validateSubOverlays(
+	pass *analysis.Pass,
+	parentSchema *schemaparser.SchemaInfo,
+	calls []subOverlayCall,
+	funcDecls map[string]*ast.FuncDecl,
+	visited map[string]bool,
+) {
+	if visited == nil {
+		visited = make(map[string]bool)
+	}
+
+	for _, call := range calls {
+		// Prevent infinite recursion.
+		if visited[call.funcName] {
+			continue
+		}
+		visited[call.funcName] = true
+
+		// Look up the nested schema for this field.
+		parentAttr, ok := parentSchema.Attrs[call.fieldName]
+		if !ok || parentAttr.NestedAttrs == nil {
+			continue // no nested schema to validate against
+		}
+
+		// Find the sub-overlay function declaration.
+		subFn, ok := funcDecls[call.funcName]
+		if !ok {
+			continue // function not found (may be in another package)
+		}
+
+		// Determine the plan parameter (second pointer param for sub-overlays).
+		planParam := findPlanParamName(subFn)
+		if planParam == "" {
+			continue
+		}
+
+		// Build a synthetic SchemaInfo from the nested attrs.
+		nestedSchema := &schemaparser.SchemaInfo{
+			Attrs: parentAttr.NestedAttrs,
+		}
+
+		// Analyze and validate the sub-overlay body.
+		bodyResult := analyzeOverlayBody(subFn.Body, planParam)
+
+		// Resolve Go field names to schema keys via tfsdk struct tags.
+		tagMap := buildTagMap(pass, subFn)
+		resolveFieldNames(&bodyResult, tagMap)
+
+		validateOverlay(pass, subFn, nestedSchema, bodyResult.assignments, planParam)
+
+		// Enforce sub-overlay helpers for deeper nested attrs too.
+		enforceSubOverlayHelpers(pass, subFn, nestedSchema, bodyResult.subOverlays)
+
+		// Recurse into deeper sub-overlays.
+		validateSubOverlays(pass, nestedSchema, bodyResult.subOverlays, funcDecls, visited)
+	}
 }
 
 // isTopLevelOverlay checks if a function name matches the top-level overlay pattern.
@@ -121,6 +223,8 @@ func matchOverlayToSchema(overlayName string, facts *schemaparser.SchemaFacts) *
 
 // findPlanParamName returns the name of the plan/model parameter.
 // Convention: the last parameter that is a pointer type is the plan.
+// When multiple names share a type (e.g., `resolved, plan *Type`),
+// the last name is the plan parameter.
 func findPlanParamName(fn *ast.FuncDecl) string {
 	if fn.Type.Params == nil {
 		return ""
@@ -131,7 +235,7 @@ func findPlanParamName(fn *ast.FuncDecl) string {
 		p := params[i]
 		if _, ok := p.Type.(*ast.StarExpr); ok {
 			if len(p.Names) > 0 {
-				return p.Names[0].Name
+				return p.Names[len(p.Names)-1].Name
 			}
 		}
 	}
@@ -140,9 +244,11 @@ func findPlanParamName(fn *ast.FuncDecl) string {
 
 // analyzeOverlayBody walks the overlay function body and records all
 // assignments to plan.FieldName, noting whether they are unconditional
-// or guarded by IsUnknown().
-func analyzeOverlayBody(body *ast.BlockStmt, planParam string) map[string]*fieldAssignment {
-	result := make(map[string]*fieldAssignment)
+// or guarded by IsUnknown(). It also records calls to sub-overlay functions.
+func analyzeOverlayBody(body *ast.BlockStmt, planParam string) overlayBodyResult {
+	result := overlayBodyResult{
+		assignments: make(map[string]*fieldAssignment),
+	}
 
 	for _, stmt := range body.List {
 		switch s := stmt.(type) {
@@ -151,11 +257,16 @@ func analyzeOverlayBody(body *ast.BlockStmt, planParam string) map[string]*field
 			for _, lhs := range s.Lhs {
 				fieldName := selectorFieldOn(lhs, planParam)
 				if fieldName != "" {
-					result[fieldName] = &fieldAssignment{
+					result.assignments[fieldName] = &fieldAssignment{
 						unconditional: true,
 						pos:           s.Pos(),
 					}
 				}
+			}
+			// Also check RHS for sub-overlay calls in assignments like:
+			// diags = overlayListElements(ctx, &resolved.X, &plan.X, overlayFn)
+			for _, rhs := range s.Rhs {
+				collectSubOverlayCallsFromExpr(rhs, planParam, &result)
 			}
 
 		case *ast.IfStmt:
@@ -169,7 +280,7 @@ func analyzeOverlayBody(body *ast.BlockStmt, planParam string) map[string]*field
 						for _, lhs := range inner.Lhs {
 							fieldName := selectorFieldOn(lhs, planParam)
 							if fieldName != "" {
-								result[fieldName] = &fieldAssignment{
+								result.assignments[fieldName] = &fieldAssignment{
 									guardedByIsUnknown: true,
 									pos:                inner.Pos(),
 								}
@@ -177,13 +288,13 @@ func analyzeOverlayBody(body *ast.BlockStmt, planParam string) map[string]*field
 						}
 					case *ast.ExprStmt:
 						// Handle &plan.X passed to helper functions inside if body.
-						handleExprForListOverlay(inner.X, planParam, result, inner.Pos())
+						handleExprForListOverlay(inner.X, planParam, result.assignments, inner.Pos())
 					}
 				}
 				// If no explicit assignment found in the body but the guard is
 				// present, record the guarded field as IsUnknown-guarded.
-				if _, exists := result[guardedField]; !exists {
-					result[guardedField] = &fieldAssignment{
+				if _, exists := result.assignments[guardedField]; !exists {
+					result.assignments[guardedField] = &fieldAssignment{
 						guardedByIsUnknown: true,
 						pos:                s.Pos(),
 					}
@@ -192,13 +303,16 @@ func analyzeOverlayBody(body *ast.BlockStmt, planParam string) map[string]*field
 				// Also handle if-else chains after IsUnknown guard:
 				// `if plan.X.IsUnknown() { ... } else if !plan.X.IsNull() { ... }`
 				if s.Else != nil {
-					walkElseChainForAssignments(s.Else, planParam, result, s.Pos())
+					walkElseChainForAssignments(s.Else, planParam, result.assignments, s.Pos())
+					// Also collect sub-overlay calls from the else chain.
+					// This catches: else if !plan.X.IsNull() { overlayListElements(..., overlayFn) }
+					collectSubOverlayCallsFromElse(s.Else, planParam, &result)
 				}
 			} else {
 				// Not an IsUnknown guard. Check for if/else covering all paths:
 				// `if apiResp.X != nil { plan.F = val } else { plan.F = null }`
 				// Both branches assign to plan.F → treat as unconditional.
-				detectIfElseUnconditional(s, planParam, result)
+				detectIfElseUnconditional(s, planParam, result.assignments)
 
 				// Also scan for &plan.X passed to helper functions inside if-body
 				// and else branches. This catches patterns like:
@@ -207,17 +321,174 @@ func analyzeOverlayBody(body *ast.BlockStmt, planParam string) map[string]*field
 				//   } else if plan.Config.IsUnknown() {
 				//       plan.Config = resolved.Config
 				//   }
-				scanIfTreeForFieldHandling(s, planParam, result)
+				scanIfTreeForFieldHandling(s, planParam, result.assignments)
+
+				// Track sub-overlay calls within if-trees.
+				collectSubOverlayCalls(s, planParam, &result)
 			}
 
 		case *ast.ExprStmt:
 			// Handle: diags.Append(overlayListElements(..., &plan.X, ...)...)
 			// These indicate the field is being handled (for list overlay).
-			handleExprForListOverlay(s.X, planParam, result, s.Pos())
+			handleExprForListOverlay(s.X, planParam, result.assignments, s.Pos())
+
+			// Track sub-overlay calls (overlayListElements with callback, or direct calls).
+			collectSubOverlayCallsFromExpr(s.X, planParam, &result)
 		}
 	}
 
 	return result
+}
+
+// collectSubOverlayCalls extracts sub-overlay function calls from an if-tree.
+// Handles patterns like:
+//
+//	if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
+//	    diags.Append(overlayConfigFields(ctx, &resolved.Config, &plan.Config)...)
+//	}
+//
+// collectSubOverlayCallsFromElse walks an else chain and collects sub-overlay calls.
+func collectSubOverlayCallsFromElse(elseStmt ast.Stmt, planParam string, result *overlayBodyResult) {
+	switch e := elseStmt.(type) {
+	case *ast.BlockStmt:
+		for _, stmt := range e.List {
+			if es, ok := stmt.(*ast.ExprStmt); ok {
+				collectSubOverlayCallsFromExpr(es.X, planParam, result)
+			}
+			if as, ok := stmt.(*ast.AssignStmt); ok {
+				for _, rhs := range as.Rhs {
+					collectSubOverlayCallsFromExpr(rhs, planParam, result)
+				}
+			}
+			if ret, ok := stmt.(*ast.ReturnStmt); ok {
+				for _, r := range ret.Results {
+					collectSubOverlayCallsFromExpr(r, planParam, result)
+				}
+			}
+		}
+	case *ast.IfStmt:
+		collectSubOverlayCalls(e, planParam, result)
+	}
+}
+
+func collectSubOverlayCalls(ifStmt *ast.IfStmt, planParam string, result *overlayBodyResult) {
+	if ifStmt.Body != nil {
+		for _, stmt := range ifStmt.Body.List {
+			if es, ok := stmt.(*ast.ExprStmt); ok {
+				collectSubOverlayCallsFromExpr(es.X, planParam, result)
+			}
+			if as, ok := stmt.(*ast.AssignStmt); ok {
+				for _, rhs := range as.Rhs {
+					collectSubOverlayCallsFromExpr(rhs, planParam, result)
+				}
+			}
+			if ret, ok := stmt.(*ast.ReturnStmt); ok {
+				for _, r := range ret.Results {
+					collectSubOverlayCallsFromExpr(r, planParam, result)
+				}
+			}
+		}
+	}
+	// Recurse into else branches.
+	if ifStmt.Else != nil {
+		switch e := ifStmt.Else.(type) {
+		case *ast.IfStmt:
+			collectSubOverlayCalls(e, planParam, result)
+		case *ast.BlockStmt:
+			for _, stmt := range e.List {
+				if es, ok := stmt.(*ast.ExprStmt); ok {
+					collectSubOverlayCallsFromExpr(es.X, planParam, result)
+				}
+			}
+		}
+	}
+}
+
+// collectSubOverlayCallsFromExpr inspects an expression for sub-overlay
+// function calls. It detects two patterns:
+//
+//  1. overlayListElements(ctx, &resolved.X, &plan.X, overlayCallback)
+//     → records overlayCallback as sub-overlay for field X
+//
+//  2. overlayHelperFunc(&resolved.X, &plan.X) or overlayHelperFunc(ctx, &resolved.X, &plan.X)
+//     → records overlayHelperFunc as sub-overlay for field X
+func collectSubOverlayCallsFromExpr(expr ast.Expr, planParam string, result *overlayBodyResult) {
+	ast.Inspect(expr, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		calledName := calledFuncNameFromExpr(call)
+		if calledName == "" {
+			return true
+		}
+
+		// Pattern 1: overlayListElements(ctx, &resolved.X, &plan.X, overlayCallback)
+		if calledName == "overlayListElements" || calledName == "overlayListElementsByKey" {
+			if len(call.Args) >= 4 {
+				// The plan field is the third argument: &plan.X
+				fieldName := extractFieldFromAddrExpr(call.Args[2], planParam)
+				// The callback is the last argument
+				callbackName := identName(call.Args[len(call.Args)-1])
+				if fieldName != "" && callbackName != "" && strings.HasPrefix(callbackName, "overlay") {
+					result.subOverlays = append(result.subOverlays, subOverlayCall{
+						funcName:  callbackName,
+						fieldName: fieldName,
+						pos:       call.Pos(),
+					})
+				}
+			}
+			return false // don't recurse into overlayListElements args
+		}
+
+		// Pattern 2: overlayHelperFunc(..., &plan.X) — direct sub-overlay call
+		if strings.HasPrefix(calledName, "overlay") && !isTopLevelOverlay(calledName) {
+			for _, arg := range call.Args {
+				fieldName := extractFieldFromAddrExpr(arg, planParam)
+				if fieldName != "" {
+					result.subOverlays = append(result.subOverlays, subOverlayCall{
+						funcName:  calledName,
+						fieldName: fieldName,
+						pos:       call.Pos(),
+					})
+					break // one field per sub-overlay call
+				}
+			}
+		}
+
+		return true
+	})
+}
+
+// extractFieldFromAddrExpr extracts the field name from &planParam.FieldName.
+func extractFieldFromAddrExpr(expr ast.Expr, planParam string) string {
+	unary, ok := expr.(*ast.UnaryExpr)
+	if !ok || unary.Op != token.AND {
+		return ""
+	}
+	return selectorFieldOn(unary.X, planParam)
+}
+
+// calledFuncNameFromExpr extracts the function name from a call expression,
+// handling both direct calls and selector calls (r.method()).
+func calledFuncNameFromExpr(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	}
+	return ""
+}
+
+// identName extracts the name from an *ast.Ident.
+func identName(expr ast.Expr) string {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return ident.Name
 }
 
 // detectIfElseUnconditional checks if an if/else assigns to the same plan field
@@ -511,6 +782,61 @@ func validateOverlay(pass *analysis.Pass, fn *ast.FuncDecl, schema *schemaparser
 	}
 }
 
+// enforceSubOverlayHelpers verifies that nested attributes with Computed-only
+// or Optional+Computed children use sub-overlay helper functions (e.g.,
+// overlayListElements callbacks or direct overlay* calls) rather than inline
+// handling. This ensures consistent patterns across all overlay functions.
+func enforceSubOverlayHelpers(
+	pass *analysis.Pass,
+	fn *ast.FuncDecl,
+	schema *schemaparser.SchemaInfo,
+	subOverlays []subOverlayCall,
+) {
+	// Build a set of field names that have sub-overlay calls.
+	coveredFields := make(map[string]bool, len(subOverlays))
+	for _, call := range subOverlays {
+		coveredFields[call.fieldName] = true
+	}
+
+	for attrName, attrInfo := range schema.Attrs {
+		if attrInfo.NestedAttrs == nil {
+			continue
+		}
+		// Computed-only nested objects are always assigned unconditionally
+		// (plan.X = resolved.X), so no sub-overlay helper is needed.
+		if attrInfo.Class == schemaparser.ComputedOnly {
+			continue
+		}
+		// Only check nested attrs that contain fields needing overlay.
+		if !nestedHasOverlayFields(attrInfo.NestedAttrs) {
+			continue
+		}
+		// Skip if a sub-overlay call already exists for this field.
+		if coveredFields[attrName] {
+			continue
+		}
+		pass.Reportf(fn.Pos(),
+			"%s: nested attribute %q has computed fields that need overlay; "+
+				"extract a sub-overlay helper function (e.g., overlayListElements or overlay%sXxx)",
+			fn.Name.Name, attrName, strings.Title(attrName)) //nolint:staticcheck // strings.Title is fine for diagnostics
+	}
+}
+
+// nestedHasOverlayFields returns true if any attribute in the map is
+// Computed-only or Optional+Computed (i.e., fields that require overlay handling).
+func nestedHasOverlayFields(attrs map[string]*schemaparser.AttrInfo) bool {
+	for _, attr := range attrs {
+		if attr.Class == schemaparser.ComputedOnly || attr.Class == schemaparser.OptionalComputed {
+			return true
+		}
+		// Recurse into deeper nested attrs.
+		if attr.NestedAttrs != nil && nestedHasOverlayFields(attr.NestedAttrs) {
+			return true
+		}
+	}
+	return false
+}
+
 // validate2PhasePattern checks that an overlay function uses the standard
 // 2-phase pattern:
 //
@@ -613,4 +939,125 @@ func toSnakeCase(s string) string {
 		}
 	}
 	return result.String()
+}
+
+// buildTagMap extracts a Go-field-name → tfsdk-tag-name mapping from the plan
+// parameter's struct type. This handles cases where the code generator prefixes
+// Go field names to avoid keyword collisions (e.g., DimensionsType → tfsdk:"type").
+//
+// Returns nil if the plan parameter's type cannot be resolved.
+func buildTagMap(pass *analysis.Pass, fn *ast.FuncDecl) map[string]string {
+	if fn.Type.Params == nil || pass.TypesInfo == nil {
+		return nil
+	}
+
+	// Find the plan parameter (last pointer parameter).
+	params := fn.Type.Params.List
+	var planField *ast.Field
+	for i := len(params) - 1; i >= 0; i-- {
+		if _, ok := params[i].Type.(*ast.StarExpr); ok {
+			planField = params[i]
+			break
+		}
+	}
+	if planField == nil || len(planField.Names) == 0 {
+		return nil
+	}
+
+	// Resolve the plan parameter's type via the type checker.
+	planIdent := planField.Names[len(planField.Names)-1]
+	obj := pass.TypesInfo.Defs[planIdent]
+	if obj == nil {
+		return nil
+	}
+
+	// Dereference pointer to get the struct type.
+	typ := obj.Type()
+	if ptr, ok := typ.(*types.Pointer); ok {
+		typ = ptr.Elem()
+	}
+
+	// Unwrap named types to get the underlying struct.
+	structType, ok := typ.Underlying().(*types.Struct)
+	if !ok {
+		return nil
+	}
+
+	return buildTagMapFromStruct(structType)
+}
+
+// buildTagMapFromStruct builds a Go-field-name → tfsdk-tag-name mapping
+// from a types.Struct by parsing `tfsdk:"..."` struct tags.
+func buildTagMapFromStruct(s *types.Struct) map[string]string {
+	tagMap := make(map[string]string)
+	for i := 0; i < s.NumFields(); i++ {
+		field := s.Field(i)
+		tag := s.Tag(i)
+		if tag == "" {
+			continue
+		}
+		tfsdkTag := reflect.StructTag(tag).Get("tfsdk")
+		if tfsdkTag == "" || tfsdkTag == "-" {
+			continue
+		}
+		// Strip options after comma (e.g., tfsdk:"name,omitempty").
+		if idx := strings.IndexByte(tfsdkTag, ','); idx >= 0 {
+			tfsdkTag = tfsdkTag[:idx]
+		}
+		tagMap[field.Name()] = tfsdkTag
+	}
+	return tagMap
+}
+
+// resolveFieldNames translates Go field names in an overlay body result to
+// schema keys using the tfsdk struct tag mapping. Falls back to toSnakeCase
+// for fields not found in the tag map.
+//
+// This fixes false positives where code-generated Go names don't match schema
+// keys via simple snake_case conversion (e.g., DimensionsType → "type", not
+// "dimensions_type").
+func resolveFieldNames(result *overlayBodyResult, tagMap map[string]string) {
+	if tagMap == nil {
+		return // no type info available; toSnakeCase was already applied
+	}
+
+	// Rebuild the assignments map with resolved keys.
+	resolved := make(map[string]*fieldAssignment, len(result.assignments))
+	for goName, assignment := range result.assignments {
+		schemaKey := resolveGoNameToSchemaKey(goName, tagMap)
+		resolved[schemaKey] = assignment
+	}
+	result.assignments = resolved
+
+	// Resolve field names in sub-overlay calls.
+	for i := range result.subOverlays {
+		result.subOverlays[i].fieldName = resolveGoNameToSchemaKey(
+			result.subOverlays[i].fieldName, tagMap,
+		)
+	}
+}
+
+// resolveGoNameToSchemaKey converts a Go field name to its schema key.
+// It first checks if the selectorFieldOn already produced a snake_case name
+// that exists in the tagMap values (i.e., toSnakeCase happened to produce the
+// right answer). If not, it looks for the original Go name in the tagMap keys.
+func resolveGoNameToSchemaKey(snakeName string, tagMap map[string]string) string {
+	// Check if snakeName is already a valid tfsdk tag value.
+	for _, v := range tagMap {
+		if v == snakeName {
+			return snakeName
+		}
+	}
+
+	// The snakeName was produced by toSnakeCase from a Go field name.
+	// Try to reverse-lookup: find a Go field name whose toSnakeCase matches,
+	// then use its tfsdk tag instead.
+	for goName, tfsdkName := range tagMap {
+		if toSnakeCase(goName) == snakeName {
+			return tfsdkName
+		}
+	}
+
+	// No match found — keep the snake_case name as-is.
+	return snakeName
 }

--- a/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
+++ b/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
@@ -135,7 +135,7 @@ func overlayRequiredNestedComputedFields(apiResp *ApiResponse, plan *RequiredNes
 
 // --- BAD: Required nested object handled inline (should use helper) ---
 
-func overlayRequiredNestedInlineComputedFields(apiResp *ApiResponse, plan *RequiredNestedModel) { // want `overlayRequiredNestedInlineComputedFields: nested attribute "config" has computed fields that need overlay`
+func overlayRequiredNestedInlineComputedFields(apiResp *ApiResponse, plan *RequiredNestedModel) { // want `overlayRequiredNestedInlineComputedFields: nested attribute\(s\) with computed fields need sub-overlay helpers: config`
 	resolved := *plan
 	mapRequiredNestedToModel(apiResp, &resolved)
 

--- a/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
+++ b/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
@@ -1,6 +1,10 @@
 package overlaytest
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 // Stub mapping functions for test.
 func mapGoodToModel(apiResp *ApiResponse, m *GoodModel)             {}
@@ -91,7 +95,29 @@ func overlayIfElseComputedFields(apiResp *Int64Pointer, plan *IfElseModel) {
 	}
 }
 
-// --- GOOD: Required nested object with IsUnknown guard ---
+// --- GOOD: Computed-only nested object assigned unconditionally (no helper needed) ---
+
+func mapComputedOnlyNestedToModel(apiResp *ApiResponse, m *ComputedOnlyNestedModel) {}
+
+func overlayComputedOnlyNestedComputedFields(apiResp *ApiResponse, plan *ComputedOnlyNestedModel) {
+	resolved := *plan
+	mapComputedOnlyNestedToModel(apiResp, &resolved)
+
+	// Computed-only fields: unconditional.
+	plan.Id = resolved.Id
+	plan.Summary = resolved.Summary // Computed-only nested — no sub-overlay needed. ✓
+}
+
+// --- GOOD: Required nested object handled via sub-overlay helper ---
+
+func overlayRequiredNestedConfig(resolved *ConfigValue, plan *ConfigValue) {
+	if plan.Mode.IsUnknown() {
+		plan.Mode = resolved.Mode
+	}
+	if plan.Amount.IsUnknown() {
+		plan.Amount = resolved.Amount
+	}
+}
 
 func overlayRequiredNestedComputedFields(apiResp *ApiResponse, plan *RequiredNestedModel) {
 	resolved := *plan
@@ -99,7 +125,23 @@ func overlayRequiredNestedComputedFields(apiResp *ApiResponse, plan *RequiredNes
 
 	plan.Id = resolved.Id
 
-	// Required nested object with Optional+Computed children: IsUnknown guard is OK. ✓
+	// Required nested object with Optional+Computed children: handled via helper. ✓
+	if plan.Config.IsUnknown() {
+		plan.Config = resolved.Config
+	} else if !plan.Config.IsNull() {
+		overlayRequiredNestedConfig(&resolved.Config, &plan.Config)
+	}
+}
+
+// --- BAD: Required nested object handled inline (should use helper) ---
+
+func overlayRequiredNestedInlineComputedFields(apiResp *ApiResponse, plan *RequiredNestedModel) { // want `overlayRequiredNestedInlineComputedFields: nested attribute "config" has computed fields that need overlay`
+	resolved := *plan
+	mapRequiredNestedToModel(apiResp, &resolved)
+
+	plan.Id = resolved.Id
+
+	// INLINE handling — should be flagged. ✗
 	if plan.Config.IsUnknown() {
 		plan.Config = resolved.Config
 	}
@@ -140,7 +182,17 @@ func overlayNoMappingComputedFields(apiResp *ApiResponse, plan *GoodModel) { // 
 // --- GOOD: Optional+Computed nested field handled via helper function ---
 
 func mapHelperOverlayToModel(apiResp *ApiResponse, m *HelperOverlayModel) {}
-func overlayHelperConfigFields(resolved *ConfigValue, plan *ConfigValue)   {}
+
+func overlayHelperConfigFields(resolved *ConfigValue, plan *ConfigValue) {
+	// mode: Optional+Computed — guarded by IsUnknown. ✓
+	if plan.Mode.IsUnknown() {
+		plan.Mode = resolved.Mode
+	}
+	// amount: Optional+Computed — guarded by IsUnknown. ✓
+	if plan.Amount.IsUnknown() {
+		plan.Amount = resolved.Amount
+	}
+}
 
 func overlayHelperOverlayComputedFields(apiResp *ApiResponse, plan *HelperOverlayModel) {
 	resolved := *plan
@@ -171,3 +223,169 @@ func overlayDefaultComputedFields(apiResp *ApiResponse, plan *DefaultModel) {
 	// folder_id: has schema Default — never Unknown at plan time. ✓
 	// No IsUnknown() guard needed.
 }
+
+// --- GOOD: Prefixed Go field name (DimensionsType → tfsdk:"type") ---
+// The code generator prefixes "type" with the parent struct name because
+// "type" is a Go keyword. The overlay correctly handles it via DimensionsType.
+
+func mapPrefixedTypeToModel(apiResp *ApiResponse, m *PrefixedTypeModel) {}
+
+func overlayPrefixedTypeComputedFields(apiResp *ApiResponse, plan *PrefixedTypeModel) {
+	resolved := *plan
+	mapPrefixedTypeToModel(apiResp, &resolved)
+
+	// Computed-only: unconditional. ✓
+	plan.Id = resolved.Id
+
+	// Optional+Computed via prefixed Go name (DimensionsType → tfsdk:"type"). ✓
+	if plan.DimensionsType.IsUnknown() {
+		plan.DimensionsType = resolved.DimensionsType
+	}
+	if plan.Amount.IsUnknown() {
+		plan.Amount = resolved.Amount
+	}
+}
+
+// --- BAD: Prefixed Go field name missing in overlay ---
+
+func mapPrefixedTypeBadToModel(apiResp *ApiResponse, m *PrefixedTypeModel) {}
+
+func overlayPrefixedTypeBadComputedFields(apiResp *ApiResponse, plan *PrefixedTypeModel) { // want `overlayPrefixedTypeBadComputedFields: Optional\+Computed field\(s\) not handled: type`
+	resolved := *plan
+	mapPrefixedTypeBadToModel(apiResp, &resolved)
+
+	plan.Id = resolved.Id
+
+	// amount: handled. ✓
+	if plan.Amount.IsUnknown() {
+		plan.Amount = resolved.Amount
+	}
+	// DimensionsType (tfsdk:"type"): MISSING! ✗
+}
+
+// --- GOOD: Sub-overlay handles all nested fields correctly ---
+
+
+func mapNestedListToModel(apiResp *ApiResponse, m *NestedListModel) {}
+
+func overlayGoodNestedAlert(_ *ApiResponse, resolved, plan *AlertsValue) {
+	// percentage: Optional+Computed — guarded by IsUnknown. ✓
+	if plan.Percentage.IsUnknown() {
+		plan.Percentage = resolved.Percentage
+	}
+	// triggered: Computed-only — unconditional. ✓
+	plan.Triggered = resolved.Triggered
+	// threshold: Required — not mentioned. ✓
+}
+
+func overlayNestedListComputedFields(apiResp *ApiResponse, plan *NestedListModel) {
+	resolved := *plan
+	mapNestedListToModel(apiResp, &resolved)
+
+	// Computed-only: unconditional. ✓
+	plan.Id = resolved.Id
+
+	// Alerts: Optional+Computed list — overlay elements. ✓
+	if plan.Alerts.IsUnknown() {
+		plan.Alerts = resolved.Alerts
+	} else if !plan.Alerts.IsNull() {
+		overlayListElements(ctx, &resolved.Alerts, &plan.Alerts, overlayGoodNestedAlert)
+	}
+}
+
+// --- BAD: Sub-overlay missing Computed-only nested field ---
+
+func overlayBadNestedMissing(_ *ApiResponse, resolved, plan *AlertsValue) { // want `overlayBadNestedMissing: Computed-only field\(s\) not set from API response: triggered`
+	// percentage: Optional+Computed — guarded by IsUnknown. ✓
+	if plan.Percentage.IsUnknown() {
+		plan.Percentage = resolved.Percentage
+	}
+	// triggered: Computed-only — MISSING! ✗
+}
+
+func mapBadNestedMissingToModel(apiResp *ApiResponse, m *NestedListModel) {}
+
+func overlayBadNestedMissingComputedFields(apiResp *ApiResponse, plan *NestedListModel) {
+	resolved := *plan
+	mapBadNestedMissingToModel(apiResp, &resolved)
+
+	plan.Id = resolved.Id
+
+	if plan.Alerts.IsUnknown() {
+		plan.Alerts = resolved.Alerts
+	} else if !plan.Alerts.IsNull() {
+		overlayListElements(ctx, &resolved.Alerts, &plan.Alerts, overlayBadNestedMissing)
+	}
+}
+
+// --- BAD: Sub-overlay unconditionally assigns Optional+Computed ---
+
+func overlayBadNestedUnconditional(_ *ApiResponse, resolved, plan *AlertsValue) {
+	// percentage: Optional+Computed — assigned unconditionally. ✗
+	plan.Percentage = resolved.Percentage // want `overlayBadNestedUnconditional: Optional\+Computed field "percentage" is assigned unconditionally`
+	// triggered: Computed-only — unconditional. ✓
+	plan.Triggered = resolved.Triggered
+}
+
+func mapBadNestedUncondToModel(apiResp *ApiResponse, m *NestedListModel) {}
+
+func overlayBadNestedUncondComputedFields(apiResp *ApiResponse, plan *NestedListModel) {
+	resolved := *plan
+	mapBadNestedUncondToModel(apiResp, &resolved)
+
+	plan.Id = resolved.Id
+
+	if plan.Alerts.IsUnknown() {
+		plan.Alerts = resolved.Alerts
+	} else if !plan.Alerts.IsNull() {
+		overlayListElements(ctx, &resolved.Alerts, &plan.Alerts, overlayBadNestedUnconditional)
+	}
+}
+
+// --- GOOD: Multi-level nesting with sub-overlay calling deeper sub-overlay ---
+
+func mapMultiLevelToModel(apiResp *ApiResponse, m *MultiLevelModel) {}
+
+func overlayMultiLevelComponent(_ *ApiResponse, resolved, plan *ComponentsValue) {
+	// case_insensitive: Optional+Computed — guarded. ✓
+	if plan.CaseInsensitive.IsUnknown() {
+		plan.CaseInsensitive = resolved.CaseInsensitive
+	}
+	// mode: Optional+Computed — guarded. ✓
+	if plan.Mode.IsUnknown() {
+		plan.Mode = resolved.Mode
+	}
+	// key: Required — not mentioned. ✓
+}
+
+func overlayMultiLevelRule(_ *ApiResponse, resolved, plan *RulesValue) {
+	// action: Optional+Computed — guarded. ✓
+	if plan.Action.IsUnknown() {
+		plan.Action = resolved.Action
+	}
+	// components: Optional+Computed list — overlay via deeper sub-overlay. ✓
+	if plan.Components.IsUnknown() {
+		plan.Components = resolved.Components
+	} else if !plan.Components.IsNull() {
+		overlayListElements(ctx, &resolved.Components, &plan.Components, overlayMultiLevelComponent)
+	}
+}
+
+func overlayMultiLevelComputedFields(apiResp *ApiResponse, plan *MultiLevelModel) {
+	resolved := *plan
+	mapMultiLevelToModel(apiResp, &resolved)
+
+	plan.Id = resolved.Id
+
+	if plan.Rules.IsUnknown() {
+		plan.Rules = resolved.Rules
+	} else if !plan.Rules.IsNull() {
+		overlayListElements(ctx, &resolved.Rules, &plan.Rules, overlayMultiLevelRule)
+	}
+}
+
+// Stub overlayListElements for test compilation.
+func overlayListElements(ctx context.Context, resolved, plan interface{}, fn interface{}) {}
+
+// Package-level ctx for test function calls.
+var ctx = context.Background()

--- a/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest_gen.go
+++ b/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest_gen.go
@@ -162,8 +162,76 @@ type ConfigValue struct {
 func (c ConfigValue) IsUnknown() bool { return false }
 func (c ConfigValue) IsNull() bool    { return false }
 
+// ComputedOnlyNestedModel — tests that Computed-only nested objects don't require helpers.
+type ComputedOnlyNestedModel struct {
+	Id      types.String
+	Name    types.String
+	Summary SummaryValue
+}
+
+// SummaryValue is a Computed-only nested type.
+type SummaryValue struct {
+	Total types.Int64
+	Count types.Int64
+}
+
+func (s SummaryValue) IsUnknown() bool { return false }
+func (s SummaryValue) IsNull() bool    { return false }
+
+// ComputedOnlyNestedResourceSchema — Computed-only nested object (no helper needed).
+func ComputedOnlyNestedResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"summary": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"total": schema.Int64Attribute{
+						Computed: true,
+					},
+					"count": schema.Int64Attribute{
+						Computed: true,
+					},
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
 // RequiredNestedResourceSchema — Required nested object with Optional+Computed children.
 func RequiredNestedResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"config": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"mode": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"amount": schema.Float64Attribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				Required: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+// RequiredNestedInlineResourceSchema — same schema; tests inline handling (should be flagged).
+func RequiredNestedInlineResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -248,6 +316,243 @@ func DefaultResourceSchema(ctx context.Context) schema.Schema {
 				Optional: true,
 				Computed: true,
 				Default:  "root", // stringdefault.StaticString("root") in real code
+			},
+		},
+	}
+}
+
+// PrefixedTypeModel — tests the code-gen pattern where Go field names
+// are prefixed to avoid keyword collisions (e.g., DimensionsType → tfsdk:"type").
+type PrefixedTypeModel struct {
+	Id             types.String  `tfsdk:"id"`
+	Name           types.String  `tfsdk:"name"`
+	DimensionsType types.String  `tfsdk:"type"`
+	Amount         types.Float64 `tfsdk:"amount"`
+}
+
+// PrefixedTypeResourceSchema — the schema key is "type" but the Go field is DimensionsType.
+func PrefixedTypeResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"amount": schema.Float64Attribute{
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// PrefixedTypeBadResourceSchema — same as PrefixedType; tests missing type field.
+func PrefixedTypeBadResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"amount": schema.Float64Attribute{
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// NestedListModel — has a ListNestedAttribute with mixed nested fields.
+type NestedListModel struct {
+	Id     types.String
+	Name   types.String
+	Alerts types.List
+}
+
+// AlertsValue is the nested element type.
+type AlertsValue struct {
+	Percentage types.Float64
+	Triggered  types.Bool
+	Threshold  types.Float64
+}
+
+func (a AlertsValue) IsUnknown() bool { return false }
+func (a AlertsValue) IsNull() bool    { return false }
+
+// BadNestedMissingResourceSchema — same schema as NestedList; tests missing computed nested field.
+func BadNestedMissingResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"alerts": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"percentage": schema.Float64Attribute{
+							Optional: true,
+							Computed: true,
+						},
+						"triggered": schema.BoolAttribute{
+							Computed: true,
+						},
+						"threshold": schema.Float64Attribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// BadNestedUncondResourceSchema — same schema as NestedList; tests unconditional O+C nested field.
+func BadNestedUncondResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"alerts": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"percentage": schema.Float64Attribute{
+							Optional: true,
+							Computed: true,
+						},
+						"triggered": schema.BoolAttribute{
+							Computed: true,
+						},
+						"threshold": schema.Float64Attribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// NestedListResourceSchema — ListNestedAttribute with mixed nested fields.
+func NestedListResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"alerts": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"percentage": schema.Float64Attribute{
+							Optional: true,
+							Computed: true,
+						},
+						"triggered": schema.BoolAttribute{
+							Computed: true,
+						},
+						"threshold": schema.Float64Attribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// MultiLevelModel — has nested objects within nested objects.
+type MultiLevelModel struct {
+	Id    types.String
+	Name  types.String
+	Rules types.List
+}
+
+// RulesValue is the top-level nested element.
+type RulesValue struct {
+	Action     types.String
+	Components types.List
+}
+
+func (r RulesValue) IsUnknown() bool { return false }
+func (r RulesValue) IsNull() bool    { return false }
+
+// ComponentsValue is the deeply nested element.
+type ComponentsValue struct {
+	Key            types.String
+	CaseInsensitive types.Bool
+	Mode           types.String
+}
+
+func (c ComponentsValue) IsUnknown() bool { return false }
+func (c ComponentsValue) IsNull() bool    { return false }
+
+// MultiLevelResourceSchema — nested objects within nested objects.
+func MultiLevelResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"rules": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"action": schema.StringAttribute{
+							Optional: true,
+							Computed: true,
+						},
+						"components": schema.ListNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"key": schema.StringAttribute{
+										Required: true,
+									},
+									"case_insensitive": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+									},
+									"mode": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/tools/linters/overlayinvariant/analyzer.go
+++ b/tools/linters/overlayinvariant/analyzer.go
@@ -190,13 +190,20 @@ func needsOverlay(fn *ast.FuncDecl, facts *schemaparser.SchemaFacts, schemaMetho
 		return true // schema exists but not parsed, assume needed
 	}
 
-	// Check if any field is Computed-only or Optional+Computed.
-	for _, attr := range schemaInfo.Attrs {
+	return hasOverlayFields(schemaInfo.Attrs)
+}
+
+// hasOverlayFields recursively checks whether any attribute (at any nesting
+// level) is Computed-only or Optional+Computed, which would require an overlay.
+func hasOverlayFields(attrs map[string]*schemaparser.AttrInfo) bool {
+	for _, attr := range attrs {
 		if attr.Class == schemaparser.ComputedOnly || attr.Class == schemaparser.OptionalComputed {
 			return true
 		}
+		if attr.NestedAttrs != nil && hasOverlayFields(attr.NestedAttrs) {
+			return true
+		}
 	}
-
 	return false
 }
 

--- a/tools/linters/overlayinvariant/testdata/src/invarianttest/invarianttest.go
+++ b/tools/linters/overlayinvariant/testdata/src/invarianttest/invarianttest.go
@@ -166,3 +166,36 @@ func (r *inlineSchemaResource) Create(ctx context.Context, req createRequest, re
 	var plan myModel
 	resp.State.Set(ctx, &plan)
 }
+
+// --- BAD: Create without overlay when nested attrs have Optional+Computed ---
+// Even though no top-level field is Optional+Computed, the nested "config.mode"
+// is, so an overlay is required.
+
+type nestedOnlyOCResource struct{}
+
+func overlayNestedOnlyOCComputedFields(m *myModel) {}
+
+func (r *nestedOnlyOCResource) Schema(ctx context.Context, req schemaRequest, resp *schemaResponse) {
+	s := NestedOnlyOCResourceSchema(ctx)
+	resp.Schema = s
+}
+
+func (r *nestedOnlyOCResource) Create(ctx context.Context, req createRequest, resp *createResponse) { // want "Create must call an overlay function"
+	var plan myModel
+	resp.State.Set(ctx, &plan)
+}
+
+// --- GOOD: Create with overlay when nested attrs have Optional+Computed ---
+
+type nestedOnlyOCGoodResource struct{}
+
+func (r *nestedOnlyOCGoodResource) Schema(ctx context.Context, req schemaRequest, resp *schemaResponse) {
+	s := NestedOnlyOCResourceSchema(ctx)
+	resp.Schema = s
+}
+
+func (r *nestedOnlyOCGoodResource) Create(ctx context.Context, req createRequest, resp *createResponse) {
+	var plan myModel
+	overlayNestedOnlyOCComputedFields(&plan)
+	resp.State.Set(ctx, &plan)
+}

--- a/tools/linters/overlayinvariant/testdata/src/invarianttest/invarianttest_gen.go
+++ b/tools/linters/overlayinvariant/testdata/src/invarianttest/invarianttest_gen.go
@@ -67,3 +67,24 @@ func AllRequiredResourceSchema(ctx context.Context) schema.Schema {
 		},
 	}
 }
+
+// NestedOnlyOCResourceSchema — Optional+Computed fields exist only inside a
+// nested object, not at the top level. The overlay should still be required.
+func NestedOnlyOCResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"config": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"mode": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				Required: true,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## What

Extends `overlaycheck` and `overlayinvariant` to validate nested attribute overlays, closing the gap where sub-overlay helpers were unchecked.

Closes #203

## Changes

### `overlaycheck` linter
- **Sub-overlay validation**: Follows `overlayListElements` callbacks and direct `overlay*(&plan.X)` calls; recursively validates nested O+C fields against the nested schema
- **tfsdk struct tag resolution**: Resolves code-gen prefixed field names (e.g., `DimensionsType` → `tfsdk:"type"`) via `pass.TypesInfo` to eliminate false positives
- **Helper enforcement**: Reports when O+C/Required nested attrs with computed children lack a sub-overlay helper function (Computed-only nested objects exempt)
- **`findPlanParamName` fix**: Returns last pointer param (was returning first, broke shared-type params)

### `overlayinvariant` linter
- `hasOverlayFields` now recurses into `NestedAttrs`

### Provider fixes (found by enhanced linter)
- Remove dead Required-field assignments in sub-overlays (`alert.go`, `allocation.go`, `budget.go`, `report.go`)
- Extract `overlayAllocationRuleFields` helper from inline handling
- Add `overlayInsightDismissalDetails` helper for missing sub-overlay

### Documentation
- Add "Nested Attributes" section to `overlay-pattern.md`
- Note that helper functions are enforced by the linter

## How validated
- All 19 linter test suites pass
- `make lint-tools` — 0 issues
- `make lint-build && ./custom-gcl run` — 0 issues
- New test cases cover: sub-overlay detection, tfsdk tag resolution, inline enforcement, Computed-only exemption, multi-level nesting