### PR TITLE
feat(linters): detect PointerValue drift risk for fields with schema defaults

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,8 @@ linters:
     - constructor
     - newexpr
     - unknownguard
+    - defaultdrift
+    - methodreceiver
   exclusions:
     generated: lax
     presets:
@@ -92,6 +94,8 @@ linters:
           - newexpr
           - unknownguard
           - diagdrop
+          - defaultdrift
+          - methodreceiver
       # Test files — exclude custom linters (except paralleltest which only applies to tests)
       - path: _test\.go
         linters:
@@ -110,6 +114,8 @@ linters:
           - newexpr
           - unknownguard
           - diagdrop
+          - defaultdrift
+          - methodreceiver
       # Data sources — exclude resource-only linters
       - path: _data_source\.go
         linters:
@@ -120,6 +126,7 @@ linters:
           - listnullread
           - usestatefunknown
           - crudnaming
+          - methodreceiver
       # Provider config — not a resource, no plan modifiers
       - path: provider\.go
         linters:
@@ -216,6 +223,12 @@ linters:
       diagdrop:
         type: "module"
         description: "Detects return nil that drops captured diag.Diagnostics variables."
+      defaultdrift:
+        type: "module"
+        description: "Flags PointerValue usage on fields with schema defaults in Read-path mapping functions."
+      methodreceiver:
+        type: "module"
+        description: "Flags mapping functions that should be free functions, not methods."
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -30,8 +30,8 @@ import (
 // NOT used by: Read, ImportState (which use populateState → mapAllocationToModel).
 //
 // NOTE: Unlike most resources, this overlay retains the receiver because
-// mapAllocationToModel makes additional API calls (r.client.GetAllocationWithResponse)
-// to fetch full allocation rule details for multi-rule allocations.
+// mapAllocationToModel needs the API client to fetch full allocation rule
+// details for multi-rule allocations.
 func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context, apiResp *models.Allocation, plan *allocationResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -39,7 +39,7 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	// Copy the plan so that mapAllocationToModel's sentinel restoration and alias
 	// normalization can compare against user-configured values in the existing state.
 	resolved := *plan
-	diags.Append(r.mapAllocationToModel(ctx, apiResp, &resolved)...)
+	diags.Append(mapAllocationToModel(ctx, r.client, apiResp, &resolved)...)
 	if diags.HasError() {
 		return diags
 	}
@@ -314,13 +314,13 @@ func (r *allocationResource) populateState(ctx context.Context, state *allocatio
 		return
 	}
 
-	return r.mapAllocationToModel(ctx, httpResp.JSON200, state)
+	return mapAllocationToModel(ctx, r.client, httpResp.JSON200, state)
 }
 
 // mapAllocationToModel maps an Allocation API response to the Terraform resource model.
 // This is used by both populateState (for Read) and directly by Create/Update
 // when the API returns the full object in the response.
-func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *models.Allocation, state *allocationResourceModel) (diags diag.Diagnostics) {
+func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponses, resp *models.Allocation, state *allocationResourceModel) (diags diag.Diagnostics) {
 	state.Id = types.StringPointerValue(resp.Id)
 	state.Type = types.StringPointerValue(resp.Type)
 	state.Description = types.StringPointerValue(resp.Description)
@@ -435,7 +435,7 @@ func (r *allocationResource) mapAllocationToModel(ctx context.Context, resp *mod
 
 			if (formula == "" || components == nil) && rule.Id != nil && action != "select" {
 				// Fetch full allocation to get formula and components
-				respHTTPFullAlloc, err := r.client.GetAllocationWithResponse(ctx, *rule.Id)
+				respHTTPFullAlloc, err := client.GetAllocationWithResponse(ctx, *rule.Id)
 				if err == nil && respHTTPFullAlloc.JSON200 != nil {
 					fullAlloc := respHTTPFullAlloc.JSON200
 					if fullAlloc.Rule != nil {

--- a/internal/provider/allocation_internal_test.go
+++ b/internal/provider/allocation_internal_test.go
@@ -158,8 +158,7 @@ func TestMapAllocationToModel_SingleRule_RulesNull(t *testing.T) {
 	state.Rule = resource_allocation.NewRuleValueNull()
 	state.Rules = types.ListNull(resource_allocation.RulesValue{}.Type(ctx))
 
-	r := &allocationResource{}
-	diags := r.mapAllocationToModel(ctx, apiResp, state)
+	diags := mapAllocationToModel(ctx, nil, apiResp, state)
 	if diags.HasError() {
 		t.Fatalf("mapAllocationToModel returned error: %v", diags)
 	}

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -452,7 +452,11 @@ func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budget
 	}
 
 	state.Currency = types.StringValue(string(resp.Currency))
-	state.Description = types.StringPointerValue(resp.Description)
+	if resp.Description != nil {
+		state.Description = types.StringValue(*resp.Description)
+	} else {
+		state.Description = types.StringValue("")
+	}
 
 	if resp.EndPeriod != nil && *resp.EndPeriod > 0 {
 		state.EndPeriod = types.Int64PointerValue(resp.EndPeriod)
@@ -460,8 +464,16 @@ func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budget
 		state.EndPeriod = types.Int64Null()
 	}
 
-	state.GrowthPerPeriod = types.Float64PointerValue(resp.GrowthPerPeriod)
-	state.Metric = types.StringPointerValue(resp.Metric)
+	if resp.GrowthPerPeriod != nil {
+		state.GrowthPerPeriod = types.Float64Value(*resp.GrowthPerPeriod)
+	} else {
+		state.GrowthPerPeriod = types.Float64Value(0)
+	}
+	if resp.Metric != nil {
+		state.Metric = types.StringValue(*resp.Metric)
+	} else {
+		state.Metric = types.StringValue("cost")
+	}
 	state.Name = types.StringValue(resp.Name)
 
 	if resp.Public != nil && *resp.Public != "" {
@@ -643,7 +655,11 @@ func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budget
 	state.StartPeriod = types.Int64Value(resp.StartPeriod)
 	state.TimeInterval = types.StringValue(resp.TimeInterval)
 	state.Type = types.StringValue(resp.Type)
-	state.UsePrevSpend = types.BoolPointerValue(resp.UsePrevSpend)
+	if resp.UsePrevSpend != nil {
+		state.UsePrevSpend = types.BoolValue(*resp.UsePrevSpend)
+	} else {
+		state.UsePrevSpend = types.BoolValue(false)
+	}
 
 	// Populate read-only fields
 	state.CreateTime = types.Int64PointerValue(resp.CreateTime)

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -1693,6 +1693,114 @@ func TestAccBudget_OmittedOptionalComputed(t *testing.T) {
 	})
 }
 
+// TestAccBudget_DefaultedScalarDrift tests that omitting Optional+Computed fields
+// with schema defaults does NOT cause perpetual plan drift.
+//
+// When a field has Default (e.g., metric defaults to "cost"), omitting it means
+// the plan resolves to "cost". After Create, Read calls mapBudgetToModel which
+// must also map the API response to "cost" (not null). If mapBudgetToModel uses
+// PointerValue and the API returns nil, state becomes null while the next plan
+// resolves to "cost" → drift.
+//
+// This test omits ALL defaulted scalar fields and verifies:
+// 1. After Create: state holds the default values (not null)
+// 2. After Read (drift check): plan is empty — state and plan agree.
+func TestAccBudget_DefaultedScalarDrift(t *testing.T) {
+	n := acctest.RandInt()
+
+	// Checks that verify defaulted scalar fields resolve to their schema defaults.
+	defaultedScalarChecks := []statecheck.StateCheck{
+		// description: Default("")
+		statecheck.ExpectKnownValue(
+			"doit_budget.defaulted_test",
+			tfjsonpath.New("description"),
+			knownvalue.StringExact("")),
+		// growth_per_period: Default(0)
+		statecheck.ExpectKnownValue(
+			"doit_budget.defaulted_test",
+			tfjsonpath.New("growth_per_period"),
+			knownvalue.Float64Exact(0)),
+		// metric: Default("cost")
+		statecheck.ExpectKnownValue(
+			"doit_budget.defaulted_test",
+			tfjsonpath.New("metric"),
+			knownvalue.StringExact("cost")),
+		// use_prev_spend: Default(false)
+		statecheck.ExpectKnownValue(
+			"doit_budget.defaulted_test",
+			tfjsonpath.New("use_prev_spend"),
+			knownvalue.Bool(false)),
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with ALL defaulted scalar fields omitted.
+			// The plan resolves them to their defaults; the overlay must agree.
+			{
+				Config: testAccBudgetDefaultedScalarsOmitted(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction("doit_budget.defaulted_test", plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: defaultedScalarChecks,
+			},
+			// Step 2: Drift check — Read refreshes state from API.
+			// If mapBudgetToModel maps nil → null for any defaulted field,
+			// the next plan will see null ≠ default → drift → test fails.
+			{
+				Config: testAccBudgetDefaultedScalarsOmitted(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: defaultedScalarChecks,
+			},
+		},
+	})
+}
+
+// testAccBudgetDefaultedScalarsOmitted creates a budget with ALL defaulted
+// scalar fields omitted: description, growth_per_period, metric, use_prev_spend.
+func testAccBudgetDefaultedScalarsOmitted(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "defaulted_test" {
+  name          = "test-default-drift-%d"
+  amount        = 100
+  currency      = "USD"
+  time_interval = "month"
+  type          = "recurring"
+  start_period  = local.start_period
+  scope         = ["%s"]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 }
+  ]
+  recipients = ["%s"]
+  # description, growth_per_period, metric, use_prev_spend are ALL intentionally
+  # omitted — they should resolve to their schema defaults.
+}
+`, budgetStartPeriod(), i, testAttribution(), testUser(), testUser())
+}
+
 func testAccBudgetMinimalOmitted(i int) string {
 	return fmt.Sprintf(`
 %s

--- a/tools/linters/defaultdrift/analyzer.go
+++ b/tools/linters/defaultdrift/analyzer.go
@@ -1,20 +1,15 @@
-// Package listnullread flags types.ListNull() usage in Read-path mapping
-// functions (mapXxxToModel / populateState) for list attributes that are
-// Optional or Optional+Computed.
+// Package defaultdrift flags PointerValue usage on fields with schema defaults
+// in mapToModel/populateState functions. When a field has a Default (e.g.,
+// stringdefault.StaticString("cost")), using PointerValue maps nil → null,
+// which silently drifts against the default value causing perpetual plan changes.
 //
-// The overlay resolves unknown lists to
-// empty [], so the Read path must also return [] (not null) for empty/nil
-// API responses. Using ListNull() here causes state churn (null↔[] flip)
-// on every apply.
-//
-// This analyzer uses schemaparser to know which attributes are lists and
-// their classification. It scopes the check to the specific schema
-// associated with the mapping function's receiver type, preventing false
-// positives when the same attribute name has different classifications
-// across resource and data source schemas.
-package listnullread
+// This analyzer uses schemaparser to know which fields have defaults and their
+// values, and scopes the check to mapping functions via receiver type → schema
+// association (same pattern as listnullread).
+package defaultdrift
 
 import (
+	"fmt"
 	"go/ast"
 	"strings"
 
@@ -24,12 +19,18 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-// Analyzer is the go/analysis Analyzer for listnullread.
+// Analyzer is the go/analysis Analyzer for defaultdrift.
 var Analyzer = &analysis.Analyzer{
-	Name:     "listnullread",
-	Doc:      "Flags types.ListNull() in Read paths for Optional/Optional+Computed list attributes.",
+	Name:     "defaultdrift",
+	Doc:      "Flags PointerValue usage on fields with schema defaults in Read-path mapping functions.",
 	Run:      run,
 	Requires: []*analysis.Analyzer{inspect.Analyzer, schemaparser.Analyzer},
+}
+
+// defaultedField records a field with a schema default and its value.
+type defaultedField struct {
+	name         string // snake_case schema name
+	defaultValue any    // extracted default value (string, float64, bool, int64)
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -42,27 +43,25 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	// Build per-schema maps of user-configurable list attributes.
-	perSchemaLists := map[string]map[string]bool{}
+	// Build per-schema maps of defaulted fields (including nested).
+	// Key: schema name, Value: map of snake_case field name → default value.
+	type fieldDefaults map[string]defaultedField
+	perSchemaDefaults := map[string]fieldDefaults{}
 	for schemaName, schemaInfo := range schemaResult.Schemas {
-		lists := map[string]bool{}
-		for fieldName, info := range schemaInfo.Attrs {
-			if info.IsList && (info.Class == schemaparser.Optional || info.Class == schemaparser.OptionalComputed) {
-				lists[fieldName] = true
-			}
-		}
-		if len(lists) > 0 {
-			perSchemaLists[schemaName] = lists
+		defaults := fieldDefaults{}
+		collectDefaultedFields(schemaInfo.Attrs, defaults, "")
+		if len(defaults) > 0 {
+			perSchemaDefaults[schemaName] = defaults
 		}
 	}
 
-	if len(perSchemaLists) == 0 {
+	if len(perSchemaDefaults) == 0 {
 		return nil, nil
 	}
 
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-	// Step 1: Map receiver types to their schema names via Schema() methods.
+	// Step 1: Map receiver types → schema names via Schema() methods.
 	receiverToSchema := map[string]string{}
 	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil)}
 	insp.Preorder(nodeFilter, func(n ast.Node) {
@@ -87,8 +86,7 @@ func run(pass *analysis.Pass) (any, error) {
 		receiverToSchema[recvType] = schemaName
 	})
 
-	// Step 2: Find mapping functions and check ListNull calls against
-	// the schema associated with the function's resource/data source type.
+	// Step 2: Find mapping functions and check PointerValue calls.
 	// Mapping functions may be methods (with a receiver) or free functions.
 	// For methods, we use the receiver type → schema mapping.
 	// For free functions, we look at the parameter types for a model type
@@ -119,14 +117,13 @@ func run(pass *analysis.Pass) (any, error) {
 			return
 		}
 
-		lists, ok := perSchemaLists[schemaName]
+		defaults, ok := perSchemaDefaults[schemaName]
 		if !ok {
 			return
 		}
 
-		// Find ListNull calls in the function body and check if they're
-		// assigned to user-configurable list fields for THIS schema.
-		findListNullAssignments(pass, fn.Body, lists)
+		// Find PointerValue assignments on defaulted fields.
+		findPointerValueAssignments(pass, fn, defaults)
 	})
 
 	return nil, nil
@@ -153,8 +150,10 @@ func resolveSchemaFromParams(fn *ast.FuncDecl, receiverToSchema map[string]strin
 		if strings.HasSuffix(typeName, "ResourceModel") {
 			resourceType = strings.TrimSuffix(typeName, "Model")
 		} else if strings.HasSuffix(typeName, "Model") {
+			// e.g., DriftTestModel → DriftTest → look for driftTestResource
 			base := strings.TrimSuffix(typeName, "Model")
 			resourceType = base + "Resource"
+			// Try lowercase first letter for private types.
 			if len(resourceType) > 0 {
 				resourceType = strings.ToLower(resourceType[:1]) + resourceType[1:]
 			}
@@ -179,6 +178,27 @@ func extractStarTypeName(expr ast.Expr) string {
 		return ident.Name
 	}
 	return ""
+}
+
+// collectDefaultedFields recursively collects fields with HasDefault into the map.
+// The prefix is used for nested attributes (e.g., "config." for config.enabled).
+// For the top level and for each nested level, field names are stored WITHOUT
+// the prefix so that they match the Go struct field names in assignments.
+func collectDefaultedFields(attrs map[string]*schemaparser.AttrInfo, out map[string]defaultedField, prefix string) {
+	for name, info := range attrs {
+		fullName := prefix + name
+		if info.HasDefault {
+			out[fullName] = defaultedField{
+				name:         fullName,
+				defaultValue: info.DefaultValue,
+			}
+		}
+		if info.NestedAttrs != nil {
+			// For nested attrs, also register the nested fields directly
+			// (without prefix) so they match in nested mapping functions.
+			collectDefaultedFields(info.NestedAttrs, out, "")
+		}
+	}
 }
 
 // isMappingFunction returns true if the function name matches the Read-path
@@ -213,18 +233,19 @@ func extractReceiverTypeName(fn *ast.FuncDecl) string {
 }
 
 // findSchemaCall finds the generated schema function call in a Schema() body.
-// Matches both resource and data source schema calls:
-//   - resource_xxx.XxxResourceSchema(ctx)
-//   - datasource_xxx.XxxDataSourceSchema(ctx)
 func findSchemaCall(fn *ast.FuncDecl) string {
-	for _, stmt := range fn.Body.List {
-		assign, ok := stmt.(*ast.AssignStmt)
+	var schemaName string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if schemaName != "" {
+			return false
+		}
+		assign, ok := n.(*ast.AssignStmt)
 		if !ok || len(assign.Rhs) != 1 {
-			continue
+			return true
 		}
 		call, ok := assign.Rhs[0].(*ast.CallExpr)
 		if !ok {
-			continue
+			return true
 		}
 		var name string
 		switch f := call.Fun.(type) {
@@ -233,36 +254,47 @@ func findSchemaCall(fn *ast.FuncDecl) string {
 		case *ast.Ident:
 			name = f.Name
 		default:
-			continue
+			return true
 		}
 		if strings.HasSuffix(name, "ResourceSchema") || strings.HasSuffix(name, "DataSourceSchema") {
-			return name
+			schemaName = name
 		}
-	}
-	return ""
+		return true
+	})
+	return schemaName
 }
 
-// findListNullAssignments finds assignments like:
+// pointerValueFuncs maps PointerValue function names to their type description.
+var pointerValueFuncs = map[string]bool{
+	"StringPointerValue":  true,
+	"Float64PointerValue": true,
+	"BoolPointerValue":    true,
+	"Int64PointerValue":   true,
+}
+
+// findPointerValueAssignments scans a function body for assignments like:
 //
-//	state.Scopes = types.ListNull(...)
+//	state.X = types.StringPointerValue(resp.X)
 //
-// and flags them if the field is a user-configurable list.
-func findListNullAssignments(pass *analysis.Pass, body *ast.BlockStmt, userConfigLists map[string]bool) {
-	ast.Inspect(body, func(n ast.Node) bool {
+// and flags them if X maps to a field with a schema default. Each finding is
+// reported at the assignment position to avoid golangci-lint --uniq-by-line
+// deduplication.
+func findPointerValueAssignments(pass *analysis.Pass, fn *ast.FuncDecl, defaults map[string]defaultedField) {
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		assign, ok := n.(*ast.AssignStmt)
 		if !ok {
 			return true
 		}
 
 		for i, rhs := range assign.Rhs {
-			if !isListNullCall(rhs) {
+			if !isPointerValueCall(rhs) {
 				continue
 			}
 			if i >= len(assign.Lhs) {
 				continue
 			}
 
-			// Check if the LHS is state.FieldName
+			// Check if the LHS is state.FieldName.
 			fieldName := extractFieldName(assign.Lhs[i])
 			if fieldName == "" {
 				continue
@@ -270,12 +302,10 @@ func findListNullAssignments(pass *analysis.Pass, body *ast.BlockStmt, userConfi
 
 			// Convert PascalCase to snake_case for schema lookup.
 			snakeName := toSnakeCase(fieldName)
-			if userConfigLists[snakeName] {
+			if df, ok := defaults[snakeName]; ok {
 				pass.Reportf(assign.Pos(),
-					"types.ListNull() used for Optional/Optional+Computed list field %q in Read path; "+
-						"use types.ListValueMust() with empty slice instead to avoid null↔[] state churn "+
-						"(use empty list for null/[] consistency)",
-					snakeName)
+					"PointerValue on field %q with schema default %v; use nil-fallback pattern",
+					snakeName, formatDefault(df.defaultValue))
 			}
 		}
 
@@ -283,8 +313,8 @@ func findListNullAssignments(pass *analysis.Pass, body *ast.BlockStmt, userConfi
 	})
 }
 
-// isListNullCall checks if an expression is types.ListNull(...).
-func isListNullCall(expr ast.Expr) bool {
+// isPointerValueCall checks if an expression is types.XxxPointerValue(...).
+func isPointerValueCall(expr ast.Expr) bool {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
 		return false
@@ -293,10 +323,10 @@ func isListNullCall(expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	if sel.Sel.Name != "ListNull" {
+	if !pointerValueFuncs[sel.Sel.Name] {
 		return false
 	}
-	// Verify it's the types package (or at least a package, not a method).
+	// Verify it's the types package.
 	if ident, ok := sel.X.(*ast.Ident); ok {
 		return ident.Name == "types"
 	}
@@ -309,7 +339,6 @@ func extractFieldName(expr ast.Expr) string {
 	if !ok {
 		return ""
 	}
-	// Verify it's a simple x.Field access.
 	if _, ok := sel.X.(*ast.Ident); !ok {
 		return ""
 	}
@@ -330,4 +359,26 @@ func toSnakeCase(s string) string {
 		}
 	}
 	return string(result)
+}
+
+// formatDefault formats a default value for display in diagnostics.
+func formatDefault(v any) string {
+	if v == nil {
+		return "<unknown>"
+	}
+	switch val := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", val)
+	case bool:
+		return fmt.Sprintf("%t", val)
+	case float64:
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%g", val)
+		}
+		return fmt.Sprintf("%g", val)
+	case int64:
+		return fmt.Sprintf("%d", val)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
 }

--- a/tools/linters/defaultdrift/analyzer_test.go
+++ b/tools/linters/defaultdrift/analyzer_test.go
@@ -1,0 +1,13 @@
+package defaultdrift_test
+
+import (
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/tools/linters/defaultdrift"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestDefaultDrift(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, defaultdrift.Analyzer, "drifttest")
+}

--- a/tools/linters/defaultdrift/testdata/src/drifttest/drifttest.go
+++ b/tools/linters/defaultdrift/testdata/src/drifttest/drifttest.go
@@ -1,0 +1,89 @@
+package drifttest
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure imports are used.
+var _ context.Context
+
+// --- Resource type with Schema() method ---
+
+type driftTestResource struct{}
+
+func (r *driftTestResource) Schema(_ context.Context, _ interface{}, resp *interface{}) {
+	s := DriftTestResourceSchema(context.Background())
+	_ = s
+}
+
+// --- BAD: PointerValue on defaulted fields ---
+
+func (r *driftTestResource) mapDriftTestToModel(resp *ApiResponse, state *DriftTestModel) {
+	state.Id = types.StringPointerValue(resp.Id)
+	state.Description = types.StringPointerValue(resp.Description)     // want `PointerValue on field "description" with schema default ""; use nil-fallback pattern`
+	state.Metric = types.StringPointerValue(resp.Metric)               // want `PointerValue on field "metric" with schema default "cost"; use nil-fallback pattern`
+	state.GrowthPerPeriod = types.Float64PointerValue(resp.GrowthPerPeriod) // want `PointerValue on field "growth_per_period" with schema default 0; use nil-fallback pattern`
+	state.UsePrevSpend = types.BoolPointerValue(resp.UsePrevSpend)     // want `PointerValue on field "use_prev_spend" with schema default false; use nil-fallback pattern`
+	state.MaxResults = types.Int64PointerValue(resp.MaxResults)        // want `PointerValue on field "max_results" with schema default 1000; use nil-fallback pattern`
+	// Non-defaulted O+C — OK
+	state.FolderId = types.StringPointerValue(resp.FolderId)
+	// Computed-only — OK
+	state.CreateTime = types.Int64PointerValue(resp.CreateTime)
+}
+
+// --- GOOD: nil-fallback pattern ---
+
+func (r *driftTestResource) mapDriftTestToModelCorrect(resp *ApiResponse, state *DriftTestModel) {
+	state.Id = types.StringPointerValue(resp.Id)
+	if resp.Description != nil {
+		state.Description = types.StringValue(*resp.Description)
+	} else {
+		state.Description = types.StringValue("")
+	}
+	if resp.Metric != nil {
+		state.Metric = types.StringValue(*resp.Metric)
+	} else {
+		state.Metric = types.StringValue("cost")
+	}
+	if resp.GrowthPerPeriod != nil {
+		state.GrowthPerPeriod = types.Float64Value(*resp.GrowthPerPeriod)
+	} else {
+		state.GrowthPerPeriod = types.Float64Value(0)
+	}
+	if resp.UsePrevSpend != nil {
+		state.UsePrevSpend = types.BoolValue(*resp.UsePrevSpend)
+	} else {
+		state.UsePrevSpend = types.BoolValue(false)
+	}
+	if resp.MaxResults != nil {
+		state.MaxResults = types.Int64Value(*resp.MaxResults)
+	} else {
+		state.MaxResults = types.Int64Value(1000)
+	}
+	state.FolderId = types.StringPointerValue(resp.FolderId)
+	state.CreateTime = types.Int64PointerValue(resp.CreateTime)
+}
+
+// --- BAD: PointerValue on nested defaulted fields ---
+
+func (r *driftTestResource) mapConfigToModel(resp *ConfigResponse, state *ConfigModel) {
+	state.Enabled = types.BoolPointerValue(resp.Enabled)     // want `PointerValue on field "enabled" with schema default false; use nil-fallback pattern`
+	state.SortOrder = types.StringPointerValue(resp.SortOrder) // want `PointerValue on field "sort_order" with schema default "desc"; use nil-fallback pattern`
+	// Non-defaulted — OK
+	state.Label = types.StringPointerValue(resp.Label)
+}
+
+// --- BAD: PointerValue on list-nested defaulted fields ---
+
+func (r *driftTestResource) mapItemToModel(resp *ItemResponse, state *ItemModel) {
+	state.Name = types.StringValue(resp.Name)
+	state.IncludeNull = types.BoolPointerValue(resp.IncludeNull) // want `PointerValue on field "include_null" with schema default false; use nil-fallback pattern`
+}
+
+// --- Not a mapping function — should be ignored ---
+
+func (r *driftTestResource) helperFunc(resp *ApiResponse, state *DriftTestModel) {
+	state.Description = types.StringPointerValue(resp.Description)
+}

--- a/tools/linters/defaultdrift/testdata/src/drifttest/drifttest_gen.go
+++ b/tools/linters/defaultdrift/testdata/src/drifttest/drifttest_gen.go
@@ -1,0 +1,156 @@
+// Package drifttest is a test fixture for the defaultdrift analyzer.
+package drifttest
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure imports are used.
+var _ context.Context
+
+// DriftTestResourceSchema returns a test schema with defaulted fields.
+func DriftTestResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			// Optional+Computed WITH default — PointerValue is risky.
+			"description": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+			"metric": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("cost"),
+			},
+			"growth_per_period": schema.Float64Attribute{
+				Optional: true,
+				Computed: true,
+				Default:  float64default.StaticFloat64(0),
+			},
+			"use_prev_spend": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
+			"max_results": schema.Int64Attribute{
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(1000),
+			},
+			// Optional+Computed WITHOUT default — PointerValue is fine.
+			"folder_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			// Computed-only — PointerValue is fine.
+			"create_time": schema.Int64Attribute{
+				Computed: true,
+			},
+			// Nested attribute with defaulted fields.
+			"config": schema.SingleNestedAttribute{
+				Optional: true,
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
+					},
+					"sort_order": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+						Default:  stringdefault.StaticString("desc"),
+					},
+					// No default — PointerValue is fine.
+					"label": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+			// List nested with defaulted fields.
+			"items": schema.ListNestedAttribute{
+				Optional: true,
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Required: true,
+						},
+						"include_null": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// DriftTestModel is the Terraform model for the test resource.
+type DriftTestModel struct {
+	Id              types.String
+	Name            types.String
+	Description     types.String
+	Metric          types.String
+	GrowthPerPeriod types.Float64
+	UsePrevSpend    types.Bool
+	MaxResults      types.Int64
+	FolderId        types.String
+	CreateTime      types.Int64
+}
+
+// ConfigModel is the nested config model.
+type ConfigModel struct {
+	Enabled   types.Bool
+	SortOrder types.String
+	Label     types.String
+}
+
+// ItemModel is the nested list item model.
+type ItemModel struct {
+	Name        types.String
+	IncludeNull types.Bool
+}
+
+// ApiResponse is a mock API response with pointer fields.
+type ApiResponse struct {
+	Id              *string
+	Name            string
+	Description     *string
+	Metric          *string
+	GrowthPerPeriod *float64
+	UsePrevSpend    *bool
+	MaxResults      *int64
+	FolderId        *string
+	CreateTime      *int64
+}
+
+// ConfigResponse is a mock API response for nested config.
+type ConfigResponse struct {
+	Enabled   *bool
+	SortOrder *string
+	Label     *string
+}
+
+// ItemResponse is a mock API response for list items.
+type ItemResponse struct {
+	Name        string
+	IncludeNull *bool
+}

--- a/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault/booldefault.go
+++ b/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault/booldefault.go
@@ -1,0 +1,3 @@
+package booldefault
+
+func StaticBool(v bool) interface{} { return v }

--- a/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default/float64default.go
+++ b/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default/float64default.go
@@ -1,0 +1,3 @@
+package float64default
+
+func StaticFloat64(v float64) interface{} { return v }

--- a/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default/int64default.go
+++ b/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default/int64default.go
@@ -1,0 +1,3 @@
+package int64default
+
+func StaticInt64(v int64) interface{} { return v }

--- a/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/schema.go
+++ b/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/schema.go
@@ -1,0 +1,82 @@
+// Stub package for analysistest.
+package schema
+
+import "context"
+
+type Schema struct {
+	Attributes          map[string]Attribute
+	Description         string
+	MarkdownDescription string
+}
+
+type Attribute interface{}
+
+type StringAttribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Validators          []interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type Float64Attribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type BoolAttribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type ListAttribute struct {
+	ElementType         interface{}
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Description         string
+	MarkdownDescription string
+}
+
+type ListNestedAttribute struct {
+	NestedObject        NestedAttributeObject
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Description         string
+	MarkdownDescription string
+}
+
+type NestedAttributeObject struct {
+	Attributes map[string]Attribute
+}
+
+type Int64Attribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type SingleNestedAttribute struct {
+	Attributes          map[string]Attribute
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Description         string
+	MarkdownDescription string
+}
+
+var _ context.Context

--- a/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault/stringdefault.go
+++ b/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault/stringdefault.go
@@ -1,0 +1,3 @@
+package stringdefault
+
+func StaticString(v string) interface{} { return v }

--- a/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/types/types.go
+++ b/tools/linters/defaultdrift/testdata/src/github.com/hashicorp/terraform-plugin-framework/types/types.go
@@ -1,0 +1,31 @@
+// Stub types package for analysistest.
+package types
+
+type String struct{}
+type Float64 struct{}
+type Bool struct{}
+type List struct{}
+type Int64 struct{}
+
+func (s String) IsUnknown() bool  { return false }
+func (s String) IsNull() bool     { return false }
+func (f Float64) IsUnknown() bool { return false }
+func (f Float64) IsNull() bool    { return false }
+func (b Bool) IsUnknown() bool    { return false }
+func (b Bool) IsNull() bool       { return false }
+func (l List) IsUnknown() bool    { return false }
+func (l List) IsNull() bool       { return false }
+func (i Int64) IsUnknown() bool   { return false }
+func (i Int64) IsNull() bool      { return false }
+
+var StringType interface{} = nil
+
+func StringValue(v string) String      { return String{} }
+func StringPointerValue(v *string) String { return String{} }
+func Float64Value(v float64) Float64   { return Float64{} }
+func Float64PointerValue(v *float64) Float64 { return Float64{} }
+func BoolValue(v bool) Bool            { return Bool{} }
+func BoolPointerValue(v *bool) Bool    { return Bool{} }
+func Int64Value(v int64) Int64         { return Int64{} }
+func Int64PointerValue(v *int64) Int64 { return Int64{} }
+func Int64Null() Int64                 { return Int64{} }

--- a/tools/linters/methodreceiver/analyzer.go
+++ b/tools/linters/methodreceiver/analyzer.go
@@ -1,0 +1,60 @@
+// Package methodreceiver flags mapping functions (mapXxxToModel, etc.) that are
+// methods instead of free functions. Mapping functions perform pure data
+// transformation from API responses to Terraform models and should not depend on
+// the resource/data source receiver. Using methods creates an unnecessary
+// coupling and prevents other linters from reliably resolving schemas via
+// parameter types.
+package methodreceiver
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Analyzer is the go/analysis Analyzer for methodreceiver.
+var Analyzer = &analysis.Analyzer{
+	Name:     "methodreceiver",
+	Doc:      "Flags mapping functions that should be free functions, not methods.",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil)}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Name == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+			return
+		}
+
+		name := fn.Name.Name
+		if !isMappingFunction(name) {
+			return
+		}
+
+		pass.Reportf(fn.Pos(),
+			"mapping function %s should be a free function, not a method; the receiver is not needed for data transformation",
+			name)
+	})
+
+	return nil, nil
+}
+
+// isMappingFunction returns true if the function name matches the Read-path
+// mapping function naming convention. populateState is excluded because it
+// legitimately needs the receiver to call the API client.
+func isMappingFunction(name string) bool {
+	if strings.HasPrefix(name, "map") && strings.Contains(name, "ToModel") {
+		return true
+	}
+	if strings.HasPrefix(name, "map") && strings.Contains(name, "Resource") {
+		return true
+	}
+	return false
+}

--- a/tools/linters/methodreceiver/analyzer_test.go
+++ b/tools/linters/methodreceiver/analyzer_test.go
@@ -1,0 +1,13 @@
+package methodreceiver_test
+
+import (
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/tools/linters/methodreceiver"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestMethodReceiver(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, methodreceiver.Analyzer, "receivertest")
+}

--- a/tools/linters/methodreceiver/testdata/src/receivertest/receivertest.go
+++ b/tools/linters/methodreceiver/testdata/src/receivertest/receivertest.go
@@ -1,0 +1,37 @@
+package receivertest
+
+// --- BAD: mapping function as a method ---
+
+type fooResource struct{}
+
+func (r *fooResource) mapFooToModel(resp interface{}, state interface{}) { // want `mapping function mapFooToModel should be a free function, not a method; the receiver is not needed for data transformation`
+	_ = resp
+	_ = state
+}
+
+type barDataSource struct{}
+
+func (ds *barDataSource) mapBarToModel(resp interface{}) { // want `mapping function mapBarToModel should be a free function, not a method; the receiver is not needed for data transformation`
+	_ = resp
+}
+
+// --- GOOD: mapping function as a free function ---
+
+func mapBazToModel(resp interface{}, state interface{}) {
+	_ = resp
+	_ = state
+}
+
+// --- GOOD: populateState is allowed as a method ---
+
+func (r *fooResource) populateState(state interface{}) {
+	_ = state
+}
+
+// --- GOOD: non-mapping methods are allowed ---
+
+func (r *fooResource) Schema() {}
+
+func (r *fooResource) Create() {}
+
+func (r *fooResource) helperFunc() {}

--- a/tools/linters/plugin.go
+++ b/tools/linters/plugin.go
@@ -5,12 +5,14 @@ import (
 	"github.com/doitintl/terraform-provider-doit/tools/linters/configuretype"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/constructor"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/crudnaming"
+	"github.com/doitintl/terraform-provider-doit/tools/linters/defaultdrift"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/delete404"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/diagdrop"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/diagsuppressed"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/errformat"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/interfacestyle"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/listnullread"
+	"github.com/doitintl/terraform-provider-doit/tools/linters/methodreceiver"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/newexpr"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/overlaycheck"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/overlayinvariant"
@@ -107,5 +109,13 @@ func init() {
 
 	register.Plugin("diagdrop", func(_ any) (register.LinterPlugin, error) {
 		return &analyzerPlugin{analyzers: []*analysis.Analyzer{diagdrop.Analyzer}}, nil
+	})
+
+	register.Plugin("defaultdrift", func(_ any) (register.LinterPlugin, error) {
+		return &analyzerPlugin{analyzers: []*analysis.Analyzer{defaultdrift.Analyzer}}, nil
+	})
+
+	register.Plugin("methodreceiver", func(_ any) (register.LinterPlugin, error) {
+		return &analyzerPlugin{analyzers: []*analysis.Analyzer{methodreceiver.Analyzer}}, nil
 	})
 }

--- a/tools/linters/schemaparser/analyzer.go
+++ b/tools/linters/schemaparser/analyzer.go
@@ -13,6 +13,7 @@ import (
 	"go/ast"
 	"go/token"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -61,6 +62,10 @@ type AttrInfo struct {
 	// Fields with defaults are resolved at plan time and are never Unknown,
 	// so they don't need IsUnknown() guards in overlay functions.
 	HasDefault bool
+	// DefaultValue holds the extracted static default value (string, float64,
+	// bool, or int64). It is nil when HasDefault is false or when the default
+	// expression could not be parsed (e.g., a dynamic default).
+	DefaultValue any
 	// NestedAttrs holds classifications for nested attributes (if any).
 	NestedAttrs map[string]*AttrInfo
 }
@@ -280,6 +285,7 @@ func classifyAttributeLit(lit *ast.CompositeLit) *AttrInfo {
 			// Exclude `Default: nil` which is effectively no default.
 			if !isNilLiteral(kv.Value) {
 				info.HasDefault = true
+				info.DefaultValue = extractStaticDefault(kv.Value)
 			}
 		case "NestedObject":
 			// Recurse into nested attributes (ListNestedAttribute, SetNestedAttribute).
@@ -610,6 +616,7 @@ func applyIfBlockOverride(ifStmt *ast.IfStmt, schemaVar string, schema *SchemaIn
 		// Copy existing metadata that isn't affected by classification changes.
 		info.IsList = existing.IsList
 		info.HasDefault = existing.HasDefault
+		info.DefaultValue = existing.DefaultValue
 		info.NestedAttrs = existing.NestedAttrs
 	}
 
@@ -792,9 +799,10 @@ func cloneSchemaInfo(src *SchemaInfo) *SchemaInfo {
 // cloneAttrInfo creates a deep copy of an AttrInfo.
 func cloneAttrInfo(src *AttrInfo) *AttrInfo {
 	dst := &AttrInfo{
-		Class:      src.Class,
-		IsList:     src.IsList,
-		HasDefault: src.HasDefault,
+		Class:        src.Class,
+		IsList:       src.IsList,
+		HasDefault:   src.HasDefault,
+		DefaultValue: src.DefaultValue,
 	}
 	if src.NestedAttrs != nil {
 		dst.NestedAttrs = make(map[string]*AttrInfo, len(src.NestedAttrs))
@@ -803,4 +811,82 @@ func cloneAttrInfo(src *AttrInfo) *AttrInfo {
 		}
 	}
 	return dst
+}
+
+// extractStaticDefault attempts to extract the static default value from
+// a Default field expression. It recognizes these patterns:
+//
+//   - stringdefault.StaticString("value") → string
+//   - float64default.StaticFloat64(0)     → float64
+//   - booldefault.StaticBool(false)       → bool
+//   - int64default.StaticInt64(1000)      → int64
+//
+// Returns nil if the expression does not match a known static default pattern.
+func extractStaticDefault(expr ast.Expr) any {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return nil
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+
+	arg := call.Args[0]
+
+	switch {
+	case pkg.Name == "stringdefault" && sel.Sel.Name == "StaticString":
+		if lit, ok := arg.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+			s, err := strconv.Unquote(lit.Value)
+			if err == nil {
+				return s
+			}
+		}
+	case pkg.Name == "float64default" && sel.Sel.Name == "StaticFloat64":
+		if lit, ok := arg.(*ast.BasicLit); ok && (lit.Kind == token.INT || lit.Kind == token.FLOAT) {
+			f, err := strconv.ParseFloat(lit.Value, 64)
+			if err == nil {
+				return f
+			}
+		}
+		// Handle negative: -X (unary minus)
+		if unary, ok := arg.(*ast.UnaryExpr); ok && unary.Op == token.SUB {
+			if lit, ok := unary.X.(*ast.BasicLit); ok && (lit.Kind == token.INT || lit.Kind == token.FLOAT) {
+				f, err := strconv.ParseFloat(lit.Value, 64)
+				if err == nil {
+					return -f
+				}
+			}
+		}
+	case pkg.Name == "booldefault" && sel.Sel.Name == "StaticBool":
+		if ident, ok := arg.(*ast.Ident); ok {
+			switch ident.Name {
+			case "true":
+				return true
+			case "false":
+				return false
+			}
+		}
+	case pkg.Name == "int64default" && sel.Sel.Name == "StaticInt64":
+		if lit, ok := arg.(*ast.BasicLit); ok && lit.Kind == token.INT {
+			i, err := strconv.ParseInt(lit.Value, 10, 64)
+			if err == nil {
+				return i
+			}
+		}
+		// Handle negative: -X (unary minus)
+		if unary, ok := arg.(*ast.UnaryExpr); ok && unary.Op == token.SUB {
+			if lit, ok := unary.X.(*ast.BasicLit); ok && lit.Kind == token.INT {
+				i, err := strconv.ParseInt(lit.Value, 10, 64)
+				if err == nil {
+					return -i
+				}
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Closes #206

Three new linters and one fix to prevent and detect perpetual plan drift caused by `PointerValue` on fields with schema defaults.

## What changed

### New linters

| Linter | Purpose |
|--------|---------|
| `defaultdrift` | Flags `PointerValue` usage on fields with schema defaults in mapping functions. When a field has a `Default` (e.g., `stringdefault.StaticString("cost")`), using `PointerValue` maps nil → null, which silently drifts against the default. |
| `methodreceiver` | Enforces that mapping functions (`mapXxxToModel`) are free functions, not methods. The receiver is unused — these are pure data transforms. |

### Existing linter fix

`listnullread` now supports free function parameter resolution. Previously it **silently skipped all 12 free-function mapping functions** because it only resolved schemas via method receivers.

### Code fixes

- **budget.go**: Fixed all 4 `defaultdrift` findings with nil-fallback pattern (`description`, `growth_per_period`, `metric`, `use_prev_spend`)
- **allocation.go**: Converted `mapAllocationToModel` from method to free function (pass `client` explicitly) — the only outlier among 13 resources
- **schemaparser**: Enhanced with `DefaultValue` extraction from `stringdefault.StaticString()`, `float64default.StaticFloat64()`, etc.

### Tests

- `defaultdrift` unit tests with `analysistest` (test fixtures with good/bad patterns, stub packages)
- `methodreceiver` unit tests with `analysistest`
- `TestAccBudget_DefaultedScalarDrift` acceptance test for the budget drift scenario

## Affected fields (from issue)

| Resource | Field | Default | Status |
|----------|-------|---------|--------|
| Budget | `description` | `""` | ✅ Fixed |
| Budget | `growth_per_period` | `0` | ✅ Fixed |
| Budget | `metric` | `"cost"` | ✅ Fixed |
| Budget | `use_prev_spend` | `false` | ✅ Fixed |
| Folder/Report/Allocation | `folder_id` | `"root"` | ✅ Already fixed in PR #202 |

## How it was built and validated

AI-assisted (Antigravity). All linter tests pass (`go test ./tools/linters/...`), provider builds, full lint suite clean.