### PR TITLE
refactor: remove redundant IsUnknown() guards for fields with schema defaults

### DIFF
--- a/internal/provider/alert.go
+++ b/internal/provider/alert.go
@@ -82,9 +82,6 @@ func overlayAlertConfig(ctx context.Context, resolved, plan *resource_alert.Conf
 	if plan.Operator.IsUnknown() {
 		plan.Operator = resolved.Operator
 	}
-	if plan.TimeInterval.IsUnknown() {
-		plan.TimeInterval = resolved.TimeInterval
-	}
 
 	// ── Metric: Required nested — subfields are both Required, never Unknown ──
 	// Defensive: overlay if Unknown.
@@ -106,13 +103,7 @@ func overlayAlertConfig(ctx context.Context, resolved, plan *resource_alert.Conf
 
 // overlayAlertScope resolves Unknown subfields in alert scope elements.
 func overlayAlertScope(_ context.Context, resolved, plan *resource_alert.ScopesValue) diag.Diagnostics {
-	if plan.CaseInsensitive.IsUnknown() {
-		plan.CaseInsensitive = resolved.CaseInsensitive
-	}
 
-	if plan.IncludeNull.IsUnknown() {
-		plan.IncludeNull = resolved.IncludeNull
-	}
 	if plan.Inverse.IsUnknown() {
 		plan.Inverse = resolved.Inverse
 	}

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -63,7 +63,10 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	if plan.Rule.IsUnknown() {
 		plan.Rule = resolved.Rule
 	} else if !plan.Rule.IsNull() {
-		diags.Append(overlayAllocationRuleFields(ctx, &resolved.Rule, &plan.Rule)...)
+		// Components is the only Optional+Computed subfield; formula is Required.
+		if plan.Rule.Components.IsUnknown() {
+			plan.Rule.Components = resolved.Rule.Components
+		}
 	}
 
 	// ── Rules (list): resolve whole list when Unknown, overlay elements when Known ──
@@ -76,24 +79,11 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	return diags
 }
 
-// overlayAllocationRuleFields overlays the "components" subfield of the "rule"
-// SingleNestedAttribute. The only other subfield, "formula", is Required and
-// never Unknown at overlay time.
-func overlayAllocationRuleFields(ctx context.Context, resolved, plan *resource_allocation.RuleValue) diag.Diagnostics {
-	if plan.Components.IsUnknown() {
-		plan.Components = resolved.Components
-	} else if !plan.Components.IsNull() {
-		return overlayListElements(ctx, &resolved.Components, &plan.Components, overlayAllocationComponent)
-	}
-	return nil
-}
-
 // ── Allocation list element overlay helpers ──
 // Each helper resolves Unknown subfields from the resolved element.
 // Known values are never touched — the user's plan is the source of truth.
 
-func overlayAllocationRule(ctx context.Context, resolved, plan *resource_allocation.RulesValue) diag.Diagnostics {
-
+func overlayAllocationRule(_ context.Context, resolved, plan *resource_allocation.RulesValue) diag.Diagnostics {
 	if plan.Description.IsUnknown() {
 		plan.Description = resolved.Description
 	}
@@ -106,29 +96,9 @@ func overlayAllocationRule(ctx context.Context, resolved, plan *resource_allocat
 	if plan.Name.IsUnknown() {
 		plan.Name = resolved.Name
 	}
-	// Components: overlay subfields when the list is Known
 	if plan.Components.IsUnknown() {
 		plan.Components = resolved.Components
-	} else if !plan.Components.IsNull() {
-		return overlayListElements(ctx, &resolved.Components, &plan.Components, overlayAllocationComponent)
 	}
-	return nil
-}
-
-func overlayAllocationComponent(_ context.Context, resolved, plan *resource_allocation.ComponentsValue) diag.Diagnostics {
-	if plan.CaseInsensitive.IsUnknown() {
-		plan.CaseInsensitive = resolved.CaseInsensitive
-	}
-	if plan.IncludeNull.IsUnknown() {
-		plan.IncludeNull = resolved.IncludeNull
-	}
-	if plan.Inverse.IsUnknown() {
-		plan.Inverse = resolved.Inverse
-	}
-	if plan.InverseSelection.IsUnknown() {
-		plan.InverseSelection = resolved.InverseSelection
-	}
-
 	return nil
 }
 

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -56,18 +56,11 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 	if plan.Currency.IsUnknown() {
 		plan.Currency = resolved.Currency
 	}
-	if plan.Description.IsUnknown() {
-		plan.Description = resolved.Description
-	}
+
 	if plan.EndPeriod.IsUnknown() {
 		plan.EndPeriod = resolved.EndPeriod
 	}
-	if plan.GrowthPerPeriod.IsUnknown() {
-		plan.GrowthPerPeriod = resolved.GrowthPerPeriod
-	}
-	if plan.Metric.IsUnknown() {
-		plan.Metric = resolved.Metric
-	}
+
 	if plan.Name.IsUnknown() {
 		plan.Name = resolved.Name
 	}
@@ -82,9 +75,6 @@ func overlayBudgetComputedFields(ctx context.Context, apiResp *models.BudgetAPI,
 	}
 	if plan.Type.IsUnknown() {
 		plan.Type = resolved.Type
-	}
-	if plan.UsePrevSpend.IsUnknown() {
-		plan.UsePrevSpend = resolved.UsePrevSpend
 	}
 
 	// ── List fields: resolve whole list when Unknown, overlay elements when Known ──
@@ -176,13 +166,7 @@ func overlayBudgetSlackChannel(_ context.Context, resolved, plan *resource_budge
 }
 
 func overlayBudgetScope(_ context.Context, resolved, plan *resource_budget.ScopesValue) diag.Diagnostics {
-	if plan.CaseInsensitive.IsUnknown() {
-		plan.CaseInsensitive = resolved.CaseInsensitive
-	}
 
-	if plan.IncludeNull.IsUnknown() {
-		plan.IncludeNull = resolved.IncludeNull
-	}
 	if plan.Inverse.IsUnknown() {
 		plan.Inverse = resolved.Inverse
 	}

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -101,18 +101,10 @@ func overlayConfigFields(ctx context.Context, resolved *resource_report.ConfigVa
 	if plan.IncludePromotionalCredits.IsUnknown() {
 		plan.IncludePromotionalCredits = resolved.IncludePromotionalCredits
 	}
-	if plan.IncludeSubtotals.IsUnknown() {
-		plan.IncludeSubtotals = resolved.IncludeSubtotals
-	}
 	if plan.Layout.IsUnknown() {
 		plan.Layout = resolved.Layout
 	}
-	if plan.SortDimensions.IsUnknown() {
-		plan.SortDimensions = resolved.SortDimensions
-	}
-	if plan.SortGroups.IsUnknown() {
-		plan.SortGroups = resolved.SortGroups
-	}
+
 	if plan.TimeInterval.IsUnknown() {
 		plan.TimeInterval = resolved.TimeInterval
 	}
@@ -351,13 +343,7 @@ func overlayDimension(_ context.Context, resolved, plan *resource_report.Dimensi
 }
 
 func overlayFilter(_ context.Context, resolved, plan *resource_report.FiltersValue) diag.Diagnostics {
-	if plan.CaseInsensitive.IsUnknown() {
-		plan.CaseInsensitive = resolved.CaseInsensitive
-	}
 
-	if plan.IncludeNull.IsUnknown() {
-		plan.IncludeNull = resolved.IncludeNull
-	}
 	if plan.Inverse.IsUnknown() {
 		plan.Inverse = resolved.Inverse
 	}

--- a/tools/linters/overlaycheck/analyzer.go
+++ b/tools/linters/overlaycheck/analyzer.go
@@ -764,6 +764,11 @@ func validateOverlay(pass *analysis.Pass, fn *ast.FuncDecl, schema *schemaparser
 					"%s: Optional+Computed field %q is assigned unconditionally; "+
 						"must be guarded by IsUnknown() to preserve user-configured values",
 					fn.Name.Name, attrName)
+			} else if attrInfo.HasDefault {
+				pass.Reportf(assignment.pos,
+					"%s: Optional+Computed field %q has a schema Default and is never Unknown; "+
+						"remove the IsUnknown() guard (dead code)",
+					fn.Name.Name, attrName)
 			}
 		}
 	}
@@ -832,10 +837,15 @@ func enforceSubOverlayHelpers(
 }
 
 // nestedHasOverlayFields returns true if any attribute in the map is
-// Computed-only or Optional+Computed (i.e., fields that require overlay handling).
+// Computed-only or Optional+Computed WITHOUT a schema Default (i.e., fields
+// that may be Unknown and require overlay handling). Fields with a Default are
+// resolved at plan time and are never Unknown, so they don't need overlaying.
 func nestedHasOverlayFields(attrs map[string]*schemaparser.AttrInfo) bool {
 	for _, attr := range attrs {
-		if attr.Class == schemaparser.ComputedOnly || attr.Class == schemaparser.OptionalComputed {
+		if attr.Class == schemaparser.ComputedOnly {
+			return true
+		}
+		if attr.Class == schemaparser.OptionalComputed && !attr.HasDefault {
 			return true
 		}
 		// Recurse into deeper nested attrs.

--- a/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
+++ b/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest.go
@@ -224,6 +224,23 @@ func overlayDefaultComputedFields(apiResp *ApiResponse, plan *DefaultModel) {
 	// No IsUnknown() guard needed.
 }
 
+// --- BAD: Redundant IsUnknown() guard on field with schema Default ---
+
+func mapDefaultGuardToModel(apiResp *ApiResponse, m *DefaultGuardModel) {}
+
+func overlayDefaultGuardComputedFields(apiResp *ApiResponse, plan *DefaultGuardModel) {
+	resolved := *plan
+	mapDefaultGuardToModel(apiResp, &resolved)
+
+	// Computed-only: unconditional. ✓
+	plan.Id = resolved.Id
+
+	// folder_id has a Default — IsUnknown() guard is dead code.
+	if plan.FolderId.IsUnknown() {
+		plan.FolderId = resolved.FolderId // want `overlayDefaultGuardComputedFields: Optional\+Computed field "folder_id" has a schema Default and is never Unknown; remove the IsUnknown\(\) guard \(dead code\)`
+	}
+}
+
 // --- GOOD: Prefixed Go field name (DimensionsType → tfsdk:"type") ---
 // The code generator prefixes "type" with the parent struct name because
 // "type" is a Go keyword. The overlay correctly handles it via DimensionsType.

--- a/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest_gen.go
+++ b/tools/linters/overlaycheck/testdata/src/overlaytest/overlaytest_gen.go
@@ -321,6 +321,32 @@ func DefaultResourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
+// DefaultGuardModel used to test BAD: redundant IsUnknown() guard on field with Default.
+type DefaultGuardModel struct {
+	Id       types.String
+	Name     types.String
+	FolderId types.String
+}
+
+// DefaultGuardResourceSchema — same as DefaultResourceSchema but used for the BAD test case.
+func DefaultGuardResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"folder_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  "root",
+			},
+		},
+	}
+}
+
 // PrefixedTypeModel — tests the code-gen pattern where Go field names
 // are prefixed to avoid keyword collisions (e.g., DimensionsType → tfsdk:"type").
 type PrefixedTypeModel struct {


### PR DESCRIPTION
## Summary

Closes #204

Remove 18 redundant `IsUnknown()` guards in overlay functions and teach `overlaycheck` to catch this pattern going forward.

## What changed

### Dead code removal (4 resources)

When a schema field has a `Default`, Terraform resolves it at plan time — the field is **never Unknown**. `IsUnknown()` guards in overlay functions are dead code.

| Resource | Fields removed | Overlay function |
|----------|---------------|------------------|
| alert | `time_interval` | `overlayAlertConfig` |
| alert | `case_insensitive`, `include_null` | `overlayAlertScope` |
| allocation | `case_insensitive`, `include_null`, `inverse`, `inverse_selection` | `overlayAllocationComponent` (removed entirely) |
| budget | `description`, `growth_per_period`, `metric`, `use_prev_spend` | `overlayBudgetComputedFields` |
| budget | `case_insensitive`, `include_null` | `overlayBudgetScope` |
| report | `include_subtotals`, `sort_dimensions`, `sort_groups` | `overlayConfigFields` |
| report | `case_insensitive`, `include_null` | `overlayFilter` |

### Allocation simplification

- Removed `overlayAllocationRuleFields` and `overlayAllocationComponent` (all component subfields are Required or have defaults)
- Inlined the remaining components `IsUnknown()` check into the parent overlay

### `overlaycheck` linter enhancements

1. **New diagnostic**: Flags conditional `IsUnknown()` guards on `Optional+Computed` fields with `HasDefault` as dead code
2. **Sub-overlay skip**: `nestedHasOverlayFields` now respects `HasDefault` — nested attrs where all children are Required or have defaults no longer require a sub-overlay helper

## How it was built and validated

AI-assisted (Antigravity). Linter tests pass, provider builds, full lint suite clean.