### PR TITLE
feat(linter): add requestguard linter and document schema default conventions

### DIFF
--- a/.agent/skills/implement-resource/references/overlay-pattern.md
+++ b/.agent/skills/implement-resource/references/overlay-pattern.md
@@ -18,6 +18,7 @@ DoIT APIs return complete objects in Create and Update responses, but frequently
 | **Required** | `Required: true` | Never touch — preserve plan value | `name` |
 | **Optional** | `Optional: true` | Never touch — preserve plan value | `description` |
 | **Optional+Computed** | `Optional: true, Computed: true` | Resolve only when `IsUnknown()` | `formula`, boolean flags |
+| **Optional+Computed with Default** | `Optional: true, Computed: true, Default: ...` | Never touch — default resolves at plan time | `metric`, `case_insensitive` |
 
 Key rules:
 
@@ -25,6 +26,7 @@ Key rules:
 - **Required / Optional**: never overwrite — user's plan wins
 - **Optional+Computed when `IsUnknown()`**: user omitted the field — resolve from API response, fall back to null/false
 - **Optional+Computed when known**: user explicitly set it — never overwrite
+- **Optional+Computed with Default**: always known — the framework resolves the default at plan time, so the field is never Unknown. **Do not add `IsUnknown()` guards** — they are dead code
 
 ## Step 2: Implement overlayXxxComputedFields
 
@@ -97,6 +99,8 @@ if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
 **Multi-level nesting**: Sub-overlays can call deeper sub-overlays. The linter recursively validates the entire chain.
 
 > **Linter:** `overlaycheck` **enforces** that nested attributes with computed fields use sub-overlay helper functions — inline handling is not allowed. The linter validates both top-level overlay functions and all sub-overlay helpers reachable via `overlayListElements` callbacks or direct `overlay*` calls with `&plan.X` arguments.
+>
+> **Exception:** If all children of a nested attribute are Required or have schema Defaults, no sub-overlay is needed — the field can be assigned unconditionally when Unknown. The linter skips enforcement for these cases.
 
 ## Step 3: Wire Into Create and Update
 
@@ -137,3 +141,5 @@ The Read path detects **real** external changes while ignoring API normalization
 6. **API-defaulted lists need API response, not null.** Some lists are auto-populated by the API when omitted (e.g. `collaborators` adds creator as owner). Resolving `IsUnknown()` to `null` causes drift. Resolve from the API response instead.
 
 7. **Test for null↔[] flips explicitly.** When omitting Optional+Computed list fields, add `ListSizeExact(0)` checks on both Create and drift-check steps.
+
+8. **Don't add IsUnknown() guards for fields with Defaults.** When a field has `Default: stringdefault.StaticString(...)` (or similar), the framework resolves it at plan time — the field is never Unknown. An `IsUnknown()` guard is dead code and can mask legitimate changes from cross-resource references. The `overlaycheck` linter flags these automatically.

--- a/.agent/skills/implementation-conventions/SKILL.md
+++ b/.agent/skills/implementation-conventions/SKILL.md
@@ -77,6 +77,41 @@ If create and update use different API request types, implement both `toCreateRe
 
 > **Signature flexibility:** The `ctx` and `diag.Diagnostics` parameters are required when the function maps nested objects (lists, objects) or can produce errors. Simple resources that only do scalar assignments (e.g. `types.StringValue`, `types.StringPointerValue`) may omit `ctx` and return nothing. Match the complexity of your resource.
 
+### Mapping Functions and Schema Defaults
+
+When a schema field has a `Default` (e.g., `stringdefault.StaticString("cost")`), `mapXxxToModel` must map `nil` API responses to the default value, not to `null`:
+
+```go
+// CORRECT — preserves the schema default on nil response
+if apiResp.Metric != nil {
+    state.Metric = types.StringValue(*apiResp.Metric)
+} else {
+    state.Metric = types.StringValue("cost") // schema default
+}
+
+// WRONG — drifts against the schema default
+state.Metric = types.StringPointerValue(apiResp.Metric) // nil → null ≠ "cost"
+```
+
+> **Linter:** `defaultdrift` — flags `PointerValue` usage on fields with schema defaults in Read-path mapping functions.
+
+### Request Builders and IsUnknown()
+
+In `toCreateRequest` / `toUpdateRequest` and similar request builder functions, `IsUnknown()` guards are only needed for `Optional+Computed` fields **without** a `Default`. For all other fields:
+
+| Field class | `IsUnknown()` needed? | Why |
+|---|---|---|
+| Required | No | User must set it — always Known |
+| Optional (no Computed) | No | Known or Null, never Unknown |
+| Optional+Computed **with Default** | No | Default resolves at plan time |
+| Optional+Computed **without Default** | **Yes** | May be Unknown at plan time |
+
+For non-pointer value accessors (`ValueString()`, `ValueBool()`, `ValueFloat64()`, `ValueInt64()`), always guard with `IsUnknown()` when the field is Optional+Computed without Default — these accessors return zero values for Unknown, not nil.
+
+Pointer accessors (`ValueStringPointer()`, etc.) return `nil` for Unknown, which is often acceptable.
+
+> **Linter:** `requestguard` — flags both redundant guards (dead code) and missing guards (bug risk) in request builder functions.
+
 ## Variable Naming
 
 Variable names must match their data source:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,7 @@ linters:
     - unknownguard
     - defaultdrift
     - methodreceiver
+    - requestguard
   exclusions:
     generated: lax
     presets:
@@ -96,6 +97,7 @@ linters:
           - diagdrop
           - defaultdrift
           - methodreceiver
+          - requestguard
       # Test files — exclude custom linters (except paralleltest which only applies to tests)
       - path: _test\.go
         linters:
@@ -116,6 +118,7 @@ linters:
           - diagdrop
           - defaultdrift
           - methodreceiver
+          - requestguard
       # Data sources — exclude resource-only linters
       - path: _data_source\.go
         linters:
@@ -127,6 +130,7 @@ linters:
           - usestatefunknown
           - crudnaming
           - methodreceiver
+          - requestguard
       # Provider config — not a resource, no plan modifiers
       - path: provider\.go
         linters:
@@ -229,6 +233,9 @@ linters:
       methodreceiver:
         type: "module"
         description: "Flags mapping functions that should be free functions, not methods."
+      requestguard:
+        type: "module"
+        description: "Validates IsUnknown() guards in request builder functions."
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/internal/provider/alert.go
+++ b/internal/provider/alert.go
@@ -158,7 +158,7 @@ func (plan *alertResourceModel) toAlertUpdateRequest(ctx context.Context) (req m
 
 // toAlertConfig converts the Terraform config object to the API AlertConfig.
 func (plan *alertResourceModel) toAlertConfig(ctx context.Context) (config models.AlertConfig, diags diag.Diagnostics) {
-	if plan.Config.IsNull() || plan.Config.IsUnknown() {
+	if plan.Config.IsNull() {
 		diags.AddError("Config Required", "Alert config is required")
 		return config, diags
 	}
@@ -171,7 +171,7 @@ func (plan *alertResourceModel) toAlertConfig(ctx context.Context) (config model
 	config.TimeInterval = models.AlertConfigTimeInterval(configVal.TimeInterval.ValueString())
 
 	// Metric (required nested object)
-	if !configVal.Metric.IsNull() && !configVal.Metric.IsUnknown() {
+	if !configVal.Metric.IsNull() {
 		metricVal := configVal.Metric
 		config.Metric = models.MetricConfig{
 			Type:  metricVal.MetricType.ValueString(),

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -176,8 +176,10 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 	req.Name = plan.Name.ValueStringPointer()
 	req.FolderId = plan.FolderId.ValueStringPointer()
 	// UnallocatedCosts is only sent if not empty because it is invalid for "single" allocations.
-	if v := plan.UnallocatedCosts.ValueString(); v != "" {
-		req.UnallocatedCosts = &v
+	if !plan.UnallocatedCosts.IsNull() && !plan.UnallocatedCosts.IsUnknown() {
+		if v := plan.UnallocatedCosts.ValueString(); v != "" {
+			req.UnallocatedCosts = &v
+		}
 	}
 
 	// Populate single Rule if present

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -230,7 +230,7 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 	}
 
 	req.GrowthPerPeriod = plan.GrowthPerPeriod.ValueFloat64Pointer()
-	if !plan.Metric.IsNull() && !plan.Metric.IsUnknown() {
+	if !plan.Metric.IsNull() {
 		metric := models.BudgetCreateUpdateRequestMetric(plan.Metric.ValueString())
 		req.Metric = &metric
 	}

--- a/internal/provider/sharing_resource.go
+++ b/internal/provider/sharing_resource.go
@@ -540,7 +540,7 @@ func buildSharingRequest(ctx context.Context, plan *sharingResourceModel, resour
 	var reqBody models.UpdateResourcePermissionJSONRequestBody
 
 	// Map permissions from plan to API type
-	if !plan.Permissions.IsNull() && !plan.Permissions.IsUnknown() {
+	if !plan.Permissions.IsNull() {
 		var permVals []resource_sharing.PermissionsValue
 		diags.Append(plan.Permissions.ElementsAs(ctx, &permVals, false)...)
 		if diags.HasError() {

--- a/internal/provider/user.go
+++ b/internal/provider/user.go
@@ -235,13 +235,13 @@ func (plan *userResourceModel) toUpdateRequest() models.UpdateUserRequest {
 	if !plan.RoleId.IsNull() && !plan.RoleId.IsUnknown() {
 		req.RoleId = plan.RoleId.ValueStringPointer()
 	}
-	if !plan.Phone.IsNull() && !plan.Phone.IsUnknown() {
+	if !plan.Phone.IsNull() {
 		req.Phone = plan.Phone.ValueStringPointer()
 	}
-	if !plan.PhoneExtension.IsNull() && !plan.PhoneExtension.IsUnknown() {
+	if !plan.PhoneExtension.IsNull() {
 		req.PhoneExtension = plan.PhoneExtension.ValueStringPointer()
 	}
-	if !plan.Language.IsNull() && !plan.Language.IsUnknown() {
+	if !plan.Language.IsNull() {
 		req.Language = new(models.UpdateUserRequestLanguage(plan.Language.ValueString()))
 	}
 

--- a/tools/linters/plugin.go
+++ b/tools/linters/plugin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/doitintl/terraform-provider-doit/tools/linters/overlaycheck"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/overlayinvariant"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/paralleltest"
+	"github.com/doitintl/terraform-provider-doit/tools/linters/requestguard"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/read404"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/structliteral"
 	"github.com/doitintl/terraform-provider-doit/tools/linters/timeoutcheck"
@@ -117,5 +118,9 @@ func init() {
 
 	register.Plugin("methodreceiver", func(_ any) (register.LinterPlugin, error) {
 		return &analyzerPlugin{analyzers: []*analysis.Analyzer{methodreceiver.Analyzer}}, nil
+	})
+
+	register.Plugin("requestguard", func(_ any) (register.LinterPlugin, error) {
+		return &analyzerPlugin{analyzers: []*analysis.Analyzer{requestguard.Analyzer}}, nil
 	})
 }

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -118,7 +118,7 @@ func run(pass *analysis.Pass) (any, error) {
 		trackVariableAssignments(fn.Body, varSchemas)
 
 		// Direction 1: Find redundant IsUnknown() guards.
-		checkRedundantGuards(pass, fn.Body, varSchemas, schema)
+		checkRedundantGuards(pass, fn.Body, varSchemas)
 
 		// Direction 2: Find missing guards on non-pointer value accessors.
 		checkMissingGuards(pass, fn.Body, varSchemas)
@@ -278,46 +278,53 @@ func resolveSelectorChain(sel *ast.SelectorExpr) (rootVar, fieldName string) {
 }
 
 // resolveFieldAttr resolves a selector expression to its schema AttrInfo
-// by navigating the schema tree via NestedAttrs.
+// by navigating the schema tree via NestedAttrs. Supports arbitrary nesting
+// depth (e.g., plan.Config.SubConfig.Field).
 func resolveFieldAttr(sel *ast.SelectorExpr, varSchemas map[string]map[string]*schemaparser.AttrInfo) *schemaparser.AttrInfo {
-	fieldName := sel.Sel.Name
-	attrName := toSnakeCase(fieldName)
+	// Build the full selector chain: plan.A.B.C → ["plan", "A", "B", "C"]
+	chain := buildSelectorChain(sel)
+	if len(chain) < 2 {
+		return nil
+	}
 
-	// Get the variable that owns this field.
-	switch x := sel.X.(type) {
-	case *ast.Ident:
-		if schema, ok := varSchemas[x.Name]; ok {
-			if attr, ok := schema[attrName]; ok {
-				return attr
-			}
-		}
-	case *ast.SelectorExpr:
-		// Nested: e.g., plan.Config.Metric → look up Config in plan's schema,
-		// then look up Metric in Config's NestedAttrs.
-		parentField := x.Sel.Name
-		parentAttrName := toSnakeCase(parentField)
+	// chain[0] is the root variable, chain[1:len-1] are intermediate fields,
+	// chain[len-1] is the leaf field we want the AttrInfo for.
+	rootVar := chain[0]
+	schema, ok := varSchemas[rootVar]
+	if !ok {
+		return nil
+	}
 
-		rootVar := ""
-		switch rx := x.X.(type) {
-		case *ast.Ident:
-			rootVar = rx.Name
-		case *ast.SelectorExpr:
-			rootVar, _ = resolveSelectorChain(rx)
-		}
-
-		if rootVar == "" {
+	// Navigate through intermediate fields via NestedAttrs.
+	for i := 1; i < len(chain)-1; i++ {
+		attrName := toSnakeCase(chain[i])
+		attr, ok := schema[attrName]
+		if !ok || attr.NestedAttrs == nil {
 			return nil
 		}
+		schema = attr.NestedAttrs
+	}
 
-		if schema, ok := varSchemas[rootVar]; ok {
-			parentAttr, ok := schema[parentAttrName]
-			if !ok || parentAttr.NestedAttrs == nil {
-				return nil
-			}
-			if attr, ok := parentAttr.NestedAttrs[attrName]; ok {
-				return attr
-			}
+	// Look up the leaf field.
+	leafAttr := toSnakeCase(chain[len(chain)-1])
+	if attr, ok := schema[leafAttr]; ok {
+		return attr
+	}
+	return nil
+}
+
+// buildSelectorChain converts a selector expression to an ordered list of names.
+// E.g., plan.Config.Metric → ["plan", "Config", "Metric"].
+func buildSelectorChain(expr ast.Expr) []string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return []string{e.Name}
+	case *ast.SelectorExpr:
+		parent := buildSelectorChain(e.X)
+		if parent == nil {
+			return nil
 		}
+		return append(parent, e.Sel.Name)
 	}
 	return nil
 }
@@ -373,7 +380,7 @@ func selectorKey(expr ast.Expr) string {
 
 // checkRedundantGuards walks the function body and flags IsUnknown() calls
 // on fields that can never be Unknown.
-func checkRedundantGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo, schema map[string]*schemaparser.AttrInfo) {
+func checkRedundantGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo) {
 	ast.Inspect(body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
@@ -535,6 +542,8 @@ func extractStarTypeName(expr ast.Expr) string {
 
 // findSchemaCall searches the Schema() method body for a call to a
 // function whose name ends with "ResourceSchema" or "DataSourceSchema".
+// Supports both unqualified calls (AlertResourceSchema) and package-qualified
+// calls (resource_alert.AlertResourceSchema).
 func findSchemaCall(fn *ast.FuncDecl) string {
 	var schemaName string
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
@@ -542,12 +551,16 @@ func findSchemaCall(fn *ast.FuncDecl) string {
 		if !ok {
 			return true
 		}
-		if ident, ok := call.Fun.(*ast.Ident); ok {
-			name := ident.Name
-			if strings.HasSuffix(name, "ResourceSchema") || strings.HasSuffix(name, "DataSourceSchema") {
-				schemaName = name
-				return false
-			}
+		var name string
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			name = fun.Name
+		case *ast.SelectorExpr:
+			name = fun.Sel.Name
+		}
+		if name != "" && (strings.HasSuffix(name, "ResourceSchema") || strings.HasSuffix(name, "DataSourceSchema")) {
+			schemaName = name
+			return false
 		}
 		return true
 	})

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -1,0 +1,567 @@
+// Package requestguard validates IsUnknown() usage in request builder functions.
+//
+// Direction 1 (redundant guard): flags IsUnknown() checks on fields that can
+// never be Unknown (Required, Optional without Computed, Optional+Computed with
+// Default). These guards are dead code.
+//
+// Direction 2 (missing guard): flags non-pointer value accessors (ValueString,
+// ValueBool, ValueFloat64, ValueInt64) on Optional+Computed fields without
+// Default when not guarded by IsUnknown(). Pointer accessors (ValueStringPointer
+// etc.) are excluded because they return nil for Unknown, which is often acceptable.
+package requestguard
+
+import (
+	"go/ast"
+	"strings"
+
+	"github.com/doitintl/terraform-provider-doit/tools/linters/schemaparser"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Analyzer is the go/analysis Analyzer for requestguard.
+var Analyzer = &analysis.Analyzer{
+	Name:     "requestguard",
+	Doc:      "Validates IsUnknown() usage in request builder functions.",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer, schemaparser.Analyzer},
+}
+
+// neverUnknownClasses are schema classifications where IsUnknown() is dead code.
+var neverUnknownClasses = map[schemaparser.FieldClass]string{
+	schemaparser.Required: "Required",
+	schemaparser.Optional: "Optional (not Computed)",
+}
+
+// nonPointerAccessors are value accessors that return zero values for Unknown
+// (not nil), making them unsafe without an IsUnknown() guard.
+var nonPointerAccessors = map[string]bool{
+	"ValueString":  true,
+	"ValueBool":    true,
+	"ValueFloat64": true,
+	"ValueInt64":   true,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	result := pass.ResultOf[schemaparser.Analyzer]
+	if result == nil {
+		return nil, nil
+	}
+	schemaResult, ok := result.(*schemaparser.SchemaFacts)
+	if !ok || schemaResult == nil {
+		return nil, nil
+	}
+
+	// Build a flat map of all schema attrs (including nested) indexed by
+	// schema function name. Each entry maps field name → AttrInfo.
+	// We store both prefixed ("config.metric") and unprefixed ("metric")
+	// for nested attrs so nested helper functions can resolve fields.
+	type attrMap = map[string]*schemaparser.AttrInfo
+	perSchema := map[string]attrMap{}
+	for name, info := range schemaResult.Schemas {
+		m := attrMap{}
+		collectAttrs(info.Attrs, m, "")
+		perSchema[name] = m
+	}
+
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	// Step 1: Map receiver types → schema names via Schema() methods.
+	receiverToSchema := map[string]string{}
+	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil)}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Name == nil || fn.Name.Name != "Schema" || fn.Body == nil {
+			return
+		}
+		if fn.Recv == nil || len(fn.Recv.List) == 0 {
+			return
+		}
+		recvType := extractReceiverTypeName(fn)
+		if recvType == "" {
+			return
+		}
+		schemaName := findSchemaCall(fn)
+		if schemaName == "" {
+			return
+		}
+		receiverToSchema[recvType] = schemaName
+	})
+
+	// Step 2: Find request builder functions and check guards.
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Name == nil || fn.Body == nil {
+			return
+		}
+		if !isRequestBuilder(fn.Name.Name) {
+			return
+		}
+
+		// Resolve schema: try receiver, then parameter types.
+		schema := resolveSchema(fn, receiverToSchema, perSchema)
+		if schema == nil {
+			return
+		}
+
+		// Build variable → schema path mapping for nested field tracking.
+		// Initialize with the plan parameter name.
+		planParam := findPlanParam(fn)
+		if planParam == "" {
+			return
+		}
+
+		// varSchemas maps variable names to their nested schema context.
+		// The plan parameter maps to the top-level schema.
+		varSchemas := map[string]attrMap{planParam: schema}
+
+		// Track variable assignments to nested types.
+		trackVariableAssignments(fn.Body, varSchemas, schema)
+
+		// Direction 1: Find redundant IsUnknown() guards.
+		checkRedundantGuards(pass, fn.Body, varSchemas, schema)
+
+		// Direction 2: Find missing guards on non-pointer value accessors.
+		checkMissingGuards(pass, fn.Body, varSchemas)
+	})
+
+	return nil, nil
+}
+
+// collectAttrs recursively builds a flat map of attribute name → AttrInfo.
+// Nested attrs are stored with dot-prefixed keys AND without prefix.
+func collectAttrs(attrs map[string]*schemaparser.AttrInfo, out map[string]*schemaparser.AttrInfo, prefix string) {
+	for name, info := range attrs {
+		out[prefix+name] = info
+		if info.NestedAttrs != nil {
+			// Store nested attrs both with prefix (for top-level resolution)
+			// and without (for when a variable holds the nested type directly).
+			collectAttrs(info.NestedAttrs, out, prefix+name+".")
+			collectAttrs(info.NestedAttrs, out, "")
+		}
+	}
+}
+
+// isRequestBuilder returns true if the function name matches a request builder
+// pattern (toCreateRequest, toUpdateRequest, fillXxxCommon, toAlertConfig, etc.).
+func isRequestBuilder(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "request") ||
+		strings.Contains(lower, "common") ||
+		strings.Contains(lower, "config") && strings.HasPrefix(lower, "to")
+}
+
+// resolveSchema resolves the schema for a function by trying receiver type,
+// then parameter types.
+func resolveSchema(fn *ast.FuncDecl, receiverToSchema map[string]string, perSchema map[string]map[string]*schemaparser.AttrInfo) map[string]*schemaparser.AttrInfo {
+	// Try receiver first.
+	recvType := extractReceiverTypeName(fn)
+	if recvType != "" {
+		if schemaName, ok := receiverToSchema[recvType]; ok {
+			if s, ok := perSchema[schemaName]; ok {
+				return s
+			}
+		}
+		// Try deriving schema from model type name.
+		schemaName := modelTypeToSchema(recvType)
+		if s, ok := perSchema[schemaName]; ok {
+			return s
+		}
+	}
+
+	// Try parameter types.
+	if fn.Type != nil && fn.Type.Params != nil {
+		for _, field := range fn.Type.Params.List {
+			typeName := extractStarTypeName(field.Type)
+			if typeName == "" {
+				continue
+			}
+			schemaName := modelTypeToSchema(typeName)
+			if s, ok := perSchema[schemaName]; ok {
+				return s
+			}
+		}
+	}
+
+	return nil
+}
+
+// modelTypeToSchema derives the schema function name from a model type name.
+// E.g., "budgetResourceModel" → "BudgetResourceSchema".
+func modelTypeToSchema(typeName string) string {
+	base := ""
+	if strings.HasSuffix(typeName, "ResourceModel") {
+		base = strings.TrimSuffix(typeName, "Model")
+	} else if strings.HasSuffix(typeName, "Model") {
+		base = strings.TrimSuffix(typeName, "Model") + "Resource"
+	}
+	if base == "" {
+		return ""
+	}
+	// Capitalize first letter.
+	return strings.ToUpper(base[:1]) + base[1:] + "Schema"
+}
+
+// findPlanParam returns the name of the plan parameter in a request builder.
+// It looks for a parameter named "plan" or a receiver (method on model).
+func findPlanParam(fn *ast.FuncDecl) string {
+	// If method, the receiver acts as the plan.
+	if fn.Recv != nil && len(fn.Recv.List) > 0 {
+		for _, name := range fn.Recv.List[0].Names {
+			return name.Name
+		}
+	}
+	// Look for a parameter named "plan" or a *XxxModel parameter.
+	if fn.Type != nil && fn.Type.Params != nil {
+		for _, field := range fn.Type.Params.List {
+			for _, name := range field.Names {
+				if name.Name == "plan" {
+					return name.Name
+				}
+			}
+			// Check if it's a model type parameter.
+			typeName := extractStarTypeName(field.Type)
+			if typeName != "" && (strings.HasSuffix(typeName, "Model") || strings.HasSuffix(typeName, "Value")) {
+				for _, name := range field.Names {
+					return name.Name
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// trackVariableAssignments scans the function body for assignments that
+// create aliases to nested schema contexts (e.g., "config := plan.Config").
+func trackVariableAssignments(body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo, topSchema map[string]*schemaparser.AttrInfo) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, rhs := range assign.Rhs {
+			if i >= len(assign.Lhs) {
+				continue
+			}
+			lhsIdent, ok := assign.Lhs[i].(*ast.Ident)
+			if !ok {
+				continue
+			}
+			// Check if RHS is varName.Field.
+			sel, ok := rhs.(*ast.SelectorExpr)
+			if !ok {
+				continue
+			}
+			varName, fieldName := resolveSelectorChain(sel)
+			if varName == "" {
+				continue
+			}
+			// Check if the parent variable has a known schema.
+			if _, ok := varSchemas[varName]; !ok {
+				continue
+			}
+			// The field corresponds to a nested attribute — register
+			// the assigned variable with the nested schema.
+			attrName := toSnakeCase(fieldName)
+			nestedKey := attrName + "."
+			nested := map[string]*schemaparser.AttrInfo{}
+			for k, v := range topSchema {
+				if strings.HasPrefix(k, nestedKey) {
+					nested[strings.TrimPrefix(k, nestedKey)] = v
+				}
+			}
+			// Also include unprefixed nested attrs.
+			for k, v := range topSchema {
+				if !strings.Contains(k, ".") {
+					nested[k] = v
+				}
+			}
+			if len(nested) > 0 {
+				varSchemas[lhsIdent.Name] = nested
+			}
+		}
+		return true
+	})
+}
+
+// resolveSelectorChain resolves a.B to ("a", "B"), a.B.C to ("a", "C") etc.
+// Returns the root variable name and the immediate field name.
+func resolveSelectorChain(sel *ast.SelectorExpr) (rootVar, fieldName string) {
+	fieldName = sel.Sel.Name
+	switch x := sel.X.(type) {
+	case *ast.Ident:
+		return x.Name, fieldName
+	case *ast.SelectorExpr:
+		root, _ := resolveSelectorChain(x)
+		return root, fieldName
+	}
+	return "", ""
+}
+
+// resolveFieldAttr resolves a selector expression to its schema AttrInfo
+// by looking up the field name in the variable's schema context.
+func resolveFieldAttr(sel *ast.SelectorExpr, varSchemas map[string]map[string]*schemaparser.AttrInfo) *schemaparser.AttrInfo {
+	fieldName := sel.Sel.Name
+	attrName := toSnakeCase(fieldName)
+
+	// Get the variable that owns this field.
+	switch x := sel.X.(type) {
+	case *ast.Ident:
+		if schema, ok := varSchemas[x.Name]; ok {
+			if attr, ok := schema[attrName]; ok {
+				return attr
+			}
+		}
+	case *ast.SelectorExpr:
+		// Nested: e.g., plan.Config.Metric → look up Metric in Config's schema.
+		// First resolve the intermediate selector.
+		parentField := x.Sel.Name
+		parentAttr := toSnakeCase(parentField)
+
+		rootVar := ""
+		switch rx := x.X.(type) {
+		case *ast.Ident:
+			rootVar = rx.Name
+		case *ast.SelectorExpr:
+			rootVar, _ = resolveSelectorChain(rx)
+		}
+
+		if rootVar == "" {
+			return nil
+		}
+
+		if schema, ok := varSchemas[rootVar]; ok {
+			// Look for parentAttr.attrName in the schema.
+			nestedKey := parentAttr + "." + attrName
+			if attr, ok := schema[nestedKey]; ok {
+				return attr
+			}
+		}
+	}
+	return nil
+}
+
+
+
+// extractGuardedFromCond extracts field selector strings from conditions
+// containing IsUnknown() calls.
+func extractGuardedFromCond(expr ast.Expr, guarded map[string]bool) {
+	switch e := expr.(type) {
+	case *ast.BinaryExpr:
+		extractGuardedFromCond(e.X, guarded)
+		extractGuardedFromCond(e.Y, guarded)
+	case *ast.UnaryExpr:
+		extractGuardedFromCond(e.X, guarded)
+	case *ast.ParenExpr:
+		extractGuardedFromCond(e.X, guarded)
+	case *ast.CallExpr:
+		// Check for plan.X.IsUnknown()
+		sel, ok := e.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "IsUnknown" {
+			return
+		}
+		// The receiver of IsUnknown is plan.X.
+		key := selectorKey(sel.X)
+		if key != "" {
+			guarded[key] = true
+		}
+	}
+}
+
+// selectorKey returns a string key for a selector expression, e.g., "plan.Metric".
+func selectorKey(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		parent := selectorKey(e.X)
+		if parent != "" {
+			return parent + "." + e.Sel.Name
+		}
+	}
+	return ""
+}
+
+// checkRedundantGuards walks the function body and flags IsUnknown() calls
+// on fields that can never be Unknown.
+func checkRedundantGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo, schema map[string]*schemaparser.AttrInfo) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "IsUnknown" {
+			return true
+		}
+
+		// Resolve the field being checked.
+		fieldSel, ok := sel.X.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		attr := resolveFieldAttr(fieldSel, varSchemas)
+		if attr == nil {
+			return true
+		}
+
+		// Check if the field can never be Unknown.
+		if reason, ok := neverUnknownClasses[attr.Class]; ok {
+			attrName := toSnakeCase(fieldSel.Sel.Name)
+			pass.Reportf(call.Pos(),
+				"IsUnknown() on %s field %q is dead code (%s fields are always Known)",
+				reason, attrName, reason)
+		} else if attr.Class == schemaparser.OptionalComputed && attr.HasDefault {
+			attrName := toSnakeCase(fieldSel.Sel.Name)
+			pass.Reportf(call.Pos(),
+				"IsUnknown() on field %q with schema Default is dead code "+
+					"(defaults are resolved at plan time)",
+				attrName)
+		}
+
+		return true
+	})
+}
+
+// checkMissingGuards walks the function body and flags non-pointer value
+// accessors on Optional+Computed fields without Default when not guarded
+// by an enclosing if-condition with IsUnknown().
+func checkMissingGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo) {
+	// Build a map from position ranges of if-bodies to the fields they guard.
+	// This allows us to check if a value accessor is inside a guarded scope.
+	type guardScope struct {
+		startPos, endPos int
+		guardedKeys      map[string]bool
+	}
+	var scopes []guardScope
+
+	ast.Inspect(body, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		guarded := map[string]bool{}
+		extractGuardedFromCond(ifStmt.Cond, guarded)
+		if len(guarded) > 0 && ifStmt.Body != nil {
+			scopes = append(scopes, guardScope{
+				startPos:    int(ifStmt.Body.Pos()),
+				endPos:      int(ifStmt.Body.End()),
+				guardedKeys: guarded,
+			})
+		}
+		return true
+	})
+
+	// Now check all value accessor calls.
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		// Check if it's a non-pointer accessor.
+		if !nonPointerAccessors[sel.Sel.Name] {
+			return true
+		}
+
+		// The receiver should be plan.X (a field selector).
+		fieldSel, ok := sel.X.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		attr := resolveFieldAttr(fieldSel, varSchemas)
+		if attr == nil {
+			return true
+		}
+
+		// Only flag Optional+Computed without Default.
+		if attr.Class != schemaparser.OptionalComputed || attr.HasDefault {
+			return true
+		}
+
+		// Check if the call is inside a guarded scope for this field.
+		key := selectorKey(fieldSel)
+		callPos := int(call.Pos())
+		for _, scope := range scopes {
+			if callPos >= scope.startPos && callPos <= scope.endPos && scope.guardedKeys[key] {
+				return true // inside guarded scope
+			}
+		}
+
+		attrName := toSnakeCase(fieldSel.Sel.Name)
+		pass.Reportf(call.Pos(),
+			"%s() on Optional+Computed field %q without IsUnknown() guard; "+
+				"field may be Unknown at plan time",
+			sel.Sel.Name, attrName)
+
+		return true
+	})
+}
+
+// toSnakeCase converts a Go field name to snake_case by inserting underscores
+// before uppercase letters.
+func toSnakeCase(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r + 32) // lowercase
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// extractReceiverTypeName extracts the type name from a method's receiver.
+func extractReceiverTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	return extractStarTypeName(fn.Recv.List[0].Type)
+}
+
+// extractStarTypeName extracts the type name from *T.
+func extractStarTypeName(expr ast.Expr) string {
+	star, ok := expr.(*ast.StarExpr)
+	if !ok {
+		if ident, ok := expr.(*ast.Ident); ok {
+			return ident.Name
+		}
+		return ""
+	}
+	if ident, ok := star.X.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
+}
+
+// findSchemaCall searches the Schema() method body for a call to a
+// function whose name ends with "ResourceSchema" or "DataSourceSchema".
+func findSchemaCall(fn *ast.FuncDecl) string {
+	var schemaName string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok {
+			name := ident.Name
+			if strings.HasSuffix(name, "ResourceSchema") || strings.HasSuffix(name, "DataSourceSchema") {
+				schemaName = name
+				return false
+			}
+		}
+		return true
+	})
+	return schemaName
+}

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -12,6 +12,7 @@ package requestguard
 
 import (
 	"go/ast"
+	"go/token"
 	"strings"
 
 	"github.com/doitintl/terraform-provider-doit/tools/linters/schemaparser"
@@ -53,16 +54,13 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	// Build a flat map of all schema attrs (including nested) indexed by
-	// schema function name. Each entry maps field name → AttrInfo.
-	// We store both prefixed ("config.metric") and unprefixed ("metric")
-	// for nested attrs so nested helper functions can resolve fields.
+	// Index schemas by function name. Each schema's Attrs map contains
+	// only top-level attributes; nested attrs live in AttrInfo.NestedAttrs.
+	// This avoids name collisions between top-level and nested attrs.
 	type attrMap = map[string]*schemaparser.AttrInfo
 	perSchema := map[string]attrMap{}
 	for name, info := range schemaResult.Schemas {
-		m := attrMap{}
-		collectAttrs(info.Attrs, m, "")
-		perSchema[name] = m
+		perSchema[name] = info.Attrs
 	}
 
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
@@ -117,7 +115,7 @@ func run(pass *analysis.Pass) (any, error) {
 		varSchemas := map[string]attrMap{planParam: schema}
 
 		// Track variable assignments to nested types.
-		trackVariableAssignments(fn.Body, varSchemas, schema)
+		trackVariableAssignments(fn.Body, varSchemas)
 
 		// Direction 1: Find redundant IsUnknown() guards.
 		checkRedundantGuards(pass, fn.Body, varSchemas, schema)
@@ -129,19 +127,7 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// collectAttrs recursively builds a flat map of attribute name → AttrInfo.
-// Nested attrs are stored with dot-prefixed keys AND without prefix.
-func collectAttrs(attrs map[string]*schemaparser.AttrInfo, out map[string]*schemaparser.AttrInfo, prefix string) {
-	for name, info := range attrs {
-		out[prefix+name] = info
-		if info.NestedAttrs != nil {
-			// Store nested attrs both with prefix (for top-level resolution)
-			// and without (for when a variable holds the nested type directly).
-			collectAttrs(info.NestedAttrs, out, prefix+name+".")
-			collectAttrs(info.NestedAttrs, out, "")
-		}
-	}
-}
+
 
 // isRequestBuilder returns true if the function name matches a request builder
 // pattern (toCreateRequest, toUpdateRequest, fillXxxCommon, toAlertConfig, etc.).
@@ -234,7 +220,9 @@ func findPlanParam(fn *ast.FuncDecl) string {
 
 // trackVariableAssignments scans the function body for assignments that
 // create aliases to nested schema contexts (e.g., "config := plan.Config").
-func trackVariableAssignments(body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo, topSchema map[string]*schemaparser.AttrInfo) {
+// It derives the nested schema from the parent AttrInfo.NestedAttrs rather
+// than flattening the schema tree, preventing name collisions.
+func trackVariableAssignments(body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo) {
 	ast.Inspect(body, func(n ast.Node) bool {
 		assign, ok := n.(*ast.AssignStmt)
 		if !ok {
@@ -258,28 +246,18 @@ func trackVariableAssignments(body *ast.BlockStmt, varSchemas map[string]map[str
 				continue
 			}
 			// Check if the parent variable has a known schema.
-			if _, ok := varSchemas[varName]; !ok {
+			parentSchema, ok := varSchemas[varName]
+			if !ok {
 				continue
 			}
-			// The field corresponds to a nested attribute — register
-			// the assigned variable with the nested schema.
+			// Look up the field in the parent's schema and use its
+			// NestedAttrs as the assigned variable's schema context.
 			attrName := toSnakeCase(fieldName)
-			nestedKey := attrName + "."
-			nested := map[string]*schemaparser.AttrInfo{}
-			for k, v := range topSchema {
-				if strings.HasPrefix(k, nestedKey) {
-					nested[strings.TrimPrefix(k, nestedKey)] = v
-				}
+			parentAttr, ok := parentSchema[attrName]
+			if !ok || parentAttr.NestedAttrs == nil {
+				continue
 			}
-			// Also include unprefixed nested attrs.
-			for k, v := range topSchema {
-				if !strings.Contains(k, ".") {
-					nested[k] = v
-				}
-			}
-			if len(nested) > 0 {
-				varSchemas[lhsIdent.Name] = nested
-			}
+			varSchemas[lhsIdent.Name] = parentAttr.NestedAttrs
 		}
 		return true
 	})
@@ -300,7 +278,7 @@ func resolveSelectorChain(sel *ast.SelectorExpr) (rootVar, fieldName string) {
 }
 
 // resolveFieldAttr resolves a selector expression to its schema AttrInfo
-// by looking up the field name in the variable's schema context.
+// by navigating the schema tree via NestedAttrs.
 func resolveFieldAttr(sel *ast.SelectorExpr, varSchemas map[string]map[string]*schemaparser.AttrInfo) *schemaparser.AttrInfo {
 	fieldName := sel.Sel.Name
 	attrName := toSnakeCase(fieldName)
@@ -314,10 +292,10 @@ func resolveFieldAttr(sel *ast.SelectorExpr, varSchemas map[string]map[string]*s
 			}
 		}
 	case *ast.SelectorExpr:
-		// Nested: e.g., plan.Config.Metric → look up Metric in Config's schema.
-		// First resolve the intermediate selector.
+		// Nested: e.g., plan.Config.Metric → look up Config in plan's schema,
+		// then look up Metric in Config's NestedAttrs.
 		parentField := x.Sel.Name
-		parentAttr := toSnakeCase(parentField)
+		parentAttrName := toSnakeCase(parentField)
 
 		rootVar := ""
 		switch rx := x.X.(type) {
@@ -332,9 +310,11 @@ func resolveFieldAttr(sel *ast.SelectorExpr, varSchemas map[string]map[string]*s
 		}
 
 		if schema, ok := varSchemas[rootVar]; ok {
-			// Look for parentAttr.attrName in the schema.
-			nestedKey := parentAttr + "." + attrName
-			if attr, ok := schema[nestedKey]; ok {
+			parentAttr, ok := schema[parentAttrName]
+			if !ok || parentAttr.NestedAttrs == nil {
+				return nil
+			}
+			if attr, ok := parentAttr.NestedAttrs[attrName]; ok {
 				return attr
 			}
 		}
@@ -345,26 +325,34 @@ func resolveFieldAttr(sel *ast.SelectorExpr, varSchemas map[string]map[string]*s
 
 
 // extractGuardedFromCond extracts field selector strings from conditions
-// containing IsUnknown() calls.
-func extractGuardedFromCond(expr ast.Expr, guarded map[string]bool) {
+// containing negated IsUnknown() calls (!plan.X.IsUnknown()). Only negated
+// calls guard the if-body — a positive check (plan.X.IsUnknown()) means the
+// body runs WHEN Unknown, so it is not a guard.
+func extractGuardedFromCond(expr ast.Expr, guarded map[string]bool, negated bool) {
 	switch e := expr.(type) {
 	case *ast.BinaryExpr:
-		extractGuardedFromCond(e.X, guarded)
-		extractGuardedFromCond(e.Y, guarded)
+		extractGuardedFromCond(e.X, guarded, negated)
+		extractGuardedFromCond(e.Y, guarded, negated)
 	case *ast.UnaryExpr:
-		extractGuardedFromCond(e.X, guarded)
+		if e.Op == token.NOT {
+			extractGuardedFromCond(e.X, guarded, !negated)
+		} else {
+			extractGuardedFromCond(e.X, guarded, negated)
+		}
 	case *ast.ParenExpr:
-		extractGuardedFromCond(e.X, guarded)
+		extractGuardedFromCond(e.X, guarded, negated)
 	case *ast.CallExpr:
 		// Check for plan.X.IsUnknown()
 		sel, ok := e.Fun.(*ast.SelectorExpr)
 		if !ok || sel.Sel.Name != "IsUnknown" {
 			return
 		}
-		// The receiver of IsUnknown is plan.X.
-		key := selectorKey(sel.X)
-		if key != "" {
-			guarded[key] = true
+		// Only treat as guard when negated: !plan.X.IsUnknown()
+		if negated {
+			key := selectorKey(sel.X)
+			if key != "" {
+				guarded[key] = true
+			}
 		}
 	}
 }
@@ -443,7 +431,7 @@ func checkMissingGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map
 			return true
 		}
 		guarded := map[string]bool{}
-		extractGuardedFromCond(ifStmt.Cond, guarded)
+		extractGuardedFromCond(ifStmt.Cond, guarded, false)
 		if len(guarded) > 0 && ifStmt.Body != nil {
 			scopes = append(scopes, guardScope{
 				startPos:    int(ifStmt.Body.Pos()),

--- a/tools/linters/requestguard/analyzer_test.go
+++ b/tools/linters/requestguard/analyzer_test.go
@@ -1,0 +1,13 @@
+package requestguard_test
+
+import (
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/tools/linters/requestguard"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestRequestGuard(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, requestguard.Analyzer, "guardtest")
+}

--- a/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault/booldefault.go
+++ b/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault/booldefault.go
@@ -1,0 +1,4 @@
+// Stub package for booldefault.
+package booldefault
+
+func StaticBool(v bool) interface{} { return v }

--- a/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/schema.go
+++ b/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/schema.go
@@ -1,0 +1,81 @@
+// Stub package for analysistest.
+package schema
+
+import "context"
+
+type Schema struct {
+	Attributes          map[string]Attribute
+	Description         string
+	MarkdownDescription string
+}
+
+type Attribute interface{}
+
+type StringAttribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type Float64Attribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type BoolAttribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type ListAttribute struct {
+	ElementType         interface{}
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Description         string
+	MarkdownDescription string
+}
+
+type ListNestedAttribute struct {
+	NestedObject        NestedAttributeObject
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Description         string
+	MarkdownDescription string
+}
+
+type NestedAttributeObject struct {
+	Attributes map[string]Attribute
+}
+
+type Int64Attribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+type SingleNestedAttribute struct {
+	Attributes          map[string]Attribute
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Description         string
+	MarkdownDescription string
+}
+
+var _ context.Context

--- a/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault/stringdefault.go
+++ b/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault/stringdefault.go
@@ -1,0 +1,4 @@
+// Stub package for stringdefault.
+package stringdefault
+
+func StaticString(v string) interface{} { return v }

--- a/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/types/types.go
+++ b/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/types/types.go
@@ -1,0 +1,33 @@
+// Stub types package for analysistest.
+package types
+
+type String struct{}
+type Float64 struct{}
+type Bool struct{}
+type List struct{}
+type Int64 struct{}
+
+func (s String) IsUnknown() bool  { return false }
+func (s String) IsNull() bool     { return false }
+func (f Float64) IsUnknown() bool { return false }
+func (f Float64) IsNull() bool    { return false }
+func (b Bool) IsUnknown() bool    { return false }
+func (b Bool) IsNull() bool       { return false }
+func (l List) IsUnknown() bool    { return false }
+func (l List) IsNull() bool       { return false }
+func (i Int64) IsUnknown() bool   { return false }
+func (i Int64) IsNull() bool      { return false }
+
+func (s String) ValueString() string      { return "" }
+func (s String) ValueStringPointer() *string { return nil }
+func (f Float64) ValueFloat64() float64   { return 0 }
+func (f Float64) ValueFloat64Pointer() *float64 { return nil }
+func (b Bool) ValueBool() bool            { return false }
+func (b Bool) ValueBoolPointer() *bool    { return nil }
+func (i Int64) ValueInt64() int64         { return 0 }
+func (i Int64) ValueInt64Pointer() *int64 { return nil }
+
+var StringType interface{} = nil
+
+func Int64Value(v int64) Int64 { return Int64{} }
+func Int64Null() Int64         { return Int64{} }

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
@@ -117,3 +117,32 @@ func (plan *GuardTestModel) toInviteRequest() ApiRequest {
 
 	return req
 }
+
+// --- Deep nesting tests (2+ levels) ---
+
+// toFilterRequest tests resolution through 2 levels of nesting.
+func toFilterRequest(plan *GuardTestModel) *FilterRequest {
+	config := plan.Config
+	req := &FilterRequest{}
+
+	// BAD: Required at 2nd nesting level via variable chain — IsUnknown() is dead code.
+	if !config.Filter.Operator.IsNull() && !config.Filter.Operator.IsUnknown() { // want `IsUnknown\(\) on Required field "operator" is dead code \(Required fields are always Known\)`
+		req.Operator = config.Filter.Operator.ValueStringPointer()
+	}
+
+	// BAD: Optional+Computed without default at 2nd nesting level — missing guard.
+	val := config.Filter.Mode.ValueString() // want `ValueString\(\) on Optional\+Computed field "mode" without IsUnknown\(\) guard; field may be Unknown at plan time`
+	_ = val
+
+	// GOOD: Guarded Optional+Computed without default at 2nd nesting level.
+	if !config.Filter.Mode.IsUnknown() {
+		req.Mode = config.Filter.Mode.ValueStringPointer()
+	}
+
+	// BAD: Required at 2nd nesting level via inline 3-level chain — IsUnknown() is dead code.
+	if !plan.Config.Filter.Operator.IsUnknown() { // want `IsUnknown\(\) on Required field "operator" is dead code \(Required fields are always Known\)`
+		req.Operator = plan.Config.Filter.Operator.ValueStringPointer()
+	}
+
+	return req
+}

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
@@ -1,0 +1,97 @@
+package guardtest
+
+// --- Direction 1: Redundant IsUnknown() guards ---
+
+// toCreateRequest is a request builder method on the model.
+func (plan *GuardTestModel) toCreateRequest() ApiRequest {
+	req := ApiRequest{}
+
+	// GOOD: Required field — no guard needed, direct access is correct.
+	req.Name = plan.Name.ValueStringPointer()
+
+	// BAD: Required field — IsUnknown() guard is dead code.
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() { // want `IsUnknown\(\) on Required field "name" is dead code \(Required fields are always Known\)`
+		req.Name = plan.Name.ValueStringPointer()
+	}
+
+	// BAD: Optional (no Computed) field — IsUnknown() guard is dead code.
+	if !plan.Label.IsNull() && !plan.Label.IsUnknown() { // want `IsUnknown\(\) on Optional \(not Computed\) field "label" is dead code \(Optional \(not Computed\) fields are always Known\)`
+		req.Label = plan.Label.ValueStringPointer()
+	}
+
+	// BAD: Optional+Computed WITH default — IsUnknown() is dead code.
+	if !plan.Metric.IsNull() && !plan.Metric.IsUnknown() { // want `IsUnknown\(\) on field "metric" with schema Default is dead code \(defaults are resolved at plan time\)`
+		req.Metric = plan.Metric.ValueStringPointer()
+	}
+
+	// GOOD: Optional+Computed WITHOUT default — IsUnknown() guard is needed.
+	if !plan.FolderId.IsNull() && !plan.FolderId.IsUnknown() {
+		req.FolderId = plan.FolderId.ValueStringPointer()
+	}
+
+	// GOOD: Computed-only — IsUnknown() guard is legitimate.
+	if !plan.Id.IsNull() && !plan.Id.IsUnknown() {
+		// id is computed-only, guard is fine
+	}
+
+	return req
+}
+
+// --- Direction 2: Missing IsUnknown() guards ---
+
+// toUpdateRequest tests missing guard detection.
+func (plan *GuardTestModel) toUpdateRequest() ApiRequest {
+	req := ApiRequest{}
+
+	// GOOD: Required — no guard needed, ValueString is safe.
+	req.Name = plan.Name.ValueStringPointer()
+
+	// GOOD: Optional+Computed WITHOUT default, properly guarded.
+	if !plan.FolderId.IsNull() && !plan.FolderId.IsUnknown() {
+		req.FolderId = plan.FolderId.ValueStringPointer()
+	}
+
+	// BAD: Optional+Computed WITHOUT default, ValueString without guard.
+	name := plan.FolderId.ValueString() // want `ValueString\(\) on Optional\+Computed field "folder_id" without IsUnknown\(\) guard; field may be Unknown at plan time`
+	_ = name
+
+	// GOOD: Optional+Computed WITHOUT default, ValueStringPointer without guard.
+	// Pointer accessors return nil for Unknown, which is often acceptable.
+	req.FolderId = plan.FolderId.ValueStringPointer()
+
+	// GOOD: Optional+Computed WITH default — no guard needed, ValueString is safe.
+	metric := plan.Metric.ValueString()
+	_ = metric
+
+	return req
+}
+
+// --- Nested field tests ---
+
+// toConfigRequest tests nested field handling.
+func toConfigRequest(plan *GuardTestModel) *ConfigRequest {
+	config := plan.Config
+	req := &ConfigRequest{}
+
+	// BAD: Required nested field — IsUnknown() is dead code.
+	if !config.Type.IsNull() && !config.Type.IsUnknown() { // want `IsUnknown\(\) on Required field "type" is dead code \(Required fields are always Known\)`
+		req.Type = config.Type.ValueStringPointer()
+	}
+
+	// BAD: Optional+Computed WITH default nested field — IsUnknown() is dead code.
+	if !config.CaseInsensitive.IsNull() && !config.CaseInsensitive.IsUnknown() { // want `IsUnknown\(\) on field "case_insensitive" with schema Default is dead code \(defaults are resolved at plan time\)`
+		b := config.CaseInsensitive.ValueBool()
+		req.CaseInsensitive = &b
+	}
+
+	// GOOD: Optional+Computed WITHOUT default nested field — guard is needed.
+	if !config.Currency.IsNull() && !config.Currency.IsUnknown() {
+		req.Currency = config.Currency.ValueStringPointer()
+	}
+
+	// BAD: Optional+Computed WITHOUT default nested field, ValueString without guard.
+	val := config.Currency.ValueString() // want `ValueString\(\) on Optional\+Computed field "currency" without IsUnknown\(\) guard; field may be Unknown at plan time`
+	_ = val
+
+	return req
+}

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
@@ -95,3 +95,25 @@ func toConfigRequest(plan *GuardTestModel) *ConfigRequest {
 
 	return req
 }
+
+// --- Guard polarity tests ---
+
+// toInviteRequest tests that positive IsUnknown() checks are NOT treated as guards.
+func (plan *GuardTestModel) toInviteRequest() ApiRequest {
+	req := ApiRequest{}
+
+	// BAD: Positive IsUnknown() check — body runs WHEN Unknown, so
+	// ValueString() inside is definitely wrong. Must still be flagged.
+	if plan.FolderId.IsUnknown() {
+		val := plan.FolderId.ValueString() // want `ValueString\(\) on Optional\+Computed field "folder_id" without IsUnknown\(\) guard; field may be Unknown at plan time`
+		req.FolderId = &val
+	}
+
+	// GOOD: Negated IsUnknown() check — body runs when Known.
+	if !plan.FolderId.IsUnknown() {
+		val := plan.FolderId.ValueString()
+		req.FolderId = &val
+	}
+
+	return req
+}

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
@@ -60,6 +60,22 @@ func GuardTestResourceSchema(ctx context.Context) schema.Schema {
 						Optional: true,
 						Computed: true,
 					},
+					// 2-level nested attribute.
+					"filter": schema.SingleNestedAttribute{
+						Optional: true,
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							// Required at 2nd nesting level.
+							"operator": schema.StringAttribute{
+								Required: true,
+							},
+							// Optional+Computed without default at 2nd nesting level.
+							"mode": schema.StringAttribute{
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -81,6 +97,13 @@ type ConfigValue struct {
 	Type             types.String
 	CaseInsensitive  types.Bool
 	Currency         types.String
+	Filter           FilterValue
+}
+
+// FilterValue is the 2nd-level nested model.
+type FilterValue struct {
+	Operator types.String
+	Mode     types.String
 }
 
 // guardTestResource is a mock resource.
@@ -105,4 +128,11 @@ type ConfigRequest struct {
 	Type            *string
 	CaseInsensitive *bool
 	Currency        *string
+	Filter          *FilterRequest
+}
+
+// FilterRequest is a mock 2nd-level nested request type.
+type FilterRequest struct {
+	Operator *string
+	Mode     *string
 }

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
@@ -1,0 +1,108 @@
+// Package guardtest is a test fixture for the requestguard analyzer.
+package guardtest
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure imports are used.
+var _ context.Context
+
+// GuardTestResourceSchema returns a test schema with various field types.
+func GuardTestResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			// Computed-only: IsUnknown() is legitimate.
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			// Required: IsUnknown() is dead code.
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			// Optional (no Computed): IsUnknown() is dead code.
+			"label": schema.StringAttribute{
+				Optional: true,
+			},
+			// Optional+Computed WITH default: IsUnknown() is dead code.
+			"metric": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("cost"),
+			},
+			// Optional+Computed WITHOUT default: IsUnknown() is needed.
+			"folder_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			// Nested attribute with mixed fields.
+			"config": schema.SingleNestedAttribute{
+				Optional: true,
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					// Required nested field.
+					"type": schema.StringAttribute{
+						Required: true,
+					},
+					// Optional+Computed WITH default nested field.
+					"case_insensitive": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
+					},
+					// Optional+Computed WITHOUT default nested field.
+					"currency": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+// GuardTestModel is the Terraform model.
+type GuardTestModel struct {
+	Id       types.String
+	Name     types.String
+	Label    types.String
+	Metric   types.String
+	FolderId types.String
+	Config   ConfigValue
+}
+
+// ConfigValue is the nested config model.
+type ConfigValue struct {
+	Type             types.String
+	CaseInsensitive  types.Bool
+	Currency         types.String
+}
+
+// guardTestResource is a mock resource.
+type guardTestResource struct{}
+
+// Schema wires the resource type to the schema.
+func (r *guardTestResource) Schema(ctx context.Context) schema.Schema {
+	return GuardTestResourceSchema(ctx)
+}
+
+// ApiRequest is a mock API request type.
+type ApiRequest struct {
+	Name     *string
+	Label    *string
+	Metric   *string
+	FolderId *string
+	Config   *ConfigRequest
+}
+
+// ConfigRequest is a mock nested API request type.
+type ConfigRequest struct {
+	Type            *string
+	CaseInsensitive *bool
+	Currency        *string
+}


### PR DESCRIPTION
## Summary

Add the `requestguard` linter and update skills documentation to codify how `IsUnknown()` guards interact with schema defaults, Required fields, and Optional-only fields.

Closes #205, closes #209.

## Changes

### New linter: `requestguard`

Bidirectional linter for `IsUnknown()` usage in request builder functions (`toCreateRequest`, `toUpdateRequest`, etc.):

**Direction 1 — Redundant guard (dead code):** Flags `IsUnknown()` on fields that can never be Unknown:

| Classification | Why never Unknown |
|---|---|
| Required | User must set it |
| Optional (no Computed) | Known or Null, never Unknown |
| Optional+Computed with Default | Default resolves at plan time |

**Direction 2 — Missing guard (bug risk):** Flags non-pointer value accessors (`ValueString()`, `ValueBool()`, etc.) on Optional+Computed fields without Default when not guarded by `IsUnknown()`. Pointer accessors (`ValueStringPointer()`, etc.) are excluded since they return nil for Unknown, which is often acceptable.

Features:
- Nested field access via variable tracking (`config := plan.Config; config.Metric.IsUnknown()`)
- Scope-aware guard detection (only suppresses within the enclosing `if` body, not globally)

### Findings fixed (8 total)

| File | Field | Direction |
|---|---|---|
| `alert.go` | `config` (Required) | Redundant |
| `alert.go` | `metric` (Required, nested) | Redundant |
| `allocation.go` | `unallocated_costs` (O+C, no Default) | Missing |
| `budget.go` | `metric` (O+C with Default) | Redundant |
| `sharing_resource.go` | `permissions` (Required) | Redundant |
| `user.go` | `phone` (Optional-only) | Redundant |
| `user.go` | `phone_extension` (Optional-only) | Redundant |
| `user.go` | `language` (Optional-only) | Redundant |

### Skills documentation

- **`overlay-pattern.md`**: Added Optional+Computed with Default to field classification table, pitfall #8, overlaycheck exception for all-default nested attrs
- **`implementation-conventions/SKILL.md`**: Added "Mapping Functions and Schema Defaults" section (nil-fallback, `defaultdrift` linter) and "Request Builders and IsUnknown()" section (classification table, pointer vs non-pointer guidance, `requestguard` linter)

## Validation

- All 22 linter test suites pass
- `requestguard` reports 0 issues after fixes
- Pre-commit hooks pass

> [!NOTE]
> This PR was authored with AI assistance (Gemini/Antigravity).