### PR TITLE
feat(report): add display_settings block with theme support

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -5323,6 +5323,50 @@
 									}
 								},
 								{
+									"name": "display_settings",
+									"single_nested": {
+										"computed_optional_required": "computed",
+										"attributes": [
+											{
+												"name": "axis_label_font_size",
+												"string": {
+													"computed_optional_required": "computed",
+													"description": "Font size used for axis labels on charts."
+												}
+											},
+											{
+												"name": "data_label_font_size",
+												"string": {
+													"computed_optional_required": "computed",
+													"description": "Font size used for data labels on charts."
+												}
+											},
+											{
+												"name": "decimal_precision",
+												"int64": {
+													"computed_optional_required": "computed",
+													"description": "Number of decimal places shown for numeric values."
+												}
+											},
+											{
+												"name": "number_scale",
+												"string": {
+													"computed_optional_required": "computed",
+													"description": "Scale applied to numeric values when rendering the report."
+												}
+											},
+											{
+												"name": "theme_id",
+												"string": {
+													"computed_optional_required": "computed",
+													"description": "Identifier of the theme applied to the report. The reserved\nsentinel `\"default\"` is returned on GET when no theme is stored\nand clears the stored value on PATCH. Omit the field on PATCH\nto leave the stored value unchanged."
+												}
+											}
+										],
+										"description": "Display settings for the report."
+									}
+								},
+								{
 									"name": "display_values",
 									"string": {
 										"computed_optional_required": "computed",

--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -2514,6 +2514,101 @@
 									}
 								},
 								{
+									"name": "display_settings",
+									"single_nested": {
+										"computed_optional_required": "computed_optional",
+										"attributes": [
+											{
+												"name": "axis_label_font_size",
+												"string": {
+													"computed_optional_required": "computed_optional",
+													"description": "Font size used for axis labels on charts.",
+													"validators": [
+														{
+															"custom": {
+																"imports": [
+																	{
+																		"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+																	}
+																],
+																"schema_definition": "stringvalidator.OneOf(\n\"auto\",\n\"small\",\n\"medium\",\n\"large\",\n)"
+															}
+														}
+													]
+												}
+											},
+											{
+												"name": "data_label_font_size",
+												"string": {
+													"computed_optional_required": "computed_optional",
+													"description": "Font size used for data labels on charts.",
+													"validators": [
+														{
+															"custom": {
+																"imports": [
+																	{
+																		"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+																	}
+																],
+																"schema_definition": "stringvalidator.OneOf(\n\"auto\",\n\"small\",\n\"medium\",\n\"large\",\n)"
+															}
+														}
+													]
+												}
+											},
+											{
+												"name": "decimal_precision",
+												"int64": {
+													"computed_optional_required": "computed_optional",
+													"description": "Number of decimal places shown for numeric values.",
+													"validators": [
+														{
+															"custom": {
+																"imports": [
+																	{
+																		"path": "github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+																	}
+																],
+																"schema_definition": "int64validator.Between(0, 8)"
+															}
+														}
+													]
+												}
+											},
+											{
+												"name": "number_scale",
+												"string": {
+													"computed_optional_required": "computed_optional",
+													"description": "Scale applied to numeric values when rendering the report.",
+													"validators": [
+														{
+															"custom": {
+																"imports": [
+																	{
+																		"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+																	}
+																],
+																"schema_definition": "stringvalidator.OneOf(\n\"auto\",\n\"thousands\",\n\"millions\",\n\"billions\",\n\"raw\",\n)"
+															}
+														}
+													]
+												}
+											},
+											{
+												"name": "theme_id",
+												"string": {
+													"computed_optional_required": "computed_optional",
+													"default": {
+														"static": "default"
+													},
+													"description": "Identifier of the theme applied to the report. The reserved\nsentinel `\"default\"` is returned on GET when no theme is stored\nand clears the stored value on PATCH. Omit the field on PATCH\nto leave the stored value unchanged."
+												}
+											}
+										],
+										"description": "Display settings for the report."
+									}
+								},
+								{
 									"name": "display_values",
 									"string": {
 										"computed_optional_required": "computed_optional",

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -7113,6 +7113,8 @@ components:
           description: The splits to use in the report.
           items:
             $ref: "#/components/schemas/ExternalSplit"
+        displaySettings:
+          $ref: "#/components/schemas/ExternalDisplaySettings"
         customTimeRange:
           description: Required when the time range is set to "custom".
           type: object
@@ -7190,6 +7192,48 @@ components:
         sortGroups: a_to_z
         sortDimensions: a_to_z
         dataSource: billing
+    ExternalDisplaySettings:
+      type: object
+      description: Display settings for the report.
+      properties:
+        themeId:
+          type: string
+          default: "default"
+          description: |-
+            Identifier of the theme applied to the report. The reserved
+            sentinel `"default"` is returned on GET when no theme is stored
+            and clears the stored value on PATCH. Omit the field on PATCH
+            to leave the stored value unchanged.
+        dataLabelFontSize:
+          type: string
+          description: Font size used for data labels on charts.
+          enum:
+            - auto
+            - small
+            - medium
+            - large
+        axisLabelFontSize:
+          type: string
+          description: Font size used for axis labels on charts.
+          enum:
+            - auto
+            - small
+            - medium
+            - large
+        numberScale:
+          type: string
+          description: Scale applied to numeric values when rendering the report.
+          enum:
+            - auto
+            - thousands
+            - millions
+            - billions
+            - raw
+        decimalPrecision:
+          type: integer
+          minimum: 0
+          maximum: 8
+          description: Number of decimal places shown for numeric values.
     ExternalConfigFilter:
       description: |-
         To include or exclude certain values.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -5015,6 +5015,8 @@ components:
           description: The splits to use in the report.
           items:
             $ref: "#/components/schemas/ExternalSplit"
+        displaySettings:
+          $ref: "#/components/schemas/ExternalDisplaySettings"
         customTimeRange:
           description: Required when the time range is set to "custom".
           allOf:
@@ -5181,6 +5183,48 @@ components:
         operator: gt
         values:
           - 50
+    ExternalDisplaySettings:
+      type: object
+      description: Display settings for the report.
+      properties:
+        themeId:
+          type: string
+          default: "default"
+          description: |-
+            Identifier of the theme applied to the report. The reserved
+            sentinel `"default"` is returned on GET when no theme is stored
+            and clears the stored value on PATCH. Omit the field on PATCH
+            to leave the stored value unchanged.
+        dataLabelFontSize:
+          type: string
+          description: Font size used for data labels on charts.
+          enum:
+            - auto
+            - small
+            - medium
+            - large
+        axisLabelFontSize:
+          type: string
+          description: Font size used for axis labels on charts.
+          enum:
+            - auto
+            - small
+            - medium
+            - large
+        numberScale:
+          type: string
+          description: Scale applied to numeric values when rendering the report.
+          enum:
+            - auto
+            - thousands
+            - millions
+            - billions
+            - raw
+        decimalPrecision:
+          type: integer
+          minimum: 0
+          maximum: 8
+          description: Number of decimal places shown for numeric values.
     ExternalMetric:
       description: Metric selector used in reports and filters.
       type: object

--- a/docs/data-sources/report.md
+++ b/docs/data-sources/report.md
@@ -80,6 +80,7 @@ Read-Only:
 - `custom_time_range` (Attributes) Required when the time range is set to "custom". (see [below for nested schema](#nestedatt--config--custom_time_range))
 - `data_source` (String) Data source of the report.
 - `dimensions` (Attributes List) See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions). (see [below for nested schema](#nestedatt--config--dimensions))
+- `display_settings` (Attributes) Display settings for the report. (see [below for nested schema](#nestedatt--config--display_settings))
 - `display_values` (String) See [View data as (Comparative report)](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#view-as).
 - `filters` (Attributes List) The filters to apply to the report. (see [below for nested schema](#nestedatt--config--filters))
 - `group` (Attributes List) The rows that appear in the tabular format of the report. See [Group by](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#group-by). (see [below for nested schema](#nestedatt--config--group))
@@ -126,6 +127,21 @@ Read-Only:
 
 - `id` (String) The identifier of the dimension.
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
+
+
+<a id="nestedatt--config--display_settings"></a>
+### Nested Schema for `config.display_settings`
+
+Read-Only:
+
+- `axis_label_font_size` (String) Font size used for axis labels on charts.
+- `data_label_font_size` (String) Font size used for data labels on charts.
+- `decimal_precision` (Number) Number of decimal places shown for numeric values.
+- `number_scale` (String) Scale applied to numeric values when rendering the report.
+- `theme_id` (String) Identifier of the theme applied to the report. The reserved
+sentinel `"default"` is returned on GET when no theme is stored
+and clears the stored value on PATCH. Omit the field on PATCH
+to leave the stored value unchanged.
 
 
 <a id="nestedatt--config--filters"></a>

--- a/docs/data-sources/report_query.md
+++ b/docs/data-sources/report_query.md
@@ -110,6 +110,7 @@ Possible values: `USD`, `ILS`, `EUR`, `AUD`, `CAD`, `GBP`, `DKK`, `NOK`, `SEK`, 
 - `data_source` (String) Data source of the report.
 Possible values: `billing`, `bqlens`, `billing-datahub`, `kubernetes-utilization`
 - `dimensions` (Attributes List) See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions). (see [below for nested schema](#nestedatt--config--dimensions))
+- `display_settings` (Attributes) Display settings for the report. (see [below for nested schema](#nestedatt--config--display_settings))
 - `display_values` (String) See [View data as (Comparative report)](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#view-as).
 Possible values: `actuals_only`, `absolute_change`, `percentage_change`, `absolute_and_percentage`
 - `filters` (Attributes List) The filters to apply to the report. (see [below for nested schema](#nestedatt--config--filters))
@@ -162,6 +163,24 @@ Optional:
 - `id` (String) The identifier of the dimension.
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `allocation`, `allocation_rule`, `gke`, `gke_label`
+
+
+<a id="nestedatt--config--display_settings"></a>
+### Nested Schema for `config.display_settings`
+
+Optional:
+
+- `axis_label_font_size` (String) Font size used for axis labels on charts.
+Possible values: `auto`, `small`, `medium`, `large`
+- `data_label_font_size` (String) Font size used for data labels on charts.
+Possible values: `auto`, `small`, `medium`, `large`
+- `decimal_precision` (Number) Number of decimal places shown for numeric values.
+- `number_scale` (String) Scale applied to numeric values when rendering the report.
+Possible values: `auto`, `thousands`, `millions`, `billions`, `raw`
+- `theme_id` (String) Identifier of the theme applied to the report. The reserved
+sentinel `"default"` is returned on GET when no theme is stored
+and clears the stored value on PATCH. Omit the field on PATCH
+to leave the stored value unchanged.
 
 
 <a id="nestedatt--config--filters"></a>

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -342,6 +342,7 @@ Possible values: `USD`, `ILS`, `EUR`, `AUD`, `CAD`, `GBP`, `DKK`, `NOK`, `SEK`, 
 - `data_source` (String) Data source of the report.
 Possible values: `billing`, `bqlens`, `billing-datahub`, `kubernetes-utilization`
 - `dimensions` (Attributes List) See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions). (see [below for nested schema](#nestedatt--config--dimensions))
+- `display_settings` (Attributes) Display settings for the report. (see [below for nested schema](#nestedatt--config--display_settings))
 - `display_values` (String) See [View data as (Comparative report)](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#view-as).
 Possible values: `actuals_only`, `absolute_change`, `percentage_change`, `absolute_and_percentage`
 - `filters` (Attributes List) The filters to apply to the report. (see [below for nested schema](#nestedatt--config--filters))
@@ -394,6 +395,24 @@ Optional:
 - `id` (String) The identifier of the dimension.
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `allocation`, `allocation_rule`, `gke`, `gke_label`
+
+
+<a id="nestedatt--config--display_settings"></a>
+### Nested Schema for `config.display_settings`
+
+Optional:
+
+- `axis_label_font_size` (String) Font size used for axis labels on charts.
+Possible values: `auto`, `small`, `medium`, `large`
+- `data_label_font_size` (String) Font size used for data labels on charts.
+Possible values: `auto`, `small`, `medium`, `large`
+- `decimal_precision` (Number) Number of decimal places shown for numeric values.
+- `number_scale` (String) Scale applied to numeric values when rendering the report.
+Possible values: `auto`, `thousands`, `millions`, `billions`, `raw`
+- `theme_id` (String) Identifier of the theme applied to the report. The reserved
+sentinel `"default"` is returned on GET when no theme is stored
+and clears the stored value on PATCH. Omit the field on PATCH
+to leave the stored value unchanged.
 
 
 <a id="nestedatt--config--filters"></a>

--- a/internal/provider/datasource_report/report_data_source_gen.go
+++ b/internal/provider/datasource_report/report_data_source_gen.go
@@ -105,6 +105,43 @@ func ReportDataSourceSchema(ctx context.Context) schema.Schema {
 						Description:         "See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions).",
 						MarkdownDescription: "See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions).",
 					},
+					"display_settings": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"axis_label_font_size": schema.StringAttribute{
+								Computed:            true,
+								Description:         "Font size used for axis labels on charts.",
+								MarkdownDescription: "Font size used for axis labels on charts.",
+							},
+							"data_label_font_size": schema.StringAttribute{
+								Computed:            true,
+								Description:         "Font size used for data labels on charts.",
+								MarkdownDescription: "Font size used for data labels on charts.",
+							},
+							"decimal_precision": schema.Int64Attribute{
+								Computed:            true,
+								Description:         "Number of decimal places shown for numeric values.",
+								MarkdownDescription: "Number of decimal places shown for numeric values.",
+							},
+							"number_scale": schema.StringAttribute{
+								Computed:            true,
+								Description:         "Scale applied to numeric values when rendering the report.",
+								MarkdownDescription: "Scale applied to numeric values when rendering the report.",
+							},
+							"theme_id": schema.StringAttribute{
+								Computed:            true,
+								Description:         "Identifier of the theme applied to the report. The reserved\nsentinel `\"default\"` is returned on GET when no theme is stored\nand clears the stored value on PATCH. Omit the field on PATCH\nto leave the stored value unchanged.",
+								MarkdownDescription: "Identifier of the theme applied to the report. The reserved\nsentinel `\"default\"` is returned on GET when no theme is stored\nand clears the stored value on PATCH. Omit the field on PATCH\nto leave the stored value unchanged.",
+							},
+						},
+						CustomType: DisplaySettingsType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+							},
+						},
+						Computed:            true,
+						Description:         "Display settings for the report.",
+						MarkdownDescription: "Display settings for the report.",
+					},
 					"display_values": schema.StringAttribute{
 						Computed:            true,
 						Description:         "See [View data as (Comparative report)](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#view-as).",
@@ -701,6 +738,24 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 			fmt.Sprintf(`dimensions expected to be basetypes.ListValue, was: %T`, dimensionsAttribute))
 	}
 
+	displaySettingsAttribute, ok := attributes["display_settings"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`display_settings is missing from object`)
+
+		return nil, diags
+	}
+
+	displaySettingsVal, ok := displaySettingsAttribute.(DisplaySettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsAttribute))
+	}
+
 	displayValuesAttribute, ok := attributes["display_values"]
 
 	if !ok {
@@ -982,6 +1037,7 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		CustomTimeRange:           customTimeRangeVal,
 		DataSource:                dataSourceVal,
 		Dimensions:                dimensionsVal,
+		DisplaySettings:           displaySettingsVal,
 		DisplayValues:             displayValuesVal,
 		Filters:                   filtersVal,
 		Group:                     groupVal,
@@ -1172,6 +1228,24 @@ func NewConfigValue(attributeTypes map[string]attr.Type, attributes map[string]a
 			fmt.Sprintf(`dimensions expected to be basetypes.ListValue, was: %T`, dimensionsAttribute))
 	}
 
+	displaySettingsAttribute, ok := attributes["display_settings"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`display_settings is missing from object`)
+
+		return NewConfigValueUnknown(), diags
+	}
+
+	displaySettingsVal, ok := displaySettingsAttribute.(DisplaySettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsAttribute))
+	}
+
 	displayValuesAttribute, ok := attributes["display_values"]
 
 	if !ok {
@@ -1453,6 +1527,7 @@ func NewConfigValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		CustomTimeRange:           customTimeRangeVal,
 		DataSource:                dataSourceVal,
 		Dimensions:                dimensionsVal,
+		DisplaySettings:           displaySettingsVal,
 		DisplayValues:             displayValuesVal,
 		Filters:                   filtersVal,
 		Group:                     groupVal,
@@ -1546,6 +1621,7 @@ type ConfigValue struct {
 	CustomTimeRange           CustomTimeRangeValue    `tfsdk:"custom_time_range"`
 	DataSource                basetypes.StringValue   `tfsdk:"data_source"`
 	Dimensions                basetypes.ListValue     `tfsdk:"dimensions"`
+	DisplaySettings           DisplaySettingsValue    `tfsdk:"display_settings"`
 	DisplayValues             basetypes.StringValue   `tfsdk:"display_values"`
 	Filters                   basetypes.ListValue     `tfsdk:"filters"`
 	Group                     basetypes.ListValue     `tfsdk:"group"`
@@ -1565,7 +1641,7 @@ type ConfigValue struct {
 }
 
 func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 21)
+	attrTypes := make(map[string]tftypes.Type, 22)
 
 	var val tftypes.Value
 	var err error
@@ -1585,6 +1661,11 @@ func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 	attrTypes["data_source"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["dimensions"] = basetypes.ListType{
 		ElemType: DimensionsValue{}.Type(ctx),
+	}.TerraformType(ctx)
+	attrTypes["display_settings"] = DisplaySettingsType{
+		basetypes.ObjectType{
+			AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+		},
 	}.TerraformType(ctx)
 	attrTypes["display_values"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["filters"] = basetypes.ListType{
@@ -1630,7 +1711,7 @@ func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 21)
+		vals := make(map[string]tftypes.Value, 22)
 
 		val, err = v.AdvancedAnalysis.ToTerraformValue(ctx)
 
@@ -1679,6 +1760,14 @@ func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 		}
 
 		vals["dimensions"] = val
+
+		val, err = v.DisplaySettings.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["display_settings"] = val
 
 		val, err = v.DisplayValues.ToTerraformValue(ctx)
 
@@ -1847,6 +1936,12 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		dimensions = v.Dimensions
 	}
 
+	var displaySettings attr.Value
+
+	{
+		displaySettings = v.DisplaySettings
+	}
+
 	var filters attr.Value
 
 	{
@@ -1912,6 +2007,11 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		"dimensions": basetypes.ListType{
 			ElemType: DimensionsValue{}.Type(ctx),
 		},
+		"display_settings": DisplaySettingsType{
+			basetypes.ObjectType{
+				AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+			},
+		},
 		"display_values": basetypes.StringType{},
 		"filters": basetypes.ListType{
 			ElemType: FiltersValue{}.Type(ctx),
@@ -1970,6 +2070,7 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 			"custom_time_range":           customTimeRange,
 			"data_source":                 v.DataSource,
 			"dimensions":                  dimensions,
+			"display_settings":            displaySettings,
 			"display_values":              v.DisplayValues,
 			"filters":                     filters,
 			"group":                       group,
@@ -2026,6 +2127,10 @@ func (v ConfigValue) Equal(o attr.Value) bool {
 	}
 
 	if !v.Dimensions.Equal(other.Dimensions) {
+		return false
+	}
+
+	if !v.DisplaySettings.Equal(other.DisplaySettings) {
 		return false
 	}
 
@@ -2117,6 +2222,11 @@ func (v ConfigValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"data_source": basetypes.StringType{},
 		"dimensions": basetypes.ListType{
 			ElemType: DimensionsValue{}.Type(ctx),
+		},
+		"display_settings": DisplaySettingsType{
+			basetypes.ObjectType{
+				AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+			},
 		},
 		"display_values": basetypes.StringType{},
 		"filters": basetypes.ListType{
@@ -3404,6 +3514,550 @@ func (v DimensionsValue) AttributeTypes(ctx context.Context) map[string]attr.Typ
 	return map[string]attr.Type{
 		"id":   basetypes.StringType{},
 		"type": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = DisplaySettingsType{}
+
+type DisplaySettingsType struct {
+	basetypes.ObjectType
+}
+
+func (t DisplaySettingsType) Equal(o attr.Type) bool {
+	other, ok := o.(DisplaySettingsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DisplaySettingsType) String() string {
+	return "DisplaySettingsType"
+}
+
+func (t DisplaySettingsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	axisLabelFontSizeAttribute, ok := attributes["axis_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`axis_label_font_size is missing from object`)
+
+		return nil, diags
+	}
+
+	axisLabelFontSizeVal, ok := axisLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`axis_label_font_size expected to be basetypes.StringValue, was: %T`, axisLabelFontSizeAttribute))
+	}
+
+	dataLabelFontSizeAttribute, ok := attributes["data_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`data_label_font_size is missing from object`)
+
+		return nil, diags
+	}
+
+	dataLabelFontSizeVal, ok := dataLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`data_label_font_size expected to be basetypes.StringValue, was: %T`, dataLabelFontSizeAttribute))
+	}
+
+	decimalPrecisionAttribute, ok := attributes["decimal_precision"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`decimal_precision is missing from object`)
+
+		return nil, diags
+	}
+
+	decimalPrecisionVal, ok := decimalPrecisionAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`decimal_precision expected to be basetypes.Int64Value, was: %T`, decimalPrecisionAttribute))
+	}
+
+	numberScaleAttribute, ok := attributes["number_scale"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`number_scale is missing from object`)
+
+		return nil, diags
+	}
+
+	numberScaleVal, ok := numberScaleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`number_scale expected to be basetypes.StringValue, was: %T`, numberScaleAttribute))
+	}
+
+	themeIdAttribute, ok := attributes["theme_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`theme_id is missing from object`)
+
+		return nil, diags
+	}
+
+	themeIdVal, ok := themeIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`theme_id expected to be basetypes.StringValue, was: %T`, themeIdAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DisplaySettingsValue{
+		AxisLabelFontSize: axisLabelFontSizeVal,
+		DataLabelFontSize: dataLabelFontSizeVal,
+		DecimalPrecision:  decimalPrecisionVal,
+		NumberScale:       numberScaleVal,
+		ThemeId:           themeIdVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDisplaySettingsValueNull() DisplaySettingsValue {
+	return DisplaySettingsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDisplaySettingsValueUnknown() DisplaySettingsValue {
+	return DisplaySettingsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDisplaySettingsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DisplaySettingsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DisplaySettingsValue Attribute Value",
+				"While creating a DisplaySettingsValue value, a missing attribute value was detected. "+
+					"A DisplaySettingsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DisplaySettingsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DisplaySettingsValue Attribute Type",
+				"While creating a DisplaySettingsValue value, an invalid attribute value was detected. "+
+					"A DisplaySettingsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DisplaySettingsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DisplaySettingsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DisplaySettingsValue Attribute Value",
+				"While creating a DisplaySettingsValue value, an extra attribute value was detected. "+
+					"A DisplaySettingsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DisplaySettingsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	axisLabelFontSizeAttribute, ok := attributes["axis_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`axis_label_font_size is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	axisLabelFontSizeVal, ok := axisLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`axis_label_font_size expected to be basetypes.StringValue, was: %T`, axisLabelFontSizeAttribute))
+	}
+
+	dataLabelFontSizeAttribute, ok := attributes["data_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`data_label_font_size is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	dataLabelFontSizeVal, ok := dataLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`data_label_font_size expected to be basetypes.StringValue, was: %T`, dataLabelFontSizeAttribute))
+	}
+
+	decimalPrecisionAttribute, ok := attributes["decimal_precision"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`decimal_precision is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	decimalPrecisionVal, ok := decimalPrecisionAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`decimal_precision expected to be basetypes.Int64Value, was: %T`, decimalPrecisionAttribute))
+	}
+
+	numberScaleAttribute, ok := attributes["number_scale"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`number_scale is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	numberScaleVal, ok := numberScaleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`number_scale expected to be basetypes.StringValue, was: %T`, numberScaleAttribute))
+	}
+
+	themeIdAttribute, ok := attributes["theme_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`theme_id is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	themeIdVal, ok := themeIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`theme_id expected to be basetypes.StringValue, was: %T`, themeIdAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	return DisplaySettingsValue{
+		AxisLabelFontSize: axisLabelFontSizeVal,
+		DataLabelFontSize: dataLabelFontSizeVal,
+		DecimalPrecision:  decimalPrecisionVal,
+		NumberScale:       numberScaleVal,
+		ThemeId:           themeIdVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDisplaySettingsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DisplaySettingsValue {
+	object, diags := NewDisplaySettingsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDisplaySettingsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DisplaySettingsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDisplaySettingsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDisplaySettingsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDisplaySettingsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDisplaySettingsValueMust(DisplaySettingsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DisplaySettingsType) ValueType(ctx context.Context) attr.Value {
+	return DisplaySettingsValue{}
+}
+
+var _ basetypes.ObjectValuable = DisplaySettingsValue{}
+
+type DisplaySettingsValue struct {
+	AxisLabelFontSize basetypes.StringValue `tfsdk:"axis_label_font_size"`
+	DataLabelFontSize basetypes.StringValue `tfsdk:"data_label_font_size"`
+	DecimalPrecision  basetypes.Int64Value  `tfsdk:"decimal_precision"`
+	NumberScale       basetypes.StringValue `tfsdk:"number_scale"`
+	ThemeId           basetypes.StringValue `tfsdk:"theme_id"`
+	state             attr.ValueState
+}
+
+func (v DisplaySettingsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 5)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["axis_label_font_size"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["data_label_font_size"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["decimal_precision"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["number_scale"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["theme_id"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 5)
+
+		val, err = v.AxisLabelFontSize.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["axis_label_font_size"] = val
+
+		val, err = v.DataLabelFontSize.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["data_label_font_size"] = val
+
+		val, err = v.DecimalPrecision.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["decimal_precision"] = val
+
+		val, err = v.NumberScale.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["number_scale"] = val
+
+		val, err = v.ThemeId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["theme_id"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DisplaySettingsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DisplaySettingsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DisplaySettingsValue) String() string {
+	return "DisplaySettingsValue"
+}
+
+func (v DisplaySettingsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"axis_label_font_size": basetypes.StringType{},
+		"data_label_font_size": basetypes.StringType{},
+		"decimal_precision":    basetypes.Int64Type{},
+		"number_scale":         basetypes.StringType{},
+		"theme_id":             basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"axis_label_font_size": v.AxisLabelFontSize,
+			"data_label_font_size": v.DataLabelFontSize,
+			"decimal_precision":    v.DecimalPrecision,
+			"number_scale":         v.NumberScale,
+			"theme_id":             v.ThemeId,
+		})
+
+	return objVal, diags
+}
+
+func (v DisplaySettingsValue) Equal(o attr.Value) bool {
+	other, ok := o.(DisplaySettingsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AxisLabelFontSize.Equal(other.AxisLabelFontSize) {
+		return false
+	}
+
+	if !v.DataLabelFontSize.Equal(other.DataLabelFontSize) {
+		return false
+	}
+
+	if !v.DecimalPrecision.Equal(other.DecimalPrecision) {
+		return false
+	}
+
+	if !v.NumberScale.Equal(other.NumberScale) {
+		return false
+	}
+
+	if !v.ThemeId.Equal(other.ThemeId) {
+		return false
+	}
+
+	return true
+}
+
+func (v DisplaySettingsValue) Type(ctx context.Context) attr.Type {
+	return DisplaySettingsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DisplaySettingsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"axis_label_font_size": basetypes.StringType{},
+		"data_label_font_size": basetypes.StringType{},
+		"decimal_precision":    basetypes.Int64Type{},
+		"number_scale":         basetypes.StringType{},
+		"theme_id":             basetypes.StringType{},
 	}
 }
 

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -893,6 +893,81 @@ func (e ExternalConfigMetricFilterOperator) Valid() bool {
 	}
 }
 
+// Defines values for ExternalDisplaySettingsAxisLabelFontSize.
+const (
+	ExternalDisplaySettingsAxisLabelFontSizeAuto   ExternalDisplaySettingsAxisLabelFontSize = "auto"
+	ExternalDisplaySettingsAxisLabelFontSizeLarge  ExternalDisplaySettingsAxisLabelFontSize = "large"
+	ExternalDisplaySettingsAxisLabelFontSizeMedium ExternalDisplaySettingsAxisLabelFontSize = "medium"
+	ExternalDisplaySettingsAxisLabelFontSizeSmall  ExternalDisplaySettingsAxisLabelFontSize = "small"
+)
+
+// Valid indicates whether the value is a known member of the ExternalDisplaySettingsAxisLabelFontSize enum.
+func (e ExternalDisplaySettingsAxisLabelFontSize) Valid() bool {
+	switch e {
+	case ExternalDisplaySettingsAxisLabelFontSizeAuto:
+		return true
+	case ExternalDisplaySettingsAxisLabelFontSizeLarge:
+		return true
+	case ExternalDisplaySettingsAxisLabelFontSizeMedium:
+		return true
+	case ExternalDisplaySettingsAxisLabelFontSizeSmall:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ExternalDisplaySettingsDataLabelFontSize.
+const (
+	ExternalDisplaySettingsDataLabelFontSizeAuto   ExternalDisplaySettingsDataLabelFontSize = "auto"
+	ExternalDisplaySettingsDataLabelFontSizeLarge  ExternalDisplaySettingsDataLabelFontSize = "large"
+	ExternalDisplaySettingsDataLabelFontSizeMedium ExternalDisplaySettingsDataLabelFontSize = "medium"
+	ExternalDisplaySettingsDataLabelFontSizeSmall  ExternalDisplaySettingsDataLabelFontSize = "small"
+)
+
+// Valid indicates whether the value is a known member of the ExternalDisplaySettingsDataLabelFontSize enum.
+func (e ExternalDisplaySettingsDataLabelFontSize) Valid() bool {
+	switch e {
+	case ExternalDisplaySettingsDataLabelFontSizeAuto:
+		return true
+	case ExternalDisplaySettingsDataLabelFontSizeLarge:
+		return true
+	case ExternalDisplaySettingsDataLabelFontSizeMedium:
+		return true
+	case ExternalDisplaySettingsDataLabelFontSizeSmall:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ExternalDisplaySettingsNumberScale.
+const (
+	Auto      ExternalDisplaySettingsNumberScale = "auto"
+	Billions  ExternalDisplaySettingsNumberScale = "billions"
+	Millions  ExternalDisplaySettingsNumberScale = "millions"
+	Raw       ExternalDisplaySettingsNumberScale = "raw"
+	Thousands ExternalDisplaySettingsNumberScale = "thousands"
+)
+
+// Valid indicates whether the value is a known member of the ExternalDisplaySettingsNumberScale enum.
+func (e ExternalDisplaySettingsNumberScale) Valid() bool {
+	switch e {
+	case Auto:
+		return true
+	case Billions:
+		return true
+	case Millions:
+		return true
+	case Raw:
+		return true
+	case Thousands:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ExternalMetricType.
 const (
 	ExternalMetricTypeBasic    ExternalMetricType = "basic"
@@ -3737,6 +3812,9 @@ type ExternalConfig struct {
 	// Dimensions See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions).
 	Dimensions *[]Dimension `json:"dimensions,omitempty"`
 
+	// DisplaySettings Display settings for the report.
+	DisplaySettings *ExternalDisplaySettings `json:"displaySettings,omitempty"`
+
 	// DisplayValues See [View data as (Comparative report)](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#view-as).
 	DisplayValues *ExternalConfigDisplayValues `json:"displayValues,omitempty"`
 
@@ -3855,6 +3933,36 @@ type ExternalConfigMetricFilter struct {
 
 // ExternalConfigMetricFilterOperator Comparison operator for filtering metric values.
 type ExternalConfigMetricFilterOperator string
+
+// ExternalDisplaySettings Display settings for the report.
+type ExternalDisplaySettings struct {
+	// AxisLabelFontSize Font size used for axis labels on charts.
+	AxisLabelFontSize *ExternalDisplaySettingsAxisLabelFontSize `json:"axisLabelFontSize,omitempty"`
+
+	// DataLabelFontSize Font size used for data labels on charts.
+	DataLabelFontSize *ExternalDisplaySettingsDataLabelFontSize `json:"dataLabelFontSize,omitempty"`
+
+	// DecimalPrecision Number of decimal places shown for numeric values.
+	DecimalPrecision *int `json:"decimalPrecision,omitempty"`
+
+	// NumberScale Scale applied to numeric values when rendering the report.
+	NumberScale *ExternalDisplaySettingsNumberScale `json:"numberScale,omitempty"`
+
+	// ThemeId Identifier of the theme applied to the report. The reserved
+	// sentinel `"default"` is returned on GET when no theme is stored
+	// and clears the stored value on PATCH. Omit the field on PATCH
+	// to leave the stored value unchanged.
+	ThemeId *string `json:"themeId,omitempty"`
+}
+
+// ExternalDisplaySettingsAxisLabelFontSize Font size used for axis labels on charts.
+type ExternalDisplaySettingsAxisLabelFontSize string
+
+// ExternalDisplaySettingsDataLabelFontSize Font size used for data labels on charts.
+type ExternalDisplaySettingsDataLabelFontSize string
+
+// ExternalDisplaySettingsNumberScale Scale applied to numeric values when rendering the report.
+type ExternalDisplaySettingsNumberScale string
 
 // ExternalMetric Metric selector used in reports and filters.
 type ExternalMetric struct {

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -109,6 +109,13 @@ func overlayConfigFields(ctx context.Context, resolved *resource_report.ConfigVa
 		plan.TimeInterval = resolved.TimeInterval
 	}
 
+	// ── Nested object: DisplaySettings ──
+	if plan.DisplaySettings.IsUnknown() {
+		plan.DisplaySettings = resolved.DisplaySettings
+	} else if !plan.DisplaySettings.IsNull() {
+		overlayDisplaySettings(&resolved.DisplaySettings, &plan.DisplaySettings)
+	}
+
 	// ── Nested objects: resolve entire object when Unknown, or walk subfields ──
 	if plan.AdvancedAnalysis.IsUnknown() {
 		plan.AdvancedAnalysis = resolved.AdvancedAnalysis
@@ -198,6 +205,23 @@ func overlayAdvancedAnalysis(resolved, plan *resource_report.AdvancedAnalysisVal
 	if plan.TrendingUp.IsUnknown() {
 		plan.TrendingUp = resolved.TrendingUp
 	}
+}
+
+func overlayDisplaySettings(resolved, plan *resource_report.DisplaySettingsValue) {
+	if plan.AxisLabelFontSize.IsUnknown() {
+		plan.AxisLabelFontSize = resolved.AxisLabelFontSize
+	}
+	if plan.DataLabelFontSize.IsUnknown() {
+		plan.DataLabelFontSize = resolved.DataLabelFontSize
+	}
+	if plan.DecimalPrecision.IsUnknown() {
+		plan.DecimalPrecision = resolved.DecimalPrecision
+	}
+	if plan.NumberScale.IsUnknown() {
+		plan.NumberScale = resolved.NumberScale
+	}
+
+	// theme_id: Optional+Computed with Default "default" — never Unknown at plan time.
 }
 
 func overlayCustomTimeRange(resolved, plan *resource_report.CustomTimeRangeValue) {
@@ -880,6 +904,31 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 		externalConfig.SecondaryTimeRange = secondaryTimeRange
 	}
 
+	if !config.DisplaySettings.IsNull() && !config.DisplaySettings.IsUnknown() {
+		ds := &models.ExternalDisplaySettings{}
+		if !config.DisplaySettings.AxisLabelFontSize.IsNull() && !config.DisplaySettings.AxisLabelFontSize.IsUnknown() {
+			v := models.ExternalDisplaySettingsAxisLabelFontSize(config.DisplaySettings.AxisLabelFontSize.ValueString())
+			ds.AxisLabelFontSize = &v
+		}
+		if !config.DisplaySettings.DataLabelFontSize.IsNull() && !config.DisplaySettings.DataLabelFontSize.IsUnknown() {
+			v := models.ExternalDisplaySettingsDataLabelFontSize(config.DisplaySettings.DataLabelFontSize.ValueString())
+			ds.DataLabelFontSize = &v
+		}
+		if !config.DisplaySettings.DecimalPrecision.IsNull() && !config.DisplaySettings.DecimalPrecision.IsUnknown() {
+			v := int(config.DisplaySettings.DecimalPrecision.ValueInt64())
+			ds.DecimalPrecision = &v
+		}
+		if !config.DisplaySettings.NumberScale.IsNull() && !config.DisplaySettings.NumberScale.IsUnknown() {
+			v := models.ExternalDisplaySettingsNumberScale(config.DisplaySettings.NumberScale.ValueString())
+			ds.NumberScale = &v
+		}
+		if !config.DisplaySettings.ThemeId.IsNull() && !config.DisplaySettings.ThemeId.IsUnknown() {
+			v := config.DisplaySettings.ThemeId.ValueString()
+			ds.ThemeId = &v
+		}
+		externalConfig.DisplaySettings = ds
+	}
+
 	return externalConfig, diags
 }
 
@@ -1468,6 +1517,37 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 		configMap["secondary_time_range"] = strVal
 	} else {
 		configMap["secondary_time_range"] = resource_report.NewSecondaryTimeRangeValueNull()
+	}
+
+	// Nested Object: DisplaySettings
+	if config.DisplaySettings != nil {
+		dsMap := map[string]attr.Value{
+			"axis_label_font_size": types.StringNull(),
+			"data_label_font_size": types.StringNull(),
+			"decimal_precision":    types.Int64Null(),
+			"number_scale":         types.StringNull(),
+			"theme_id":             types.StringNull(),
+		}
+		if config.DisplaySettings.AxisLabelFontSize != nil {
+			dsMap["axis_label_font_size"] = types.StringValue(string(*config.DisplaySettings.AxisLabelFontSize))
+		}
+		if config.DisplaySettings.DataLabelFontSize != nil {
+			dsMap["data_label_font_size"] = types.StringValue(string(*config.DisplaySettings.DataLabelFontSize))
+		}
+		if config.DisplaySettings.DecimalPrecision != nil {
+			dsMap["decimal_precision"] = types.Int64Value(int64(*config.DisplaySettings.DecimalPrecision))
+		}
+		if config.DisplaySettings.NumberScale != nil {
+			dsMap["number_scale"] = types.StringValue(string(*config.DisplaySettings.NumberScale))
+		}
+		if config.DisplaySettings.ThemeId != nil {
+			dsMap["theme_id"] = types.StringValue(*config.DisplaySettings.ThemeId)
+		}
+		dsVal, dsDiags := resource_report.NewDisplaySettingsValue(resource_report.DisplaySettingsValue{}.AttributeTypes(ctx), dsMap)
+		diags.Append(dsDiags...)
+		configMap["display_settings"] = dsVal
+	} else {
+		configMap["display_settings"] = resource_report.NewDisplaySettingsValueNull()
 	}
 
 	state.Config, d = resource_report.NewConfigValue(resource_report.ConfigValue{}.AttributeTypes(ctx), configMap)

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -1526,7 +1526,9 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 			"data_label_font_size": types.StringNull(),
 			"decimal_precision":    types.Int64Null(),
 			"number_scale":         types.StringNull(),
-			"theme_id":             types.StringNull(),
+			// Defend against API returning nil: fall back to "default" to match
+			// the schema default and prevent perpetual plan drift.
+			"theme_id": types.StringValue("default"),
 		}
 		if config.DisplaySettings.AxisLabelFontSize != nil {
 			dsMap["axis_label_font_size"] = types.StringValue(string(*config.DisplaySettings.AxisLabelFontSize))

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -922,7 +922,7 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 			v := models.ExternalDisplaySettingsNumberScale(config.DisplaySettings.NumberScale.ValueString())
 			ds.NumberScale = &v
 		}
-		if !config.DisplaySettings.ThemeId.IsNull() && !config.DisplaySettings.ThemeId.IsUnknown() {
+		if !config.DisplaySettings.ThemeId.IsNull() {
 			v := config.DisplaySettings.ThemeId.ValueString()
 			ds.ThemeId = &v
 		}

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -527,6 +527,37 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 		configMap["secondary_time_range"] = datasource_report.NewSecondaryTimeRangeValueNull()
 	}
 
+	// Nested Object: DisplaySettings
+	if config.DisplaySettings != nil {
+		dsMap := map[string]attr.Value{
+			"axis_label_font_size": types.StringNull(),
+			"data_label_font_size": types.StringNull(),
+			"decimal_precision":    types.Int64Null(),
+			"number_scale":         types.StringNull(),
+			"theme_id":             types.StringNull(),
+		}
+		if config.DisplaySettings.AxisLabelFontSize != nil {
+			dsMap["axis_label_font_size"] = types.StringValue(string(*config.DisplaySettings.AxisLabelFontSize))
+		}
+		if config.DisplaySettings.DataLabelFontSize != nil {
+			dsMap["data_label_font_size"] = types.StringValue(string(*config.DisplaySettings.DataLabelFontSize))
+		}
+		if config.DisplaySettings.DecimalPrecision != nil {
+			dsMap["decimal_precision"] = types.Int64Value(int64(*config.DisplaySettings.DecimalPrecision))
+		}
+		if config.DisplaySettings.NumberScale != nil {
+			dsMap["number_scale"] = types.StringValue(string(*config.DisplaySettings.NumberScale))
+		}
+		if config.DisplaySettings.ThemeId != nil {
+			dsMap["theme_id"] = types.StringValue(*config.DisplaySettings.ThemeId)
+		}
+		dsVal, dsDiags := datasource_report.NewDisplaySettingsValue(datasource_report.DisplaySettingsValue{}.AttributeTypes(ctx), dsMap)
+		diags.Append(dsDiags...)
+		configMap["display_settings"] = dsVal
+	} else {
+		configMap["display_settings"] = datasource_report.NewDisplaySettingsValueNull()
+	}
+
 	var configDiags diag.Diagnostics
 	state.Config, configDiags = datasource_report.NewConfigValue(datasource_report.ConfigValue{}.AttributeTypes(ctx), configMap)
 	diags.Append(configDiags...)

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -2735,12 +2735,20 @@ func TestAccReport_DisplaySettings(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"doit_report.ds_test",
-						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("number_scale"),
-						knownvalue.StringExact("millions")),
+						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("axis_label_font_size"),
+						knownvalue.StringExact("large")),
+					statecheck.ExpectKnownValue(
+						"doit_report.ds_test",
+						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("data_label_font_size"),
+						knownvalue.StringExact("small")),
 					statecheck.ExpectKnownValue(
 						"doit_report.ds_test",
 						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("decimal_precision"),
 						knownvalue.Int64Exact(2)),
+					statecheck.ExpectKnownValue(
+						"doit_report.ds_test",
+						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("number_scale"),
+						knownvalue.StringExact("millions")),
 					statecheck.ExpectKnownValue(
 						"doit_report.ds_test",
 						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("theme_id"),
@@ -2777,8 +2785,10 @@ resource "doit_report" "ds_test" {
         currency       = "USD"
         layout         = "table"
         display_settings = {
-            number_scale      = "millions"
-            decimal_precision = 2
+            axis_label_font_size = "large"
+            data_label_font_size = "small"
+            decimal_precision    = 2
+            number_scale         = "millions"
         }
     }
 }

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -2709,3 +2709,152 @@ resource "doit_report" "folder_test" {
 }
 `, i)
 }
+
+// TestAccReport_DisplaySettings verifies that the display_settings block
+// (including theme_id) round-trips without drift on create and update.
+func TestAccReport_DisplaySettings(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with display_settings (default theme)
+			{
+				Config: testAccReportWithDisplaySettings(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_report.ds_test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_report.ds_test",
+						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("number_scale"),
+						knownvalue.StringExact("millions")),
+					statecheck.ExpectKnownValue(
+						"doit_report.ds_test",
+						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("decimal_precision"),
+						knownvalue.Int64Exact(2)),
+					statecheck.ExpectKnownValue(
+						"doit_report.ds_test",
+						tfjsonpath.New("config").AtMapKey("display_settings").AtMapKey("theme_id"),
+						knownvalue.StringExact("default")),
+				},
+			},
+			// Step 2: Drift check
+			{
+				Config: testAccReportWithDisplaySettings(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportWithDisplaySettings(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "ds_test" {
+    name        = "test-display-settings-%d"
+    description = "Report testing display_settings block"
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        display_settings = {
+            number_scale      = "millions"
+            decimal_precision = 2
+        }
+    }
+}
+`, i)
+}
+
+// TestAccReport_DisplaySettingsWithTheme verifies that a custom theme can be
+// applied to a report via display_settings.theme_id and that the value
+// round-trips without drift. Uses a custom_theme resource as the source.
+func TestAccReport_DisplaySettingsWithTheme(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportWithTheme(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"doit_report.themed",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"doit_report.themed", "config.display_settings.theme_id",
+						"doit_custom_theme.report_theme", "id"),
+				),
+			},
+			// Drift check
+			{
+				Config: testAccReportWithTheme(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportWithTheme(i int) string {
+	return fmt.Sprintf(`
+resource "doit_custom_theme" "report_theme" {
+  name          = "tf-acc-report-theme-%d"
+  primary_color = "#FF5733"
+  colors = {
+    light = ["#FF5733", "#33FF57", "#3357FF"]
+    dark  = ["#C70039", "#900C3F", "#581845"]
+  }
+}
+
+resource "doit_report" "themed" {
+    name        = "test-report-themed-%d"
+    description = "Report with a custom theme applied"
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        display_settings = {
+            theme_id = doit_custom_theme.report_theme.id
+        }
+    }
+}
+`, i, i)
+}

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -185,6 +185,78 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 						Description:         "See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions).",
 						MarkdownDescription: "See [Dimensions](https://help.doit.com/docs/cloud-analytics/reports/editing-your-cloud-report#dimensions).",
 					},
+					"display_settings": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"axis_label_font_size": schema.StringAttribute{
+								Optional:            true,
+								Computed:            true,
+								Description:         "Font size used for axis labels on charts.\nPossible values: `auto`, `small`, `medium`, `large`",
+								MarkdownDescription: "Font size used for axis labels on charts.\nPossible values: `auto`, `small`, `medium`, `large`",
+								Validators: []validator.String{
+									stringvalidator.OneOf(
+										"auto",
+										"small",
+										"medium",
+										"large",
+									),
+								},
+							},
+							"data_label_font_size": schema.StringAttribute{
+								Optional:            true,
+								Computed:            true,
+								Description:         "Font size used for data labels on charts.\nPossible values: `auto`, `small`, `medium`, `large`",
+								MarkdownDescription: "Font size used for data labels on charts.\nPossible values: `auto`, `small`, `medium`, `large`",
+								Validators: []validator.String{
+									stringvalidator.OneOf(
+										"auto",
+										"small",
+										"medium",
+										"large",
+									),
+								},
+							},
+							"decimal_precision": schema.Int64Attribute{
+								Optional:            true,
+								Computed:            true,
+								Description:         "Number of decimal places shown for numeric values.",
+								MarkdownDescription: "Number of decimal places shown for numeric values.",
+								Validators: []validator.Int64{
+									int64validator.Between(0, 8),
+								},
+							},
+							"number_scale": schema.StringAttribute{
+								Optional:            true,
+								Computed:            true,
+								Description:         "Scale applied to numeric values when rendering the report.\nPossible values: `auto`, `thousands`, `millions`, `billions`, `raw`",
+								MarkdownDescription: "Scale applied to numeric values when rendering the report.\nPossible values: `auto`, `thousands`, `millions`, `billions`, `raw`",
+								Validators: []validator.String{
+									stringvalidator.OneOf(
+										"auto",
+										"thousands",
+										"millions",
+										"billions",
+										"raw",
+									),
+								},
+							},
+							"theme_id": schema.StringAttribute{
+								Optional:            true,
+								Computed:            true,
+								Description:         "Identifier of the theme applied to the report. The reserved\nsentinel `\"default\"` is returned on GET when no theme is stored\nand clears the stored value on PATCH. Omit the field on PATCH\nto leave the stored value unchanged.",
+								MarkdownDescription: "Identifier of the theme applied to the report. The reserved\nsentinel `\"default\"` is returned on GET when no theme is stored\nand clears the stored value on PATCH. Omit the field on PATCH\nto leave the stored value unchanged.",
+								Default:             stringdefault.StaticString("default"),
+							},
+						},
+						CustomType: DisplaySettingsType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+							},
+						},
+						Optional:            true,
+						Computed:            true,
+						Description:         "Display settings for the report.",
+						MarkdownDescription: "Display settings for the report.",
+					},
 					"display_values": schema.StringAttribute{
 						Optional:            true,
 						Computed:            true,
@@ -1076,6 +1148,24 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 			fmt.Sprintf(`dimensions expected to be basetypes.ListValue, was: %T`, dimensionsAttribute))
 	}
 
+	displaySettingsAttribute, ok := attributes["display_settings"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`display_settings is missing from object`)
+
+		return nil, diags
+	}
+
+	displaySettingsVal, ok := displaySettingsAttribute.(DisplaySettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsAttribute))
+	}
+
 	displayValuesAttribute, ok := attributes["display_values"]
 
 	if !ok {
@@ -1357,6 +1447,7 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		CustomTimeRange:           customTimeRangeVal,
 		DataSource:                dataSourceVal,
 		Dimensions:                dimensionsVal,
+		DisplaySettings:           displaySettingsVal,
 		DisplayValues:             displayValuesVal,
 		Filters:                   filtersVal,
 		Group:                     groupVal,
@@ -1547,6 +1638,24 @@ func NewConfigValue(attributeTypes map[string]attr.Type, attributes map[string]a
 			fmt.Sprintf(`dimensions expected to be basetypes.ListValue, was: %T`, dimensionsAttribute))
 	}
 
+	displaySettingsAttribute, ok := attributes["display_settings"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`display_settings is missing from object`)
+
+		return NewConfigValueUnknown(), diags
+	}
+
+	displaySettingsVal, ok := displaySettingsAttribute.(DisplaySettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsAttribute))
+	}
+
 	displayValuesAttribute, ok := attributes["display_values"]
 
 	if !ok {
@@ -1828,6 +1937,7 @@ func NewConfigValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		CustomTimeRange:           customTimeRangeVal,
 		DataSource:                dataSourceVal,
 		Dimensions:                dimensionsVal,
+		DisplaySettings:           displaySettingsVal,
 		DisplayValues:             displayValuesVal,
 		Filters:                   filtersVal,
 		Group:                     groupVal,
@@ -1921,6 +2031,7 @@ type ConfigValue struct {
 	CustomTimeRange           CustomTimeRangeValue    `tfsdk:"custom_time_range"`
 	DataSource                basetypes.StringValue   `tfsdk:"data_source"`
 	Dimensions                basetypes.ListValue     `tfsdk:"dimensions"`
+	DisplaySettings           DisplaySettingsValue    `tfsdk:"display_settings"`
 	DisplayValues             basetypes.StringValue   `tfsdk:"display_values"`
 	Filters                   basetypes.ListValue     `tfsdk:"filters"`
 	Group                     basetypes.ListValue     `tfsdk:"group"`
@@ -1940,7 +2051,7 @@ type ConfigValue struct {
 }
 
 func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 21)
+	attrTypes := make(map[string]tftypes.Type, 22)
 
 	var val tftypes.Value
 	var err error
@@ -1960,6 +2071,11 @@ func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 	attrTypes["data_source"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["dimensions"] = basetypes.ListType{
 		ElemType: DimensionsValue{}.Type(ctx),
+	}.TerraformType(ctx)
+	attrTypes["display_settings"] = DisplaySettingsType{
+		basetypes.ObjectType{
+			AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+		},
 	}.TerraformType(ctx)
 	attrTypes["display_values"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["filters"] = basetypes.ListType{
@@ -2005,7 +2121,7 @@ func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 21)
+		vals := make(map[string]tftypes.Value, 22)
 
 		val, err = v.AdvancedAnalysis.ToTerraformValue(ctx)
 
@@ -2054,6 +2170,14 @@ func (v ConfigValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 		}
 
 		vals["dimensions"] = val
+
+		val, err = v.DisplaySettings.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["display_settings"] = val
 
 		val, err = v.DisplayValues.ToTerraformValue(ctx)
 
@@ -2222,6 +2346,12 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		dimensions = v.Dimensions
 	}
 
+	var displaySettings attr.Value
+
+	{
+		displaySettings = v.DisplaySettings
+	}
+
 	var filters attr.Value
 
 	{
@@ -2287,6 +2417,11 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		"dimensions": basetypes.ListType{
 			ElemType: DimensionsValue{}.Type(ctx),
 		},
+		"display_settings": DisplaySettingsType{
+			basetypes.ObjectType{
+				AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+			},
+		},
 		"display_values": basetypes.StringType{},
 		"filters": basetypes.ListType{
 			ElemType: FiltersValue{}.Type(ctx),
@@ -2345,6 +2480,7 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 			"custom_time_range":           customTimeRange,
 			"data_source":                 v.DataSource,
 			"dimensions":                  dimensions,
+			"display_settings":            displaySettings,
 			"display_values":              v.DisplayValues,
 			"filters":                     filters,
 			"group":                       group,
@@ -2401,6 +2537,10 @@ func (v ConfigValue) Equal(o attr.Value) bool {
 	}
 
 	if !v.Dimensions.Equal(other.Dimensions) {
+		return false
+	}
+
+	if !v.DisplaySettings.Equal(other.DisplaySettings) {
 		return false
 	}
 
@@ -2492,6 +2632,11 @@ func (v ConfigValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"data_source": basetypes.StringType{},
 		"dimensions": basetypes.ListType{
 			ElemType: DimensionsValue{}.Type(ctx),
+		},
+		"display_settings": DisplaySettingsType{
+			basetypes.ObjectType{
+				AttrTypes: DisplaySettingsValue{}.AttributeTypes(ctx),
+			},
 		},
 		"display_values": basetypes.StringType{},
 		"filters": basetypes.ListType{
@@ -3779,6 +3924,550 @@ func (v DimensionsValue) AttributeTypes(ctx context.Context) map[string]attr.Typ
 	return map[string]attr.Type{
 		"id":   basetypes.StringType{},
 		"type": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = DisplaySettingsType{}
+
+type DisplaySettingsType struct {
+	basetypes.ObjectType
+}
+
+func (t DisplaySettingsType) Equal(o attr.Type) bool {
+	other, ok := o.(DisplaySettingsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DisplaySettingsType) String() string {
+	return "DisplaySettingsType"
+}
+
+func (t DisplaySettingsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	axisLabelFontSizeAttribute, ok := attributes["axis_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`axis_label_font_size is missing from object`)
+
+		return nil, diags
+	}
+
+	axisLabelFontSizeVal, ok := axisLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`axis_label_font_size expected to be basetypes.StringValue, was: %T`, axisLabelFontSizeAttribute))
+	}
+
+	dataLabelFontSizeAttribute, ok := attributes["data_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`data_label_font_size is missing from object`)
+
+		return nil, diags
+	}
+
+	dataLabelFontSizeVal, ok := dataLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`data_label_font_size expected to be basetypes.StringValue, was: %T`, dataLabelFontSizeAttribute))
+	}
+
+	decimalPrecisionAttribute, ok := attributes["decimal_precision"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`decimal_precision is missing from object`)
+
+		return nil, diags
+	}
+
+	decimalPrecisionVal, ok := decimalPrecisionAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`decimal_precision expected to be basetypes.Int64Value, was: %T`, decimalPrecisionAttribute))
+	}
+
+	numberScaleAttribute, ok := attributes["number_scale"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`number_scale is missing from object`)
+
+		return nil, diags
+	}
+
+	numberScaleVal, ok := numberScaleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`number_scale expected to be basetypes.StringValue, was: %T`, numberScaleAttribute))
+	}
+
+	themeIdAttribute, ok := attributes["theme_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`theme_id is missing from object`)
+
+		return nil, diags
+	}
+
+	themeIdVal, ok := themeIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`theme_id expected to be basetypes.StringValue, was: %T`, themeIdAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DisplaySettingsValue{
+		AxisLabelFontSize: axisLabelFontSizeVal,
+		DataLabelFontSize: dataLabelFontSizeVal,
+		DecimalPrecision:  decimalPrecisionVal,
+		NumberScale:       numberScaleVal,
+		ThemeId:           themeIdVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDisplaySettingsValueNull() DisplaySettingsValue {
+	return DisplaySettingsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDisplaySettingsValueUnknown() DisplaySettingsValue {
+	return DisplaySettingsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDisplaySettingsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DisplaySettingsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DisplaySettingsValue Attribute Value",
+				"While creating a DisplaySettingsValue value, a missing attribute value was detected. "+
+					"A DisplaySettingsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DisplaySettingsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DisplaySettingsValue Attribute Type",
+				"While creating a DisplaySettingsValue value, an invalid attribute value was detected. "+
+					"A DisplaySettingsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DisplaySettingsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DisplaySettingsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DisplaySettingsValue Attribute Value",
+				"While creating a DisplaySettingsValue value, an extra attribute value was detected. "+
+					"A DisplaySettingsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DisplaySettingsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	axisLabelFontSizeAttribute, ok := attributes["axis_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`axis_label_font_size is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	axisLabelFontSizeVal, ok := axisLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`axis_label_font_size expected to be basetypes.StringValue, was: %T`, axisLabelFontSizeAttribute))
+	}
+
+	dataLabelFontSizeAttribute, ok := attributes["data_label_font_size"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`data_label_font_size is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	dataLabelFontSizeVal, ok := dataLabelFontSizeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`data_label_font_size expected to be basetypes.StringValue, was: %T`, dataLabelFontSizeAttribute))
+	}
+
+	decimalPrecisionAttribute, ok := attributes["decimal_precision"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`decimal_precision is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	decimalPrecisionVal, ok := decimalPrecisionAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`decimal_precision expected to be basetypes.Int64Value, was: %T`, decimalPrecisionAttribute))
+	}
+
+	numberScaleAttribute, ok := attributes["number_scale"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`number_scale is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	numberScaleVal, ok := numberScaleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`number_scale expected to be basetypes.StringValue, was: %T`, numberScaleAttribute))
+	}
+
+	themeIdAttribute, ok := attributes["theme_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`theme_id is missing from object`)
+
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	themeIdVal, ok := themeIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`theme_id expected to be basetypes.StringValue, was: %T`, themeIdAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDisplaySettingsValueUnknown(), diags
+	}
+
+	return DisplaySettingsValue{
+		AxisLabelFontSize: axisLabelFontSizeVal,
+		DataLabelFontSize: dataLabelFontSizeVal,
+		DecimalPrecision:  decimalPrecisionVal,
+		NumberScale:       numberScaleVal,
+		ThemeId:           themeIdVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDisplaySettingsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DisplaySettingsValue {
+	object, diags := NewDisplaySettingsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDisplaySettingsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DisplaySettingsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDisplaySettingsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDisplaySettingsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDisplaySettingsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDisplaySettingsValueMust(DisplaySettingsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DisplaySettingsType) ValueType(ctx context.Context) attr.Value {
+	return DisplaySettingsValue{}
+}
+
+var _ basetypes.ObjectValuable = DisplaySettingsValue{}
+
+type DisplaySettingsValue struct {
+	AxisLabelFontSize basetypes.StringValue `tfsdk:"axis_label_font_size"`
+	DataLabelFontSize basetypes.StringValue `tfsdk:"data_label_font_size"`
+	DecimalPrecision  basetypes.Int64Value  `tfsdk:"decimal_precision"`
+	NumberScale       basetypes.StringValue `tfsdk:"number_scale"`
+	ThemeId           basetypes.StringValue `tfsdk:"theme_id"`
+	state             attr.ValueState
+}
+
+func (v DisplaySettingsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 5)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["axis_label_font_size"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["data_label_font_size"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["decimal_precision"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["number_scale"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["theme_id"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 5)
+
+		val, err = v.AxisLabelFontSize.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["axis_label_font_size"] = val
+
+		val, err = v.DataLabelFontSize.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["data_label_font_size"] = val
+
+		val, err = v.DecimalPrecision.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["decimal_precision"] = val
+
+		val, err = v.NumberScale.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["number_scale"] = val
+
+		val, err = v.ThemeId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["theme_id"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DisplaySettingsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DisplaySettingsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DisplaySettingsValue) String() string {
+	return "DisplaySettingsValue"
+}
+
+func (v DisplaySettingsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"axis_label_font_size": basetypes.StringType{},
+		"data_label_font_size": basetypes.StringType{},
+		"decimal_precision":    basetypes.Int64Type{},
+		"number_scale":         basetypes.StringType{},
+		"theme_id":             basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"axis_label_font_size": v.AxisLabelFontSize,
+			"data_label_font_size": v.DataLabelFontSize,
+			"decimal_precision":    v.DecimalPrecision,
+			"number_scale":         v.NumberScale,
+			"theme_id":             v.ThemeId,
+		})
+
+	return objVal, diags
+}
+
+func (v DisplaySettingsValue) Equal(o attr.Value) bool {
+	other, ok := o.(DisplaySettingsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AxisLabelFontSize.Equal(other.AxisLabelFontSize) {
+		return false
+	}
+
+	if !v.DataLabelFontSize.Equal(other.DataLabelFontSize) {
+		return false
+	}
+
+	if !v.DecimalPrecision.Equal(other.DecimalPrecision) {
+		return false
+	}
+
+	if !v.NumberScale.Equal(other.NumberScale) {
+		return false
+	}
+
+	if !v.ThemeId.Equal(other.ThemeId) {
+		return false
+	}
+
+	return true
+}
+
+func (v DisplaySettingsValue) Type(ctx context.Context) attr.Type {
+	return DisplaySettingsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DisplaySettingsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"axis_label_font_size": basetypes.StringType{},
+		"data_label_font_size": basetypes.StringType{},
+		"decimal_precision":    basetypes.Int64Type{},
+		"number_scale":         basetypes.StringType{},
+		"theme_id":             basetypes.StringType{},
 	}
 }
 


### PR DESCRIPTION
## Summary

Add the `config.display_settings` nested object to the report resource and data source, enabling per-report theme and display customization.

### New Attributes (`config.display_settings`)

| Attribute | Type | Classification | Notes |
|-----------|------|----------------|-------|
| `axis_label_font_size` | string enum | Optional+Computed | auto, small, medium, large |
| `data_label_font_size` | string enum | Optional+Computed | auto, small, medium, large |
| `decimal_precision` | int64 | Optional+Computed | 0–8 |
| `number_scale` | string enum | Optional+Computed | auto, thousands, millions, billions, raw |
| `theme_id` | string | Optional+Computed, Default `"default"` | References a `doit_custom_theme` ID |

### Changes

- **OpenAPI spec + generated code**: Upstream spec changes for `ExternalDisplaySettings`
- **`report.go`**: `overlayDisplaySettings` helper, wiring in `overlayConfigFields`, `toExternalConfig`, and `mapReportToModel`
- **`report_data_source.go`**: `display_settings` mapping in DS `populateState`
- **`report_resource_test.go`**: Two new acceptance tests

### Validation

- `go build ./...`: ✅
- `make lint`: 0 issues ✅ (including `overlaycheck` — `theme_id` correctly has no `IsUnknown()` guard since it has a schema Default)
- `TestAccReport_DisplaySettings`: ✅ (number_scale + decimal_precision + default theme)
- `TestAccReport_DisplaySettingsWithTheme`: ✅ (custom theme via `doit_custom_theme`, `TestCheckResourceAttrPair`)
- Both tests include drift verification (empty plan on re-apply)

---
> AI-assisted development