### PR TITLE
fix(requestguard): support helper functions with nested value types

### DIFF
--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -650,11 +650,11 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 		layout := models.ExternalRenderer(config.Layout.ValueString())
 		externalConfig.Layout = &layout
 	}
-	if !config.SortDimensions.IsNull() && !config.SortDimensions.IsUnknown() {
+	if !config.SortDimensions.IsNull() {
 		sortDimensions := models.ExternalConfigSortDimensions(config.SortDimensions.ValueString())
 		externalConfig.SortDimensions = &sortDimensions
 	}
-	if !config.SortGroups.IsNull() && !config.SortGroups.IsUnknown() {
+	if !config.SortGroups.IsNull() {
 		sortGroups := models.ExternalConfigSortGroups(config.SortGroups.ValueString())
 		externalConfig.SortGroups = &sortGroups
 	}
@@ -678,20 +678,22 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	}
 
 	if !config.CustomTimeRange.IsNull() && !config.CustomTimeRange.IsUnknown() {
-		fromTime, err := time.Parse(time.RFC3339, config.CustomTimeRange.From.ValueString())
-		if err != nil {
-			diags.AddError("Invalid From Time", "Could not parse CustomTimeRange.From as RFC3339: "+err.Error())
-		}
-		toTime, err := time.Parse(time.RFC3339, config.CustomTimeRange.To.ValueString())
-		if err != nil {
-			diags.AddError("Invalid To Time", "Could not parse CustomTimeRange.To as RFC3339: "+err.Error())
-		}
-
-		if !diags.HasError() {
-			customTimeRange := models.ExternalConfigCustomTimeRange{
-				From: &fromTime,
-				To:   &toTime,
+		customTimeRange := models.ExternalConfigCustomTimeRange{}
+		if !config.CustomTimeRange.From.IsNull() && !config.CustomTimeRange.From.IsUnknown() {
+			fromTime, err := time.Parse(time.RFC3339, config.CustomTimeRange.From.ValueString())
+			if err != nil {
+				diags.AddError("Invalid From Time", "Could not parse CustomTimeRange.From as RFC3339: "+err.Error())
 			}
+			customTimeRange.From = &fromTime
+		}
+		if !config.CustomTimeRange.To.IsNull() && !config.CustomTimeRange.To.IsUnknown() {
+			toTime, err := time.Parse(time.RFC3339, config.CustomTimeRange.To.ValueString())
+			if err != nil {
+				diags.AddError("Invalid To Time", "Could not parse CustomTimeRange.To as RFC3339: "+err.Error())
+			}
+			customTimeRange.To = &toTime
+		}
+		if !diags.HasError() {
 			externalConfig.CustomTimeRange = &customTimeRange
 		}
 	}
@@ -865,14 +867,19 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	}
 
 	if !config.TimeRange.IsNull() && !config.TimeRange.IsUnknown() {
-		timeSettingsMode := models.TimeSettingsMode(config.TimeRange.Mode.ValueString())
-		timeSettingsUnit := models.TimeSettingsUnit(config.TimeRange.Unit.ValueString())
-		externalConfig.TimeRange = &models.TimeSettings{
+		ts := &models.TimeSettings{
 			Amount:         config.TimeRange.Amount.ValueInt64Pointer(),
 			IncludeCurrent: config.TimeRange.IncludeCurrent.ValueBoolPointer(),
-			Mode:           &timeSettingsMode,
-			Unit:           &timeSettingsUnit,
 		}
+		if !config.TimeRange.Mode.IsNull() && !config.TimeRange.Mode.IsUnknown() {
+			mode := models.TimeSettingsMode(config.TimeRange.Mode.ValueString())
+			ts.Mode = &mode
+		}
+		if !config.TimeRange.Unit.IsNull() && !config.TimeRange.Unit.IsUnknown() {
+			unit := models.TimeSettingsUnit(config.TimeRange.Unit.ValueString())
+			ts.Unit = &unit
+		}
+		externalConfig.TimeRange = ts
 	}
 
 	if !config.SecondaryTimeRange.IsNull() && !config.SecondaryTimeRange.IsUnknown() {
@@ -885,19 +892,22 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 			secondaryTimeRange.Unit = &unit
 		}
 		if !config.SecondaryTimeRange.CustomTimeRange.IsNull() && !config.SecondaryTimeRange.CustomTimeRange.IsUnknown() {
-			fromTime, err := time.Parse(time.RFC3339, config.SecondaryTimeRange.CustomTimeRange.From.ValueString())
-			if err != nil {
-				diags.AddError("Invalid From Time", "Could not parse SecondaryTimeRange.CustomTimeRange.From as RFC3339: "+err.Error())
+			ctr := models.TimeSettingsSecondaryCustomTimeRange{}
+			if !config.SecondaryTimeRange.CustomTimeRange.From.IsNull() && !config.SecondaryTimeRange.CustomTimeRange.From.IsUnknown() {
+				fromTime, err := time.Parse(time.RFC3339, config.SecondaryTimeRange.CustomTimeRange.From.ValueString())
+				if err != nil {
+					diags.AddError("Invalid From Time", "Could not parse SecondaryTimeRange.CustomTimeRange.From as RFC3339: "+err.Error())
+				}
+				ctr.From = &fromTime
 			}
-			toTime, err := time.Parse(time.RFC3339, config.SecondaryTimeRange.CustomTimeRange.To.ValueString())
-			if err != nil {
-				diags.AddError("Invalid To Time", "Could not parse SecondaryTimeRange.CustomTimeRange.To as RFC3339: "+err.Error())
+			if !config.SecondaryTimeRange.CustomTimeRange.To.IsNull() && !config.SecondaryTimeRange.CustomTimeRange.To.IsUnknown() {
+				toTime, err := time.Parse(time.RFC3339, config.SecondaryTimeRange.CustomTimeRange.To.ValueString())
+				if err != nil {
+					diags.AddError("Invalid To Time", "Could not parse SecondaryTimeRange.CustomTimeRange.To as RFC3339: "+err.Error())
+				}
+				ctr.To = &toTime
 			}
 			if !diags.HasError() {
-				ctr := models.TimeSettingsSecondaryCustomTimeRange{
-					From: &fromTime,
-					To:   &toTime,
-				}
 				secondaryTimeRange.CustomTimeRange = &ctr
 			}
 		}
@@ -1564,7 +1574,7 @@ func baseTypeObjectValueToExternalMetric(metricValue resource_report.MetricValue
 		tString := models.ExternalMetricType(metricValue.MetricType.ValueString())
 		metric.Type = &tString
 	}
-	if !metricValue.Value.IsNull() {
+	if !metricValue.Value.IsNull() && !metricValue.Value.IsUnknown() {
 		vString := metricValue.Value.ValueString()
 		metric.Value = &vString
 	}

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -2935,3 +2935,42 @@ resource "doit_report" "this" {
 }
 `, i)
 }
+
+// TestAccReport_EmptyCustomTimeRange verifies that setting custom_time_range = {}
+// (both from and to omitted) is rejected at plan time by the config validator.
+func TestAccReport_EmptyCustomTimeRange(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccReportEmptyCustomTimeRange(n),
+				ExpectError: regexp.MustCompile(`Empty Custom Time Range`),
+			},
+		},
+	})
+}
+
+func testAccReportEmptyCustomTimeRange(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "this" {
+    name = "test-empty-ctr-%d"
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        custom_time_range = {}
+    }
+}
+`, i)
+}

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -2868,3 +2868,70 @@ resource "doit_report" "themed" {
 }
 `, i, i)
 }
+
+// TestAccReport_PartialTimeRange verifies that omitting Optional+Computed
+// subfields (here include_current) within a user-specified time_range object
+// does not cause errors on Create and does not produce drift on re-apply.
+func TestAccReport_PartialTimeRange(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportPartialTimeRange(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_report.this",
+						tfjsonpath.New("config").AtMapKey("time_range").AtMapKey("mode"),
+						knownvalue.StringExact("last")),
+					statecheck.ExpectKnownValue(
+						"doit_report.this",
+						tfjsonpath.New("config").AtMapKey("time_range").AtMapKey("amount"),
+						knownvalue.Int64Exact(3)),
+					// include_current is omitted — verify it resolves to a known value.
+					statecheck.ExpectKnownValue(
+						"doit_report.this",
+						tfjsonpath.New("config").AtMapKey("time_range").AtMapKey("include_current"),
+						knownvalue.NotNull()),
+				},
+			},
+			// Drift check: re-apply same config, expect no changes.
+			{
+				Config: testAccReportPartialTimeRange(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportPartialTimeRange(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "this" {
+    name = "test-partial-tr-%d"
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode   = "last"
+          amount = 3
+          unit   = "month"
+        }
+    }
+}
+`, i)
+}

--- a/internal/provider/report_validator.go
+++ b/internal/provider/report_validator.go
@@ -113,23 +113,49 @@ func (v reportMetricsLengthValidator) ValidateResource(ctx context.Context, req 
 	}
 }
 
-// reportTimestampValidator validates that custom_time_range.from/to values are valid
-// RFC3339 timestamps at plan time. This is a ConfigValidator because attribute-level
-// validators do not fire on attributes inside SingleNestedAttribute with CustomType
-// (which the code generator adds to all nested objects).
+// reportTimestampValidator validates custom_time_range objects:
+// 1. When set, at least one of from/to must be specified (rejects empty `{}`).
+// 2. Any provided from/to values must be valid RFC3339 timestamps.
+//
+// This is a ConfigValidator because attribute-level validators do not fire on
+// attributes inside SingleNestedAttribute with CustomType (which the code
+// generator adds to all nested objects).
 type reportTimestampValidator struct{}
 
 var _ resource.ConfigValidator = reportTimestampValidator{}
 
 func (v reportTimestampValidator) Description(_ context.Context) string {
-	return "Validates RFC3339 timestamps in custom_time_range and secondary_time_range.custom_time_range"
+	return "Validates custom_time_range objects are non-empty and contain valid RFC3339 timestamps"
 }
 
 func (v reportTimestampValidator) MarkdownDescription(_ context.Context) string {
-	return "Validates RFC3339 timestamps in `custom_time_range` and `secondary_time_range.custom_time_range`"
+	return "Validates `custom_time_range` objects are non-empty and contain valid RFC3339 timestamps"
 }
 
 func (v reportTimestampValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	// Reject empty custom_time_range objects (set but both from and to are null).
+	ctrPaths := []path.Path{
+		path.Root("config").AtName("custom_time_range"),
+		path.Root("config").AtName("secondary_time_range").AtName("custom_time_range"),
+	}
+	for _, p := range ctrPaths {
+		var ctr resource_report.CustomTimeRangeValue
+		diags := req.Config.GetAttribute(ctx, p, &ctr)
+		if diags.HasError() || ctr.IsNull() || ctr.IsUnknown() {
+			continue
+		}
+		fromEmpty := ctr.From.IsNull() || ctr.From.IsUnknown()
+		toEmpty := ctr.To.IsNull() || ctr.To.IsUnknown()
+		if fromEmpty && toEmpty {
+			resp.Diagnostics.AddAttributeError(
+				p,
+				"Empty Custom Time Range",
+				"custom_time_range requires at least one of `from` or `to` to be set.",
+			)
+		}
+	}
+
+	// Validate individual timestamp formats.
 	timestampPaths := []path.Path{
 		path.Root("config").AtName("custom_time_range").AtName("from"),
 		path.Root("config").AtName("custom_time_range").AtName("to"),

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -1,4 +1,5 @@
-// Package requestguard validates IsUnknown() usage in request builder functions.
+// Package requestguard validates IsUnknown() usage in request builder functions
+// and helper functions they call.
 //
 // Direction 1 (redundant guard): flags IsUnknown() checks on fields that can
 // never be Unknown (Required, Optional without Computed, Optional+Computed with
@@ -8,6 +9,10 @@
 // ValueBool, ValueFloat64, ValueInt64) on Optional+Computed fields without
 // Default when not guarded by IsUnknown(). Pointer accessors (ValueStringPointer
 // etc.) are excluded because they return nil for Unknown, which is often acceptable.
+//
+// The analyzer propagates schema context across function call boundaries:
+// when a builder calls a helper with plan.X as an argument, the helper's
+// corresponding parameter inherits the nested schema context.
 package requestguard
 
 import (
@@ -44,6 +49,9 @@ var nonPointerAccessors = map[string]bool{
 	"ValueInt64":   true,
 }
 
+// attrMap is a convenience alias for field name → AttrInfo maps.
+type attrMap = map[string]*schemaparser.AttrInfo
+
 func run(pass *analysis.Pass) (any, error) {
 	result := pass.ResultOf[schemaparser.Analyzer]
 	if result == nil {
@@ -57,7 +65,6 @@ func run(pass *analysis.Pass) (any, error) {
 	// Index schemas by function name. Each schema's Attrs map contains
 	// only top-level attributes; nested attrs live in AttrInfo.NestedAttrs.
 	// This avoids name collisions between top-level and nested attrs.
-	type attrMap = map[string]*schemaparser.AttrInfo
 	perSchema := map[string]attrMap{}
 	for name, info := range schemaResult.Schemas {
 		perSchema[name] = info.Attrs
@@ -65,12 +72,19 @@ func run(pass *analysis.Pass) (any, error) {
 
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-	// Step 1: Map receiver types → schema names via Schema() methods.
+	// Pass 1: Index all FuncDecls by name and map receiver types → schema names.
+	allFuncs := map[string]*ast.FuncDecl{}
 	receiverToSchema := map[string]string{}
 	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil)}
 	insp.Preorder(nodeFilter, func(n ast.Node) {
 		fn := n.(*ast.FuncDecl)
-		if fn.Name == nil || fn.Name.Name != "Schema" || fn.Body == nil {
+		if fn.Name == nil || fn.Body == nil {
+			return
+		}
+		allFuncs[fn.Name.Name] = fn
+
+		// Check if this is a Schema() method.
+		if fn.Name.Name != "Schema" {
 			return
 		}
 		if fn.Recv == nil || len(fn.Recv.List) == 0 {
@@ -87,44 +101,189 @@ func run(pass *analysis.Pass) (any, error) {
 		receiverToSchema[recvType] = schemaName
 	})
 
-	// Step 2: Find request builder functions and check guards.
-	insp.Preorder(nodeFilter, func(n ast.Node) {
-		fn := n.(*ast.FuncDecl)
-		if fn.Name == nil || fn.Body == nil {
-			return
-		}
+	// Pass 2: Find request builder functions, check guards, and propagate
+	// schema context into helper functions they call.
+	for _, fn := range allFuncs {
 		if !isRequestBuilder(fn.Name.Name) {
-			return
+			continue
 		}
 
 		// Resolve schema: try receiver, then parameter types.
 		schema := resolveSchema(fn, receiverToSchema, perSchema)
 		if schema == nil {
-			return
+			continue
 		}
 
-		// Build variable → schema path mapping for nested field tracking.
-		// Initialize with the plan parameter name.
 		planParam := findPlanParam(fn)
 		if planParam == "" {
-			return
+			continue
 		}
 
-		// varSchemas maps variable names to their nested schema context.
-		// The plan parameter maps to the top-level schema.
 		varSchemas := map[string]attrMap{planParam: schema}
-
-		// Track variable assignments to nested types.
-		trackVariableAssignments(fn.Body, varSchemas)
-
-		// Direction 1: Find redundant IsUnknown() guards.
-		checkRedundantGuards(pass, fn.Body, varSchemas)
-
-		// Direction 2: Find missing guards on non-pointer value accessors.
-		checkMissingGuards(pass, fn.Body, varSchemas)
-	})
+		seen := map[string]bool{fn.Name.Name: true}
+		analyzeFunction(pass, fn, varSchemas, allFuncs, seen)
+	}
 
 	return nil, nil
+}
+
+// analyzeFunction checks guards within a function body and recursively
+// propagates schema context into helper functions it calls.
+func analyzeFunction(pass *analysis.Pass, fn *ast.FuncDecl, varSchemas map[string]attrMap, allFuncs map[string]*ast.FuncDecl, seen map[string]bool) {
+	// Track variable assignments to nested types (e.g., config := plan.Config).
+	trackVariableAssignments(fn.Body, varSchemas)
+
+	// Direction 1: Find redundant IsUnknown() guards.
+	checkRedundantGuards(pass, fn.Body, varSchemas)
+
+	// Direction 2: Find missing guards on non-pointer value accessors.
+	checkMissingGuards(pass, fn.Body, varSchemas)
+
+	// Propagate schema context into helper functions called from this body.
+	propagateToCallees(pass, fn.Body, varSchemas, allFuncs, seen)
+}
+
+// propagateToCallees scans the function body for call expressions that pass
+// tracked variables (or their fields) as arguments. For each such call, it
+// resolves the nested schema and recursively analyzes the callee.
+func propagateToCallees(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map[string]attrMap, allFuncs map[string]*ast.FuncDecl, seen map[string]bool) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		// Resolve the callee function name.
+		calleeName := calleeIdent(call)
+		if calleeName == "" {
+			return true
+		}
+
+		// Skip if already visited (prevent infinite recursion).
+		if seen[calleeName] {
+			return true
+		}
+
+		// Look up the callee's FuncDecl.
+		calleeFn, ok := allFuncs[calleeName]
+		if !ok || calleeFn.Body == nil {
+			return true
+		}
+
+		// Match arguments to parameters: for each argument that is a field
+		// access on a tracked variable, propagate the nested schema to the
+		// corresponding parameter.
+		calleeSchemas := resolveCalleeSchemas(call, calleeFn, varSchemas)
+		if len(calleeSchemas) == 0 {
+			return true
+		}
+
+		seen[calleeName] = true
+		analyzeFunction(pass, calleeFn, calleeSchemas, allFuncs, seen)
+
+		return true
+	})
+}
+
+// calleeIdent extracts the function name from a call expression.
+// Handles both unqualified (foo()) and ignored-receiver calls.
+func calleeIdent(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		// Method calls (obj.Method) — skip, we only propagate into
+		// free functions. Package-qualified calls are in a different
+		// package and won't be in allFuncs.
+		return ""
+	}
+	return ""
+}
+
+// resolveCalleeSchemas builds a varSchemas map for a callee function by
+// matching call arguments to the callee's parameters. When an argument
+// is a field access on a tracked variable (e.g., plan.Config), the
+// corresponding parameter inherits the field's nested schema.
+func resolveCalleeSchemas(call *ast.CallExpr, callee *ast.FuncDecl, callerSchemas map[string]attrMap) map[string]attrMap {
+	if callee.Type == nil || callee.Type.Params == nil {
+		return nil
+	}
+
+	result := map[string]attrMap{}
+
+	// Build a flat list of (paramIndex, paramName) from the callee's params.
+	type paramEntry struct {
+		index int
+		name  string
+	}
+	var params []paramEntry
+	idx := 0
+	for _, field := range callee.Type.Params.List {
+		for _, name := range field.Names {
+			params = append(params, paramEntry{index: idx, name: name.Name})
+			idx++
+		}
+		if len(field.Names) == 0 {
+			idx++ // unnamed parameter
+		}
+	}
+
+	// For each call argument, check if it's a field access on a tracked var.
+	for argIdx, arg := range call.Args {
+		nestedSchema := resolveArgSchema(arg, callerSchemas)
+		if nestedSchema == nil {
+			continue
+		}
+
+		// Find the corresponding parameter name.
+		for _, p := range params {
+			if p.index == argIdx {
+				result[p.name] = nestedSchema
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+// resolveArgSchema resolves a call argument to a nested schema.
+// Handles direct field access (plan.Config), chained access (plan.Config.Sub),
+// and tracked variable references (config where config := plan.Config).
+func resolveArgSchema(arg ast.Expr, callerSchemas map[string]attrMap) attrMap {
+	switch a := arg.(type) {
+	case *ast.Ident:
+		// Direct variable reference (e.g., passing "config" where config
+		// is already tracked). Return its schema context.
+		if schema, ok := callerSchemas[a.Name]; ok {
+			return schema
+		}
+	case *ast.SelectorExpr:
+		// Field access: plan.Config or config.Filter etc.
+		// Walk the chain to resolve the nested schema.
+		chain := buildSelectorChain(a)
+		if len(chain) < 2 {
+			return nil
+		}
+
+		rootVar := chain[0]
+		schema, ok := callerSchemas[rootVar]
+		if !ok {
+			return nil
+		}
+
+		// Walk through all fields in the chain to reach the leaf's NestedAttrs.
+		for i := 1; i < len(chain); i++ {
+			attrName := toSnakeCase(chain[i])
+			attr, ok := schema[attrName]
+			if !ok || attr.NestedAttrs == nil {
+				return nil
+			}
+			schema = attr.NestedAttrs
+		}
+		return schema
+	}
+	return nil
 }
 
 
@@ -525,17 +684,17 @@ func extractReceiverTypeName(fn *ast.FuncDecl) string {
 	return extractStarTypeName(fn.Recv.List[0].Type)
 }
 
-// extractStarTypeName extracts the type name from *T.
+// extractStarTypeName extracts the type name from T, *T, pkg.T, or *pkg.T.
 func extractStarTypeName(expr ast.Expr) string {
-	star, ok := expr.(*ast.StarExpr)
-	if !ok {
-		if ident, ok := expr.(*ast.Ident); ok {
-			return ident.Name
-		}
-		return ""
+	// Unwrap pointer if present.
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
 	}
-	if ident, ok := star.X.(*ast.Ident); ok {
-		return ident.Name
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return e.Sel.Name // pkg.Type → Type
 	}
 	return ""
 }

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -193,7 +193,8 @@ func propagateToCallees(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map
 }
 
 // calleeIdent extracts the function name from a call expression.
-// Handles both unqualified (foo()) and ignored-receiver calls.
+// Only unqualified calls (foo()) are considered for propagation;
+// selector calls (obj.Method(), pkg.Func()) are skipped.
 func calleeIdent(call *ast.CallExpr) string {
 	switch fun := call.Fun.(type) {
 	case *ast.Ident:

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -103,26 +103,33 @@ func run(pass *analysis.Pass) (any, error) {
 
 	// Pass 2: Find request builder functions, check guards, and propagate
 	// schema context into helper functions they call.
-	for _, fn := range allFuncs {
+	// This uses insp.Preorder (not allFuncs iteration) because multiple
+	// receiver types can define the same method name (e.g., toCreateRequest
+	// on 10+ resources) — the map only keeps the last one written.
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Name == nil || fn.Body == nil {
+			return
+		}
 		if !isRequestBuilder(fn.Name.Name) {
-			continue
+			return
 		}
 
 		// Resolve schema: try receiver, then parameter types.
 		schema := resolveSchema(fn, receiverToSchema, perSchema)
 		if schema == nil {
-			continue
+			return
 		}
 
 		planParam := findPlanParam(fn)
 		if planParam == "" {
-			continue
+			return
 		}
 
 		varSchemas := map[string]attrMap{planParam: schema}
 		seen := map[string]bool{fn.Name.Name: true}
 		analyzeFunction(pass, fn, varSchemas, allFuncs, seen)
-	}
+	})
 
 	return nil, nil
 }

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
@@ -165,7 +165,7 @@ func (plan *GuardTestModel) toHelperTestRequest() ApiRequest {
 }
 
 // fillFromConfig is a helper function taking a ConfigValue directly.
-// Schema context is propagated from toCreateRequest's call with plan.Config.
+// Schema context is propagated from toHelperTestRequest's call with plan.Config.
 func fillFromConfig(req *ApiRequest, config ConfigValue) {
 	// BAD: Required nested field — IsUnknown() is dead code.
 	if !config.Type.IsNull() && !config.Type.IsUnknown() { // want `IsUnknown\(\) on Required field "type" is dead code \(Required fields are always Known\)`
@@ -199,7 +199,7 @@ func fillFilterFromConfig(filter FilterValue) {
 }
 
 // fillDisplaySettings is a helper taking a DisplaySettingsValue.
-// Schema context propagated from toCreateRequest via config.DisplaySettings.
+// Schema context propagated from toHelperTestRequest via config.DisplaySettings.
 func fillDisplaySettings(req *ApiRequest, ds DisplaySettingsValue) {
 	// BAD: Optional+Computed WITH default — IsUnknown() is dead code.
 	if !ds.ThemeId.IsNull() && !ds.ThemeId.IsUnknown() { // want `IsUnknown\(\) on field "theme_id" with schema Default is dead code \(defaults are resolved at plan time\)`

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
@@ -146,3 +146,74 @@ func toFilterRequest(plan *GuardTestModel) *FilterRequest {
 
 	return req
 }
+
+// --- Cross-function schema propagation tests ---
+
+// toHelperTestRequest is a builder that calls helper functions with plan fields.
+// The linter should propagate schema context into the helpers.
+func (plan *GuardTestModel) toHelperTestRequest() ApiRequest {
+	req := ApiRequest{}
+
+	// Call a helper function with plan.Config as argument.
+	fillFromConfig(&req, plan.Config)
+
+	// Call a helper with a tracked variable.
+	config := plan.Config
+	fillDisplaySettings(&req, config.DisplaySettings)
+
+	return req
+}
+
+// fillFromConfig is a helper function taking a ConfigValue directly.
+// Schema context is propagated from toCreateRequest's call with plan.Config.
+func fillFromConfig(req *ApiRequest, config ConfigValue) {
+	// BAD: Required nested field — IsUnknown() is dead code.
+	if !config.Type.IsNull() && !config.Type.IsUnknown() { // want `IsUnknown\(\) on Required field "type" is dead code \(Required fields are always Known\)`
+		req.Name = config.Type.ValueStringPointer()
+	}
+
+	// BAD: Optional+Computed WITH default — IsUnknown() is dead code.
+	if !config.CaseInsensitive.IsUnknown() { // want `IsUnknown\(\) on field "case_insensitive" with schema Default is dead code \(defaults are resolved at plan time\)`
+		_ = config.CaseInsensitive.ValueBool()
+	}
+
+	// BAD: Optional+Computed WITHOUT default — missing guard.
+	val := config.Currency.ValueString() // want `ValueString\(\) on Optional\+Computed field "currency" without IsUnknown\(\) guard; field may be Unknown at plan time`
+	_ = val
+
+	// Transitive call: pass a nested field to another helper.
+	fillFilterFromConfig(config.Filter)
+}
+
+// fillFilterFromConfig is called transitively from fillFromConfig.
+// Schema context propagates: builder → fillFromConfig → fillFilterFromConfig.
+func fillFilterFromConfig(filter FilterValue) {
+	// BAD: Required at 2nd nesting level — IsUnknown() is dead code.
+	if !filter.Operator.IsUnknown() { // want `IsUnknown\(\) on Required field "operator" is dead code \(Required fields are always Known\)`
+		_ = filter.Operator.ValueStringPointer()
+	}
+
+	// BAD: Optional+Computed without default — missing guard.
+	val := filter.Mode.ValueString() // want `ValueString\(\) on Optional\+Computed field "mode" without IsUnknown\(\) guard; field may be Unknown at plan time`
+	_ = val
+}
+
+// fillDisplaySettings is a helper taking a DisplaySettingsValue.
+// Schema context propagated from toCreateRequest via config.DisplaySettings.
+func fillDisplaySettings(req *ApiRequest, ds DisplaySettingsValue) {
+	// BAD: Optional+Computed WITH default — IsUnknown() is dead code.
+	if !ds.ThemeId.IsNull() && !ds.ThemeId.IsUnknown() { // want `IsUnknown\(\) on field "theme_id" with schema Default is dead code \(defaults are resolved at plan time\)`
+		req.Metric = ds.ThemeId.ValueStringPointer()
+	}
+}
+
+// --- Non-builder standalone function (should NOT be analyzed) ---
+
+// standaloneHelper is not called from any builder. The linter should not
+// analyze it, so these patterns should NOT produce diagnostics.
+func standaloneHelper(config ConfigValue) {
+	_ = config.Currency.ValueString() // no diagnostic — not reachable from a builder
+	if !config.Type.IsUnknown() {     // no diagnostic — not reachable from a builder
+		_ = config.Type.ValueStringPointer()
+	}
+}

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
@@ -76,6 +76,19 @@ func GuardTestResourceSchema(ctx context.Context) schema.Schema {
 							},
 						},
 					},
+					// 2-level nested attribute with a defaulted field.
+					"display_settings": schema.SingleNestedAttribute{
+						Optional: true,
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							// Optional+Computed WITH default at 2nd nesting level.
+							"theme_id": schema.StringAttribute{
+								Optional: true,
+								Computed: true,
+								Default:  stringdefault.StaticString("default"),
+							},
+						},
+					},
 				},
 			},
 		},
@@ -98,6 +111,7 @@ type ConfigValue struct {
 	CaseInsensitive  types.Bool
 	Currency         types.String
 	Filter           FilterValue
+	DisplaySettings  DisplaySettingsValue
 }
 
 // FilterValue is the 2nd-level nested model.
@@ -105,6 +119,13 @@ type FilterValue struct {
 	Operator types.String
 	Mode     types.String
 }
+
+// DisplaySettingsValue is the 2nd-level nested model for display settings.
+type DisplaySettingsValue struct {
+	ThemeId types.String
+}
+
+
 
 // guardTestResource is a mock resource.
 type guardTestResource struct{}
@@ -135,4 +156,9 @@ type ConfigRequest struct {
 type FilterRequest struct {
 	Operator *string
 	Mode     *string
+}
+
+// DisplaySettingsRequest is a mock 2nd-level nested request type.
+type DisplaySettingsRequest struct {
+	ThemeId *string
 }


### PR DESCRIPTION
## Summary

Extend the `requestguard` linter to analyze helper functions that take package-qualified nested value types (e.g., `resource_report.ConfigValue`) by propagating schema context across function call boundaries.

Closes #217

## Changes

### Linter (`tools/linters/requestguard/`)

**Fix `extractStarTypeName`** — now handles `SelectorExpr` (`pkg.Type`, `*pkg.Type`) in addition to `Ident` and `StarExpr`. This is required for `findPlanParam` to identify parameters with package-qualified types.

**Restructure `run()` into two-pass flow:**
1. **Pass 1:** Index all `FuncDecl` nodes by name and map receiver types → schema names
2. **Pass 2:** For each request builder, analyze guards and recursively propagate schema context into helper functions

**Add cross-function schema propagation:**
- `analyzeFunction` — checks guards and recursively propagates into callees
- `propagateToCallees` — scans call expressions for arguments that are tracked variable fields (e.g., `plan.Config`), resolves the nested schema, and recursively analyzes the callee
- `resolveCalleeSchemas` — positionally matches call arguments to callee parameters
- `resolveArgSchema` — handles direct field access (`plan.Config`), chained access (`config.Filter`), and tracked variable references

**Infinite recursion prevention** via a `seen` set of visited function names.

### Test fixtures (`requestguard/testdata/src/guardtest/`)

- Added `display_settings` nested attribute with `theme_id` (Optional+Computed with Default)
- Added `toHelperTestRequest` builder that calls helpers with `plan.Config` and `config.DisplaySettings`
- Added `fillFromConfig` — tests Direction 1+2 in a helper function
- Added `fillFilterFromConfig` — tests transitive propagation (builder → helper → sub-helper)
- Added `fillDisplaySettings` — tests tracked variable argument propagation
- Added `standaloneHelper` — verifies no false positives for unreachable functions

### Report fixes (`internal/provider/report.go`)

Fixes 9 pre-existing issues now detected by the enhanced linter:
- Removed redundant `IsUnknown()` on `sort_dimensions` and `sort_groups` (have Default)
- Added `IsUnknown()` guards on `CustomTimeRange.From/To`, `TimeRange.Mode/Unit`, `SecondaryTimeRange.CustomTimeRange.From/To`
- Added `IsUnknown()` guard on `metricValue.Value` in `baseTypeObjectValueToExternalMetric`

## Validation

- `go test ./requestguard/... -v -count=1` — PASS
- `go test ./... -count=1` — all linter tests PASS
- `./custom-gcl run --enable-only=requestguard` — 0 issues
- Pre-commit hooks pass