### PR TITLE
fix(requestguard): flag pointer accessors as unsafe for Unknown values

### DIFF
--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -217,7 +217,9 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 	}
 
 	// Simple fields
-	req.Amount = plan.Amount.ValueFloat64Pointer()
+	if !plan.Amount.IsNull() && !plan.Amount.IsUnknown() {
+		req.Amount = plan.Amount.ValueFloat64Pointer()
+	}
 	if !plan.Currency.IsNull() && !plan.Currency.IsUnknown() {
 		currency := models.Currency(plan.Currency.ValueString())
 		req.Currency = &currency
@@ -234,7 +236,9 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 		metric := models.BudgetCreateUpdateRequestMetric(plan.Metric.ValueString())
 		req.Metric = &metric
 	}
-	req.Name = plan.Name.ValueStringPointer()
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		req.Name = plan.Name.ValueStringPointer()
+	}
 
 	if !plan.Public.IsNull() && !plan.Public.IsUnknown() {
 		public := models.BudgetCreateUpdateRequestPublic(plan.Public.ValueString())
@@ -327,8 +331,12 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 		req.StartPeriod = plan.StartPeriod.ValueInt64Pointer()
 	}
 
-	req.TimeInterval = plan.TimeInterval.ValueStringPointer()
-	req.Type = plan.Type.ValueStringPointer()
+	if !plan.TimeInterval.IsNull() && !plan.TimeInterval.IsUnknown() {
+		req.TimeInterval = plan.TimeInterval.ValueStringPointer()
+	}
+	if !plan.Type.IsNull() && !plan.Type.IsUnknown() {
+		req.Type = plan.Type.ValueStringPointer()
+	}
 	req.UsePrevSpend = plan.UsePrevSpend.ValueBoolPointer()
 
 	return req, diags

--- a/internal/provider/pointer_accessor_test.go
+++ b/internal/provider/pointer_accessor_test.go
@@ -1,0 +1,156 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestPointerAccessorsOnUnknown proves that Terraform Plugin Framework pointer
+// accessors return a pointer to the zero value for Unknown, NOT nil.
+// This is the core justification for why the requestguard linter flags
+// pointer accessors: omitting an IsUnknown() guard sends a zero value
+// to the API instead of omitting the field (via omitempty + nil).
+func TestPointerAccessorsOnUnknown(t *testing.T) {
+	t.Run("ValueBoolPointer on Unknown returns *false, not nil", func(t *testing.T) {
+		unknown := types.BoolUnknown()
+		got := unknown.ValueBoolPointer()
+		if got == nil {
+			t.Fatal("ValueBoolPointer() on Unknown returned nil; expected *false")
+		}
+		if *got != false {
+			t.Fatalf("ValueBoolPointer() on Unknown returned *%v; expected *false", *got)
+		}
+	})
+
+	t.Run("ValueBoolPointer on Null returns nil", func(t *testing.T) {
+		null := types.BoolNull()
+		got := null.ValueBoolPointer()
+		if got != nil {
+			t.Fatalf("ValueBoolPointer() on Null returned *%v; expected nil", *got)
+		}
+	})
+
+	t.Run("ValueInt64Pointer on Unknown returns *0, not nil", func(t *testing.T) {
+		unknown := types.Int64Unknown()
+		got := unknown.ValueInt64Pointer()
+		if got == nil {
+			t.Fatal("ValueInt64Pointer() on Unknown returned nil; expected *0")
+		}
+		if *got != 0 {
+			t.Fatalf("ValueInt64Pointer() on Unknown returned *%d; expected *0", *got)
+		}
+	})
+
+	t.Run("ValueInt64Pointer on Null returns nil", func(t *testing.T) {
+		null := types.Int64Null()
+		got := null.ValueInt64Pointer()
+		if got != nil {
+			t.Fatalf("ValueInt64Pointer() on Null returned *%d; expected nil", *got)
+		}
+	})
+
+	t.Run("ValueStringPointer on Unknown returns *empty, not nil", func(t *testing.T) {
+		unknown := types.StringUnknown()
+		got := unknown.ValueStringPointer()
+		if got == nil {
+			t.Fatal("ValueStringPointer() on Unknown returned nil; expected *\"\"")
+		}
+		if *got != "" {
+			t.Fatalf("ValueStringPointer() on Unknown returned *%q; expected *\"\"", *got)
+		}
+	})
+
+	t.Run("ValueStringPointer on Null returns nil", func(t *testing.T) {
+		null := types.StringNull()
+		got := null.ValueStringPointer()
+		if got != nil {
+			t.Fatalf("ValueStringPointer() on Null returned *%q; expected nil", *got)
+		}
+	})
+
+	t.Run("ValueFloat64Pointer on Unknown returns *0.0, not nil", func(t *testing.T) {
+		unknown := types.Float64Unknown()
+		got := unknown.ValueFloat64Pointer()
+		if got == nil {
+			t.Fatal("ValueFloat64Pointer() on Unknown returned nil; expected *0.0")
+		}
+		if *got != 0.0 {
+			t.Fatalf("ValueFloat64Pointer() on Unknown returned *%f; expected *0.0", *got)
+		}
+	})
+
+	t.Run("ValueFloat64Pointer on Null returns nil", func(t *testing.T) {
+		null := types.Float64Null()
+		got := null.ValueFloat64Pointer()
+		if got != nil {
+			t.Fatalf("ValueFloat64Pointer() on Null returned *%f; expected nil", *got)
+		}
+	})
+}
+
+// TestPointerAccessorSerialization demonstrates the practical impact: when a
+// struct field uses omitempty, a nil pointer is omitted from the JSON payload
+// but a pointer to zero-value is serialized, sending unintended data to the API.
+func TestPointerAccessorSerialization(t *testing.T) {
+	type apiRequest struct {
+		IncludeCurrent *bool   `json:"include_current,omitempty"`
+		Amount         *int64  `json:"amount,omitempty"`
+		Name           *string `json:"name,omitempty"`
+	}
+
+	t.Run("Null produces omitted fields (correct)", func(t *testing.T) {
+		req := apiRequest{
+			IncludeCurrent: types.BoolNull().ValueBoolPointer(),     // nil
+			Amount:         types.Int64Null().ValueInt64Pointer(),   // nil
+			Name:           types.StringNull().ValueStringPointer(), // nil
+		}
+		b, _ := json.Marshal(req)
+		got := string(b)
+		expected := "{}"
+		if got != expected {
+			t.Fatalf("Null fields should be omitted.\ngot:  %s\nwant: %s", got, expected)
+		}
+	})
+
+	t.Run("Unknown produces zero-value fields (the bug)", func(t *testing.T) {
+		req := apiRequest{
+			IncludeCurrent: types.BoolUnknown().ValueBoolPointer(),     // *false
+			Amount:         types.Int64Unknown().ValueInt64Pointer(),   // *0
+			Name:           types.StringUnknown().ValueStringPointer(), // *""
+		}
+		b, _ := json.Marshal(req)
+		got := string(b)
+		// omitempty on pointer fields only omits nil, not pointers to zero
+		// values. So all three zero-value pointers (*false, *0, *"") are
+		// serialized — sending unintended data to the API.
+		expected := `{"include_current":false,"amount":0,"name":""}`
+		if got != expected {
+			t.Fatalf("Unknown fields should NOT be serialized but they are.\ngot:  %s\nwant: %s", got, expected)
+		}
+	})
+
+	t.Run("Guarded Unknown produces omitted fields (the fix)", func(t *testing.T) {
+		req := apiRequest{}
+		// With guards: only set fields that are Known
+		boolVal := types.BoolUnknown()
+		if !boolVal.IsNull() && !boolVal.IsUnknown() {
+			req.IncludeCurrent = boolVal.ValueBoolPointer()
+		}
+		intVal := types.Int64Unknown()
+		if !intVal.IsNull() && !intVal.IsUnknown() {
+			req.Amount = intVal.ValueInt64Pointer()
+		}
+		strVal := types.StringUnknown()
+		if !strVal.IsNull() && !strVal.IsUnknown() {
+			req.Name = strVal.ValueStringPointer()
+		}
+		b, _ := json.Marshal(req)
+		got := string(b)
+		expected := "{}"
+		if got != expected {
+			t.Fatalf("Guarded Unknown fields should be omitted.\ngot:  %s\nwant: %s", got, expected)
+		}
+	})
+}

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -574,8 +574,12 @@ func (r *reportResource) populateState(ctx context.Context, state *reportResourc
 }
 
 func (plan *reportResourceModel) toCreateRequest(ctx context.Context) (req models.CreateReportJSONRequestBody, diags diag.Diagnostics) {
-	req.Name = plan.Name.ValueStringPointer()
-	req.Description = plan.Description.ValueStringPointer()
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		req.Name = plan.Name.ValueStringPointer()
+	}
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		req.Description = plan.Description.ValueStringPointer()
+	}
 	req.FolderId = plan.FolderId.ValueStringPointer()
 
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
@@ -598,8 +602,12 @@ func (plan *reportResourceModel) toCreateRequest(ctx context.Context) (req model
 }
 
 func (plan *reportResourceModel) toUpdateRequest(ctx context.Context) (req models.UpdateReportJSONRequestBody, diags diag.Diagnostics) {
-	req.Name = plan.Name.ValueStringPointer()
-	req.Description = plan.Description.ValueStringPointer()
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		req.Name = plan.Name.ValueStringPointer()
+	}
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		req.Description = plan.Description.ValueStringPointer()
+	}
 	req.FolderId = plan.FolderId.ValueStringPointer()
 
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
@@ -669,12 +677,20 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	}
 
 	if !config.AdvancedAnalysis.IsNull() && !config.AdvancedAnalysis.IsUnknown() {
-		externalConfig.AdvancedAnalysis = &models.AdvancedAnalysis{
-			Forecast:     config.AdvancedAnalysis.Forecast.ValueBoolPointer(),
-			NotTrending:  config.AdvancedAnalysis.NotTrending.ValueBoolPointer(),
-			TrendingDown: config.AdvancedAnalysis.TrendingDown.ValueBoolPointer(),
-			TrendingUp:   config.AdvancedAnalysis.TrendingUp.ValueBoolPointer(),
+		aa := &models.AdvancedAnalysis{}
+		if !config.AdvancedAnalysis.Forecast.IsNull() && !config.AdvancedAnalysis.Forecast.IsUnknown() {
+			aa.Forecast = config.AdvancedAnalysis.Forecast.ValueBoolPointer()
 		}
+		if !config.AdvancedAnalysis.NotTrending.IsNull() && !config.AdvancedAnalysis.NotTrending.IsUnknown() {
+			aa.NotTrending = config.AdvancedAnalysis.NotTrending.ValueBoolPointer()
+		}
+		if !config.AdvancedAnalysis.TrendingDown.IsNull() && !config.AdvancedAnalysis.TrendingDown.IsUnknown() {
+			aa.TrendingDown = config.AdvancedAnalysis.TrendingDown.ValueBoolPointer()
+		}
+		if !config.AdvancedAnalysis.TrendingUp.IsNull() && !config.AdvancedAnalysis.TrendingUp.IsUnknown() {
+			aa.TrendingUp = config.AdvancedAnalysis.TrendingUp.ValueBoolPointer()
+		}
+		externalConfig.AdvancedAnalysis = aa
 	}
 
 	if !config.CustomTimeRange.IsNull() && !config.CustomTimeRange.IsUnknown() {
@@ -867,9 +883,12 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	}
 
 	if !config.TimeRange.IsNull() && !config.TimeRange.IsUnknown() {
-		ts := &models.TimeSettings{
-			Amount:         config.TimeRange.Amount.ValueInt64Pointer(),
-			IncludeCurrent: config.TimeRange.IncludeCurrent.ValueBoolPointer(),
+		ts := &models.TimeSettings{}
+		if !config.TimeRange.Amount.IsNull() && !config.TimeRange.Amount.IsUnknown() {
+			ts.Amount = config.TimeRange.Amount.ValueInt64Pointer()
+		}
+		if !config.TimeRange.IncludeCurrent.IsNull() && !config.TimeRange.IncludeCurrent.IsUnknown() {
+			ts.IncludeCurrent = config.TimeRange.IncludeCurrent.ValueBoolPointer()
 		}
 		if !config.TimeRange.Mode.IsNull() && !config.TimeRange.Mode.IsUnknown() {
 			mode := models.TimeSettingsMode(config.TimeRange.Mode.ValueString())
@@ -883,9 +902,12 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	}
 
 	if !config.SecondaryTimeRange.IsNull() && !config.SecondaryTimeRange.IsUnknown() {
-		secondaryTimeRange := &models.TimeSettingsSecondary{
-			Amount:         config.SecondaryTimeRange.Amount.ValueInt64Pointer(),
-			IncludeCurrent: config.SecondaryTimeRange.IncludeCurrent.ValueBoolPointer(),
+		secondaryTimeRange := &models.TimeSettingsSecondary{}
+		if !config.SecondaryTimeRange.Amount.IsNull() && !config.SecondaryTimeRange.Amount.IsUnknown() {
+			secondaryTimeRange.Amount = config.SecondaryTimeRange.Amount.ValueInt64Pointer()
+		}
+		if !config.SecondaryTimeRange.IncludeCurrent.IsNull() && !config.SecondaryTimeRange.IncludeCurrent.IsUnknown() {
+			secondaryTimeRange.IncludeCurrent = config.SecondaryTimeRange.IncludeCurrent.ValueBoolPointer()
 		}
 		if !config.SecondaryTimeRange.Unit.IsNull() && !config.SecondaryTimeRange.Unit.IsUnknown() {
 			unit := models.TimeSettingsSecondaryUnit(config.SecondaryTimeRange.Unit.ValueString())

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -5,10 +5,11 @@
 // never be Unknown (Required, Optional without Computed, Optional+Computed with
 // Default). These guards are dead code.
 //
-// Direction 2 (missing guard): flags non-pointer value accessors (ValueString,
-// ValueBool, ValueFloat64, ValueInt64) on Optional+Computed fields without
-// Default when not guarded by IsUnknown(). Pointer accessors (ValueStringPointer
-// etc.) are excluded because they return nil for Unknown, which is often acceptable.
+// Direction 2 (missing guard): flags value accessors (ValueString, ValueBool,
+// ValueFloat64, ValueInt64, and their Pointer variants) on Optional+Computed
+// fields without Default when not guarded by IsUnknown(). Both pointer and
+// non-pointer accessors return zero values for Unknown (pointers return *zero,
+// not nil).
 //
 // The analyzer propagates schema context across function call boundaries:
 // when a builder calls a helper with plan.X as an argument, the helper's
@@ -149,7 +150,7 @@ func analyzeFunction(pass *analysis.Pass, fn *ast.FuncDecl, varSchemas map[strin
 	// Direction 1: Find redundant IsUnknown() guards.
 	checkRedundantGuards(pass, fn.Body, varSchemas)
 
-	// Direction 2: Find missing guards on non-pointer value accessors.
+	// Direction 2: Find missing guards on value accessors.
 	checkMissingGuards(pass, fn.Body, varSchemas)
 
 	// Propagate schema context into helper functions called from this body.
@@ -593,9 +594,9 @@ func checkRedundantGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas m
 	})
 }
 
-// checkMissingGuards walks the function body and flags non-pointer value
-// accessors on Optional+Computed fields without Default when not guarded
-// by an enclosing if-condition with IsUnknown().
+// checkMissingGuards walks the function body and flags value accessors
+// (both pointer and non-pointer) on Optional+Computed fields without Default
+// when not guarded by an enclosing if-condition with IsUnknown().
 func checkMissingGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map[string]map[string]*schemaparser.AttrInfo) {
 	// Build a map from position ranges of if-bodies to the fields they guard.
 	// This allows us to check if a value accessor is inside a guarded scope.

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -40,13 +40,19 @@ var neverUnknownClasses = map[schemaparser.FieldClass]string{
 	schemaparser.Optional: "Optional (not Computed)",
 }
 
-// nonPointerAccessors are value accessors that return zero values for Unknown
-// (not nil), making them unsafe without an IsUnknown() guard.
-var nonPointerAccessors = map[string]bool{
-	"ValueString":  true,
-	"ValueBool":    true,
-	"ValueFloat64": true,
-	"ValueInt64":   true,
+// unsafeAccessors are value accessors that return zero values for Unknown,
+// making them unsafe without an IsUnknown() guard. This includes both
+// non-pointer accessors (which return the zero value directly) and pointer
+// accessors (which return a pointer to the zero value, not nil).
+var unsafeAccessors = map[string]bool{
+	"ValueString":         true,
+	"ValueBool":           true,
+	"ValueFloat64":        true,
+	"ValueInt64":          true,
+	"ValueStringPointer":  true,
+	"ValueBoolPointer":    true,
+	"ValueFloat64Pointer": true,
+	"ValueInt64Pointer":   true,
 }
 
 // attrMap is a convenience alias for field name → AttrInfo maps.
@@ -627,8 +633,8 @@ func checkMissingGuards(pass *analysis.Pass, body *ast.BlockStmt, varSchemas map
 			return true
 		}
 
-		// Check if it's a non-pointer accessor.
-		if !nonPointerAccessors[sel.Sel.Name] {
+		// Check if it's an unsafe accessor.
+		if !unsafeAccessors[sel.Sel.Name] {
 			return true
 		}
 

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
@@ -55,9 +55,9 @@ func (plan *GuardTestModel) toUpdateRequest() ApiRequest {
 	name := plan.FolderId.ValueString() // want `ValueString\(\) on Optional\+Computed field "folder_id" without IsUnknown\(\) guard; field may be Unknown at plan time`
 	_ = name
 
-	// GOOD: Optional+Computed WITHOUT default, ValueStringPointer without guard.
-	// Pointer accessors return nil for Unknown, which is often acceptable.
-	req.FolderId = plan.FolderId.ValueStringPointer()
+	// BAD: Optional+Computed WITHOUT default, ValueStringPointer without guard.
+	// Pointer accessors return a pointer to the zero value for Unknown (*""), not nil.
+	req.FolderId = plan.FolderId.ValueStringPointer() // want `ValueStringPointer\(\) on Optional\+Computed field "folder_id" without IsUnknown\(\) guard; field may be Unknown at plan time`
 
 	// GOOD: Optional+Computed WITH default — no guard needed, ValueString is safe.
 	metric := plan.Metric.ValueString()


### PR DESCRIPTION
## Summary

Pointer accessors (`ValueStringPointer`, `ValueBoolPointer`, `ValueInt64Pointer`, `ValueFloat64Pointer`) return a **pointer to the zero value** for Unknown, not `nil`. This makes them equally unsafe as non-pointer accessors without an `IsUnknown()` guard.

Closes #218

## Changes

### Linter (`tools/linters/requestguard/`)

- Rename `nonPointerAccessors` → `unsafeAccessors`
- Add `ValueStringPointer`, `ValueBoolPointer`, `ValueFloat64Pointer`, `ValueInt64Pointer` to the checked set
- Update test fixture: `ValueStringPointer` without guard now expects a diagnostic

### Findings fixed

**`budget.go` (4):** Added `IsUnknown()` guards for `amount` (Float64Pointer), `name` (StringPointer), `time_interval` (StringPointer), `type` (StringPointer)

**`report.go` (12):** Added `IsUnknown()` guards for:
- `name`, `description` in `toCreateRequest`/`toUpdateRequest`
- `forecast`, `not_trending`, `trending_down`, `trending_up` (BoolPointer) in advanced_analysis
- `amount` (Int64Pointer), `include_current` (BoolPointer) in time_range and secondary_time_range

## SDK Reference

Per the Terraform Plugin Framework SDK:

| Accessor | Null | Unknown | Known |
|---|---|---|---|
| `ValueBoolPointer()` | `nil` | `*false` | `*value` |
| `ValueStringPointer()` | `nil` | `*""` | `*value` |
| `ValueInt64Pointer()` | `nil` | `*0` | `*value` |
| `ValueFloat64Pointer()` | `nil` | `*0.0` | `*value` |

## Validation

- `go test ./requestguard/... -v -count=1` — PASS
- `./custom-gcl run --enable-only=requestguard` — 0 issues
- Pre-commit hooks pass