### PR TITLE
feat(diagdrop): detect captured diags never appended to resp.Diagnostics

### DIFF
--- a/internal/provider/report_validator.go
+++ b/internal/provider/report_validator.go
@@ -141,6 +141,7 @@ func (v reportTimestampValidator) ValidateResource(ctx context.Context, req reso
 	for _, p := range ctrPaths {
 		var ctr resource_report.CustomTimeRangeValue
 		diags := req.Config.GetAttribute(ctx, p, &ctr)
+		resp.Diagnostics.Append(diags...)
 		if diags.HasError() || ctr.IsNull() || ctr.IsUnknown() {
 			continue
 		}

--- a/tools/linters/diagdrop/analyzer.go
+++ b/tools/linters/diagdrop/analyzer.go
@@ -1,6 +1,8 @@
-// Package diagdrop detects leaked diagnostics: functions that capture
-// diag.Diagnostics into a named variable but return nil on some paths,
-// silently dropping non-error diagnostics (e.g. warnings).
+// Package diagdrop detects leaked diagnostics in two directions:
+//
+// Direction 1 (return nil): functions that capture diag.Diagnostics into a
+// named variable but return nil on some paths, silently dropping non-error
+// diagnostics (e.g. warnings).
 //
 // Bad:
 //
@@ -23,6 +25,26 @@
 //
 // Early-return nil guards that precede any diag variable assignment are also
 // excluded (e.g. `if x == nil { return NullValue(), nil }`).
+//
+// Direction 2 (unappended diags): in functions that take a resp parameter with
+// a Diagnostics field (CRUD methods, validators), captured diag.Diagnostics
+// variables that are never appended to resp.Diagnostics or passed to another
+// function are flagged.
+//
+// Bad:
+//
+//	func (v myValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+//	    diags := req.Config.GetAttribute(ctx, p, &val)
+//	    if diags.HasError() { return }  // ← diags never appended to resp.Diagnostics
+//	}
+//
+// Good:
+//
+//	func (v myValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+//	    diags := req.Config.GetAttribute(ctx, p, &val)
+//	    resp.Diagnostics.Append(diags...)  // ← properly propagated
+//	    if diags.HasError() { return }
+//	}
 package diagdrop
 
 import (
@@ -61,11 +83,15 @@ func run(pass *analysis.Pass) (any, error) {
 		switch fn := n.(type) {
 		case *ast.FuncDecl:
 			if fn.Body != nil && fn.Type != nil {
+				// Direction 1: return nil drops captured diags.
 				checkFunc(pass, fn.Type, fn.Body)
+				// Direction 2: captured diags never appended to resp.Diagnostics.
+				checkUnappendedDiags(pass, fn.Type, fn.Body)
 			}
 		case *ast.FuncLit:
 			if fn.Body != nil && fn.Type != nil {
 				checkFunc(pass, fn.Type, fn.Body)
+				checkUnappendedDiags(pass, fn.Type, fn.Body)
 			}
 		}
 	})
@@ -301,4 +327,124 @@ func isDiagnosticsType(t types.Type) bool {
 		return false
 	}
 	return obj.Pkg().Path()+"."+obj.Name() == diagType
+}
+
+// --- Direction 2: unappended diagnostics ---
+
+// checkUnappendedDiags flags captured diag.Diagnostics variables that are never
+// appended to resp.Diagnostics (or passed to another function) in functions
+// that take a resp parameter with a Diagnostics field.
+func checkUnappendedDiags(pass *analysis.Pass, funcType *ast.FuncType, body *ast.BlockStmt) {
+	// Only applies to functions with a resp-style parameter.
+	if !hasRespDiagnosticsParam(pass, funcType) {
+		return
+	}
+
+	// Collect all captured diag.Diagnostics variables in the body.
+	allVars := collectDiagVars(pass, funcType, body)
+	if len(allVars) == 0 {
+		return
+	}
+
+	// Find which variable objects are propagated (appended, passed, or returned).
+	// Uses types.Object identity, not names, to handle same-name variables in
+	// different scopes (e.g., two loops both declaring diags := ...).
+	propagated := collectPropagatedObjects(pass, body)
+
+	// Flag variables that are captured but never propagated.
+	for _, v := range allVars {
+		// Skip named return params — they are implicitly returned.
+		if v.isAccumulator && v.pos == 0 {
+			continue
+		}
+		if v.obj != nil && propagated[v.obj] {
+			continue
+		}
+		pass.Reportf(v.pos,
+			"captured diag.Diagnostics variable %q is never appended to resp.Diagnostics",
+			v.name)
+	}
+}
+
+// hasRespDiagnosticsParam checks if a function has a parameter whose underlying
+// type contains a Diagnostics field of type diag.Diagnostics. This matches
+// resource.CreateResponse, resource.ValidateConfigResponse, etc.
+func hasRespDiagnosticsParam(pass *analysis.Pass, funcType *ast.FuncType) bool {
+	if funcType.Params == nil {
+		return false
+	}
+	for _, field := range funcType.Params.List {
+		typ := pass.TypesInfo.TypeOf(field.Type)
+		if typ == nil {
+			continue
+		}
+		// Unwrap pointer.
+		if ptr, ok := typ.(*types.Pointer); ok {
+			typ = ptr.Elem()
+		}
+		// Check if the struct has a Diagnostics field of type diag.Diagnostics.
+		st, ok := typ.Underlying().(*types.Struct)
+		if !ok {
+			continue
+		}
+		for i := 0; i < st.NumFields(); i++ {
+			f := st.Field(i)
+			if f.Name() == "Diagnostics" && isDiagnosticsType(f.Type()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// collectPropagatedObjects walks a function body and returns the set of
+// types.Object identities that are propagated via:
+//   - *.Append(varName...) calls
+//   - someFunc(varName) or someFunc(varName...) calls (passed as argument)
+//   - return statements that include the variable
+//
+// Using types.Object instead of names ensures that same-name variables in
+// different scopes (e.g., loop iterations) are tracked independently.
+func collectPropagatedObjects(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]bool {
+	result := map[types.Object]bool{}
+
+	ast.Inspect(body, func(n ast.Node) bool {
+		// Skip nested function literals.
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			// Check all arguments (covers both Append and general function calls).
+			for _, arg := range node.Args {
+				if ident, ok := arg.(*ast.Ident); ok {
+					if obj := resolveObject(pass, ident); obj != nil {
+						result[obj] = true
+					}
+				}
+			}
+
+		case *ast.ReturnStmt:
+			for _, expr := range node.Results {
+				if ident, ok := expr.(*ast.Ident); ok {
+					if obj := resolveObject(pass, ident); obj != nil {
+						result[obj] = true
+					}
+				}
+			}
+		}
+
+		return true
+	})
+
+	return result
+}
+
+// resolveObject returns the types.Object for an identifier, preferring Uses over Defs.
+func resolveObject(pass *analysis.Pass, ident *ast.Ident) types.Object {
+	if obj := pass.TypesInfo.Uses[ident]; obj != nil {
+		return obj
+	}
+	return pass.TypesInfo.Defs[ident]
 }

--- a/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
+++ b/tools/linters/diagdrop/testdata/src/diagdroptest/diagdroptest.go
@@ -1,7 +1,10 @@
 package diagdroptest
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 // Stub helpers to simulate Terraform framework calls.
@@ -208,4 +211,108 @@ func goodInnerBlockScope() diag.Diagnostics {
 		}
 	}
 	return nil // Should NOT be flagged
+}
+
+// ============================================================================
+// Direction 2: unappended diagnostics in resp-parameter functions
+// ============================================================================
+
+// Stub to simulate GetAttribute returning diags.
+func getAttribute() diag.Diagnostics {
+	return nil
+}
+
+// Stub to simulate a helper that propagates diags.
+func propagateHelper(d diag.Diagnostics) {}
+
+type myValidator struct{}
+
+// --- BAD: captured diags never appended ---
+
+// badUnappendedDiags captures diags but only uses HasError(), never appends.
+func (v *myValidator) ValidateResource(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	diags := getAttribute() // want `captured diag.Diagnostics variable "diags" is never appended to resp.Diagnostics`
+	if diags.HasError() {
+		return
+	}
+	_ = "do something"
+}
+
+// badUnappendedDiagsInLoop captures diags in a loop without appending.
+func badUnappendedDiagsInLoop(_ resource.CreateRequest, resp *resource.CreateResponse) {
+	paths := []string{"a", "b"}
+	for range paths {
+		diags := getAttribute() // want `captured diag.Diagnostics variable "diags" is never appended to resp.Diagnostics`
+		if diags.HasError() {
+			continue
+		}
+	}
+}
+
+// --- GOOD: diags properly appended ---
+
+// goodAppendedDiags appends diags before checking.
+func goodAppendedDiags(_ resource.ReadRequest, resp *resource.ReadResponse) {
+	diags := getAttribute()
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+}
+
+// goodDiagsPassedToHelper passes diags to another function.
+func goodDiagsPassedToHelper(_ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	diags := getAttribute()
+	propagateHelper(diags)
+	if diags.HasError() {
+		return
+	}
+	_ = resp
+}
+
+// goodDiagsReturned is a function that also returns diags (direction 1 territory).
+func goodDiagsReturned(_ resource.DeleteRequest, _ *resource.DeleteResponse) diag.Diagnostics {
+	diags := getAttribute()
+	if diags.HasError() {
+		return diags
+	}
+	return diags
+}
+
+// goodNoCapture has a resp parameter but never captures diags.
+func goodNoCapture(_ resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(diag.Diagnostics{}...)
+}
+
+// badMixedLoopsSameName has two loops using the same variable name "diags".
+// Loop 1 does NOT append, loop 2 DOES append. Object-based tracking ensures
+// only loop 1's capture is flagged despite the shared name.
+func badMixedLoopsSameName(_ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	paths1 := []string{"a", "b"}
+	for range paths1 {
+		diags := getAttribute() // want `captured diag.Diagnostics variable "diags" is never appended to resp.Diagnostics`
+		if diags.HasError() {
+			continue
+		}
+	}
+
+	paths2 := []string{"c", "d"}
+	for range paths2 {
+		diags := getAttribute()
+		resp.Diagnostics.Append(diags...)
+		if diags.HasError() {
+			continue
+		}
+	}
+}
+
+// --- Scope guard: Direction 2 should NOT fire for non-resp functions ---
+
+// goodNotRespFunction captures diags but has no resp parameter — only Direction 1 applies.
+func goodNotRespFunction() diag.Diagnostics {
+	diags := getAttribute()
+	if diags.HasError() {
+		return diags
+	}
+	return nil // want "return nil drops captured diag.Diagnostics variable \"diags\"; return diags instead"
 }

--- a/tools/linters/diagdrop/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/resource.go
+++ b/tools/linters/diagdrop/testdata/src/github.com/hashicorp/terraform-plugin-framework/resource/resource.go
@@ -1,0 +1,47 @@
+// Package resource is a stub of github.com/hashicorp/terraform-plugin-framework/resource
+// for use in analysistest test fixtures.
+package resource
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// ValidateConfigRequest is a stub request type.
+type ValidateConfigRequest struct{}
+
+// ValidateConfigResponse is a stub response type with Diagnostics.
+type ValidateConfigResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+// CreateRequest is a stub request type.
+type CreateRequest struct{}
+
+// CreateResponse is a stub response type with Diagnostics.
+type CreateResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+// ReadRequest is a stub request type.
+type ReadRequest struct{}
+
+// ReadResponse is a stub response type with Diagnostics.
+type ReadResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+// UpdateRequest is a stub request type.
+type UpdateRequest struct{}
+
+// UpdateResponse is a stub response type with Diagnostics.
+type UpdateResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+// DeleteRequest is a stub request type.
+type DeleteRequest struct{}
+
+// DeleteResponse is a stub response type with Diagnostics.
+type DeleteResponse struct {
+	Diagnostics diag.Diagnostics
+}


### PR DESCRIPTION
## Summary

Extends the `diagdrop` linter with **Direction 2**: detect captured `diag.Diagnostics` variables that are never appended to `resp.Diagnostics` in CRUD/validator functions.

Closes #220

## Problem

`diagdrop` Direction 1 catches `return nil` that drops captured diags, but misses a sibling pattern: captured diags used only in `HasError()` checks without being appended to `resp.Diagnostics`.

```go
// BAD: diags silently dropped
diags := req.Config.GetAttribute(ctx, p, &ctr)
if diags.HasError() {  // ← only checks, never appends
    continue
}
```

## Changes

### Linter (`tools/linters/diagdrop/`)

- Add `checkUnappendedDiags` — scoped to functions with a resp parameter containing a `Diagnostics` field
- Add `hasRespDiagnosticsParam` — type-checked struct field lookup (covers all CRUD/validator response types)
- Add `collectPropagatedObjects` — tracks propagation by `types.Object` identity (not variable names) to correctly handle same-name variables in different scopes
- Add stub `resource` package for test fixtures
- Test cases: unappended diags, loop patterns, mixed loops with same name, helper propagation, return propagation, scope guards

### Finding fixed

**`report_validator.go:143`**: Added `resp.Diagnostics.Append(diags...)` before `HasError()` check in the `ctrPaths` loop.

## Design Decision: Object-Based Tracking

Name-based tracking (`map[string]bool`) would miss bugs when the same variable name appears in multiple scopes — e.g., two loops both using `diags :=`, where one appends and one doesn't. The first version of this linter had exactly this bug. Object-based tracking (`map[types.Object]bool`) resolves each identifier to its unique declaration, ensuring independent tracking.

## Validation

- `go test ./diagdrop/... -v -count=1` — PASS
- `./custom-gcl run --enable-only=diagdrop` — 0 issues (after fix)
- Pre-commit hooks pass