### PR TITLE
fix(linters): newexpr nested blocks + requestguard data source schemas

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,7 +130,6 @@ linters:
           - usestatefunknown
           - crudnaming
           - methodreceiver
-          - requestguard
       # Provider config — not a resource, no plan modifiers
       - path: provider\.go
         linters:

--- a/internal/provider/alert.go
+++ b/internal/provider/alert.go
@@ -175,28 +175,23 @@ func (plan *alertResourceModel) toAlertConfig(ctx context.Context) (config model
 
 	// Optional fields
 	if !configVal.Condition.IsNull() {
-		condition := models.Condition(configVal.Condition.ValueString())
-		config.Condition = &condition
+		config.Condition = new(models.Condition(configVal.Condition.ValueString()))
 	}
 
 	if !configVal.Currency.IsNull() && !configVal.Currency.IsUnknown() {
-		currency := models.Currency(configVal.Currency.ValueString())
-		config.Currency = &currency
+		config.Currency = new(models.Currency(configVal.Currency.ValueString()))
 	}
 
 	if !configVal.DataSource.IsNull() {
-		dataSource := models.AlertConfigDataSource(configVal.DataSource.ValueString())
-		config.DataSource = &dataSource
+		config.DataSource = new(models.AlertConfigDataSource(configVal.DataSource.ValueString()))
 	}
 
 	if !configVal.EvaluateForEach.IsNull() && !configVal.EvaluateForEach.IsUnknown() {
-		evaluateForEach := configVal.EvaluateForEach.ValueString()
-		config.EvaluateForEach = &evaluateForEach
+		config.EvaluateForEach = new(configVal.EvaluateForEach.ValueString())
 	}
 
 	if !configVal.Operator.IsNull() && !configVal.Operator.IsUnknown() {
-		operator := models.MetricFilterText(configVal.Operator.ValueString())
-		config.Operator = &operator
+		config.Operator = new(models.MetricFilterText(configVal.Operator.ValueString()))
 	}
 
 	// Attributions

--- a/internal/provider/asset_resource.go
+++ b/internal/provider/asset_resource.go
@@ -183,8 +183,7 @@ func (r *assetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	// Build the update request body
 	updateBody := models.IdOfAssetJSONRequestBody{}
 	if !plan.Quantity.IsNull() && !plan.Quantity.IsUnknown() {
-		q := plan.Quantity.ValueInt64()
-		updateBody.Quantity = &q
+		updateBody.Quantity = new(plan.Quantity.ValueInt64())
 	}
 
 	// Call PATCH

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -207,10 +207,9 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 
 		reqCollaborators := make([]models.Collaborator, len(collaborators))
 		for i, collaborator := range collaborators {
-			role := models.CollaboratorRole(collaborator.Role.ValueString())
 			reqCollaborators[i] = models.Collaborator{
 				Email: collaborator.Email.ValueStringPointer(),
-				Role:  &role,
+				Role:  new(models.CollaboratorRole(collaborator.Role.ValueString())),
 			}
 		}
 		req.Collaborators = &reqCollaborators
@@ -221,8 +220,7 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 		req.Amount = plan.Amount.ValueFloat64Pointer()
 	}
 	if !plan.Currency.IsNull() && !plan.Currency.IsUnknown() {
-		currency := models.Currency(plan.Currency.ValueString())
-		req.Currency = &currency
+		req.Currency = new(models.Currency(plan.Currency.ValueString()))
 	}
 	req.Description = plan.Description.ValueStringPointer()
 
@@ -233,16 +231,14 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 
 	req.GrowthPerPeriod = plan.GrowthPerPeriod.ValueFloat64Pointer()
 	if !plan.Metric.IsNull() {
-		metric := models.BudgetCreateUpdateRequestMetric(plan.Metric.ValueString())
-		req.Metric = &metric
+		req.Metric = new(models.BudgetCreateUpdateRequestMetric(plan.Metric.ValueString()))
 	}
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
 		req.Name = plan.Name.ValueStringPointer()
 	}
 
 	if !plan.Public.IsNull() && !plan.Public.IsUnknown() {
-		public := models.BudgetCreateUpdateRequestPublic(plan.Public.ValueString())
-		req.Public = &public
+		req.Public = new(models.BudgetCreateUpdateRequestPublic(plan.Public.ValueString()))
 	}
 
 	if !plan.Recipients.IsNull() && !plan.Recipients.IsUnknown() {

--- a/internal/provider/insight_resource.go
+++ b/internal/provider/insight_resource.go
@@ -139,38 +139,31 @@ func (plan *insightResourceModel) toInsightRequest(ctx context.Context) (*models
 
 	// Optional fields
 	if !plan.DetailedDescriptionMdx.IsNull() && !plan.DetailedDescriptionMdx.IsUnknown() {
-		v := plan.DetailedDescriptionMdx.ValueString()
-		req.DetailedDescriptionMdx = &v
+		req.DetailedDescriptionMdx = new(plan.DetailedDescriptionMdx.ValueString())
 	}
 	if !plan.EasyWinDescription.IsNull() && !plan.EasyWinDescription.IsUnknown() {
-		v := plan.EasyWinDescription.ValueString()
-		req.EasyWinDescription = &v
+		req.EasyWinDescription = new(plan.EasyWinDescription.ValueString())
 	}
 	if !plan.ReportUrl.IsNull() && !plan.ReportUrl.IsUnknown() {
-		v := plan.ReportUrl.ValueString()
-		req.ReportUrl = &v
+		req.ReportUrl = new(plan.ReportUrl.ValueString())
 	}
 	if !plan.CloudFlowTemplateId.IsNull() && !plan.CloudFlowTemplateId.IsUnknown() {
-		v := plan.CloudFlowTemplateId.ValueString()
-		req.CloudFlowTemplateId = &v
+		req.CloudFlowTemplateId = new(plan.CloudFlowTemplateId.ValueString())
 	}
 
 	// Status (Optional+Computed) — sets the display status inline
 	if !plan.Status.IsNull() && !plan.Status.IsUnknown() {
-		v := models.DisplayStatus(plan.Status.ValueString())
-		req.Status = &v
+		req.Status = new(models.DisplayStatus(plan.Status.ValueString()))
 	}
 
 	// DismissalDetails (Optional+Computed) — required when status is "dismissed"
 	if !plan.DismissalDetails.IsNull() && !plan.DismissalDetails.IsUnknown() {
 		dd := models.DismissalDetails{}
 		if !plan.DismissalDetails.Comment.IsNull() && !plan.DismissalDetails.Comment.IsUnknown() {
-			v := plan.DismissalDetails.Comment.ValueString()
-			dd.Comment = &v
+			dd.Comment = new(plan.DismissalDetails.Comment.ValueString())
 		}
 		if !plan.DismissalDetails.Reason.IsNull() && !plan.DismissalDetails.Reason.IsUnknown() {
-			v := models.DismissalDetailsReason(plan.DismissalDetails.Reason.ValueString())
-			dd.Reason = &v
+			dd.Reason = new(models.DismissalDetailsReason(plan.DismissalDetails.Reason.ValueString()))
 		}
 		req.DismissalDetails = &dd
 	}

--- a/internal/provider/insight_resource_results_resource.go
+++ b/internal/provider/insight_resource_results_resource.go
@@ -144,56 +144,44 @@ func (plan *insightResourceResultsModel) toResourceResultsRequest(ctx context.Co
 		}
 
 		if !elem.Location.IsNull() && !elem.Location.IsUnknown() {
-			v := elem.Location.ValueString()
-			apiResult.Location = &v
+			apiResult.Location = new(elem.Location.ValueString())
 		}
 		if !elem.ExternalId.IsNull() && !elem.ExternalId.IsUnknown() {
-			v := elem.ExternalId.ValueString()
-			apiResult.ExternalId = &v
+			apiResult.ExternalId = new(elem.ExternalId.ValueString())
 		}
 		if !elem.ExternalUrl.IsNull() && !elem.ExternalUrl.IsUnknown() {
-			v := elem.ExternalUrl.ValueString()
-			apiResult.ExternalUrl = &v
+			apiResult.ExternalUrl = new(elem.ExternalUrl.ValueString())
 		}
 		if !elem.ResourceType.IsNull() && !elem.ResourceType.IsUnknown() {
-			v := elem.ResourceType.ValueString()
-			apiResult.ResourceType = &v
+			apiResult.ResourceType = new(elem.ResourceType.ValueString())
 		}
 
 		// Result object
 		if !elem.Result.IsNull() && !elem.Result.IsUnknown() {
 			result := &models.ResourceResultRequestResult{}
 			if !elem.Result.Value.IsNull() && !elem.Result.Value.IsUnknown() {
-				val64 := elem.Result.Value.ValueFloat64()
-				result.Value = &val64
+				result.Value = new(elem.Result.Value.ValueFloat64())
 			}
 			if !elem.Result.Current.IsNull() && !elem.Result.Current.IsUnknown() {
-				v := elem.Result.Current.ValueString()
-				result.Current = &v
+				result.Current = new(elem.Result.Current.ValueString())
 			}
 			if !elem.Result.Recommendation.IsNull() && !elem.Result.Recommendation.IsUnknown() {
-				v := elem.Result.Recommendation.ValueString()
-				result.Recommendation = &v
+				result.Recommendation = new(elem.Result.Recommendation.ValueString())
 			}
 			if !elem.Result.AgentInstalled.IsNull() && !elem.Result.AgentInstalled.IsUnknown() {
-				v := elem.Result.AgentInstalled.ValueBool()
-				result.AgentInstalled = &v
+				result.AgentInstalled = new(elem.Result.AgentInstalled.ValueBool())
 			}
 			if !elem.Result.Critical.IsNull() && !elem.Result.Critical.IsUnknown() {
-				v := int(elem.Result.Critical.ValueInt64())
-				result.Critical = &v
+				result.Critical = new(int(elem.Result.Critical.ValueInt64()))
 			}
 			if !elem.Result.High.IsNull() && !elem.Result.High.IsUnknown() {
-				v := int(elem.Result.High.ValueInt64())
-				result.High = &v
+				result.High = new(int(elem.Result.High.ValueInt64()))
 			}
 			if !elem.Result.Medium.IsNull() && !elem.Result.Medium.IsUnknown() {
-				v := int(elem.Result.Medium.ValueInt64())
-				result.Medium = &v
+				result.Medium = new(int(elem.Result.Medium.ValueInt64()))
 			}
 			if !elem.Result.Low.IsNull() && !elem.Result.Low.IsUnknown() {
-				v := int(elem.Result.Low.ValueInt64())
-				result.Low = &v
+				result.Low = new(int(elem.Result.Low.ValueInt64()))
 			}
 			apiResult.Result = result
 		}

--- a/internal/provider/label_assignments_resource.go
+++ b/internal/provider/label_assignments_resource.go
@@ -160,9 +160,8 @@ func (r *labelAssignmentsResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	if len(assignments) > 0 {
-		apiObjs := toAPIAssignments(assignments)
 		apiReq := models.AssignObjectsToLabelJSONRequestBody{
-			Add: &apiObjs,
+			Add: new(toAPIAssignments(assignments)),
 		}
 
 		assignResp, err := r.client.AssignObjectsToLabelWithResponse(ctx, plan.LabelId.ValueString(), apiReq)
@@ -274,12 +273,10 @@ func (r *labelAssignmentsResource) Update(ctx context.Context, req resource.Upda
 		apiReq := models.AssignObjectsToLabelJSONRequestBody{}
 
 		if len(toAdd) > 0 {
-			addObjs := toAPIAssignments(toAdd)
-			apiReq.Add = &addObjs
+			apiReq.Add = new(toAPIAssignments(toAdd))
 		}
 		if len(toRemove) > 0 {
-			removeObjs := toAPIAssignments(toRemove)
-			apiReq.Remove = &removeObjs
+			apiReq.Remove = new(toAPIAssignments(toRemove))
 		}
 
 		updateResp, err := r.client.AssignObjectsToLabelWithResponse(ctx, plan.LabelId.ValueString(), apiReq)
@@ -327,9 +324,8 @@ func (r *labelAssignmentsResource) Delete(ctx context.Context, req resource.Dele
 	}
 
 	if len(assignments) > 0 {
-		apiObjs := toAPIAssignments(assignments)
 		apiReq := models.AssignObjectsToLabelJSONRequestBody{
-			Remove: &apiObjs,
+			Remove: new(toAPIAssignments(assignments)),
 		}
 
 		removeResp, err := r.client.AssignObjectsToLabelWithResponse(ctx, state.LabelId.ValueString(), apiReq)

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -639,41 +639,32 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	// function works both in the resource context (where defaults populate
 	// these fields) and in the data source context (where they may be omitted).
 	if !config.Aggregation.IsNull() && !config.Aggregation.IsUnknown() {
-		aggregation := models.ExternalConfigAggregation(config.Aggregation.ValueString())
-		externalConfig.Aggregation = &aggregation
+		externalConfig.Aggregation = new(models.ExternalConfigAggregation(config.Aggregation.ValueString()))
 	}
 	if !config.Currency.IsNull() && !config.Currency.IsUnknown() {
-		currency := models.Currency(config.Currency.ValueString())
-		externalConfig.Currency = &currency
+		externalConfig.Currency = new(models.Currency(config.Currency.ValueString()))
 	}
 	if !config.DisplayValues.IsNull() && !config.DisplayValues.IsUnknown() {
-		displayValues := models.ExternalConfigDisplayValues(config.DisplayValues.ValueString())
-		externalConfig.DisplayValues = &displayValues
+		externalConfig.DisplayValues = new(models.ExternalConfigDisplayValues(config.DisplayValues.ValueString()))
 	}
 	if !config.IncludePromotionalCredits.IsNull() && !config.IncludePromotionalCredits.IsUnknown() {
-		includePromotionalCredits := config.IncludePromotionalCredits.ValueBool()
-		externalConfig.IncludePromotionalCredits = &includePromotionalCredits
+		externalConfig.IncludePromotionalCredits = new(config.IncludePromotionalCredits.ValueBool())
 	}
 	if !config.Layout.IsNull() && !config.Layout.IsUnknown() {
-		layout := models.ExternalRenderer(config.Layout.ValueString())
-		externalConfig.Layout = &layout
+		externalConfig.Layout = new(models.ExternalRenderer(config.Layout.ValueString()))
 	}
 	if !config.SortDimensions.IsNull() {
-		sortDimensions := models.ExternalConfigSortDimensions(config.SortDimensions.ValueString())
-		externalConfig.SortDimensions = &sortDimensions
+		externalConfig.SortDimensions = new(models.ExternalConfigSortDimensions(config.SortDimensions.ValueString()))
 	}
 	if !config.SortGroups.IsNull() {
-		sortGroups := models.ExternalConfigSortGroups(config.SortGroups.ValueString())
-		externalConfig.SortGroups = &sortGroups
+		externalConfig.SortGroups = new(models.ExternalConfigSortGroups(config.SortGroups.ValueString()))
 	}
 	if !config.TimeInterval.IsNull() && !config.TimeInterval.IsUnknown() {
-		timeInterval := models.ExternalConfigTimeInterval(config.TimeInterval.ValueString())
-		externalConfig.TimeInterval = &timeInterval
+		externalConfig.TimeInterval = new(models.ExternalConfigTimeInterval(config.TimeInterval.ValueString()))
 	}
 
 	if !config.DataSource.IsNull() && !config.DataSource.IsUnknown() {
-		dataSource := models.ExternalConfigDataSource(config.DataSource.ValueString())
-		externalConfig.DataSource = &dataSource
+		externalConfig.DataSource = new(models.ExternalConfigDataSource(config.DataSource.ValueString()))
 	}
 
 	if !config.AdvancedAnalysis.IsNull() && !config.AdvancedAnalysis.IsUnknown() {
@@ -720,10 +711,9 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 		if !diags.HasError() {
 			externalDimensions := make([]models.Dimension, len(dimensions))
 			for i, d := range dimensions {
-				dimType := models.DimensionsTypes(d.DimensionsType.ValueString())
 				externalDimensions[i] = models.Dimension{
 					Id:   d.Id.ValueStringPointer(),
-					Type: &dimType,
+					Type: new(models.DimensionsTypes(d.DimensionsType.ValueString())),
 				}
 			}
 			externalConfig.Dimensions = &externalDimensions
@@ -764,16 +754,14 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 		if !diags.HasError() {
 			externalGroups := make([]models.Group, len(groups))
 			for i, g := range groups {
-				groupType := models.DimensionsTypes(g.GroupType.ValueString())
 				externalGroups[i] = models.Group{
 					Id:   g.Id.ValueStringPointer(),
-					Type: &groupType,
+					Type: new(models.DimensionsTypes(g.GroupType.ValueString())),
 				}
 				if !g.Limit.IsNull() && !g.Limit.IsUnknown() {
 					limit := models.Limit{}
 					if !g.Limit.Sort.IsNull() && !g.Limit.Sort.IsUnknown() {
-						sort := models.LimitSort(g.Limit.Sort.ValueString())
-						limit.Sort = &sort
+						limit.Sort = new(models.LimitSort(g.Limit.Sort.ValueString()))
 					}
 					if !g.Limit.Value.IsNull() && !g.Limit.Value.IsUnknown() {
 						limit.Value = g.Limit.Value.ValueInt64Pointer()
@@ -807,8 +795,7 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 			for i, m := range metricsValues {
 				externalMetrics[i] = models.ExternalMetric{}
 				if !m.MetricsType.IsNull() && !m.MetricsType.IsUnknown() {
-					mType := models.ExternalMetricType(m.MetricsType.ValueString())
-					externalMetrics[i].Type = &mType
+					externalMetrics[i].Type = new(models.ExternalMetricType(m.MetricsType.ValueString()))
 				}
 				if !m.Value.IsNull() && !m.Value.IsUnknown() {
 					externalMetrics[i].Value = m.Value.ValueStringPointer()
@@ -834,8 +821,7 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 			externalConfig.MetricFilter.Values = &values
 		}
 		if !config.MetricFilter.Operator.IsNull() && !config.MetricFilter.Operator.IsUnknown() {
-			operator := models.ExternalConfigMetricFilterOperator(config.MetricFilter.Operator.ValueString())
-			externalConfig.MetricFilter.Operator = &operator
+			externalConfig.MetricFilter.Operator = new(models.ExternalConfigMetricFilterOperator(config.MetricFilter.Operator.ValueString()))
 		}
 	}
 
@@ -845,19 +831,16 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 		if !diags.HasError() {
 			externalSplits := make([]models.ExternalSplit, len(splits))
 			for i, s := range splits {
-				splitMode := models.ExternalSplitMode(s.Mode.ValueString())
-				splitType := models.ExternalSplitType(s.SplitsType.ValueString())
 				externalSplits[i] = models.ExternalSplit{
 					Id:            s.Id.ValueStringPointer(),
 					IncludeOrigin: s.IncludeOrigin.ValueBoolPointer(),
-					Mode:          &splitMode,
-					Type:          &splitType,
+					Mode:          new(models.ExternalSplitMode(s.Mode.ValueString())),
+					Type:          new(models.ExternalSplitType(s.SplitsType.ValueString())),
 				}
 				if !s.Origin.IsNull() && !s.Origin.IsUnknown() {
-					originType := models.ExternalOriginType(s.Origin.OriginType.ValueString())
 					externalSplits[i].Origin = &models.ExternalOrigin{
 						Id:   s.Origin.Id.ValueStringPointer(),
-						Type: &originType,
+						Type: new(models.ExternalOriginType(s.Origin.OriginType.ValueString())),
 					}
 				}
 				if !s.Targets.IsNull() && !s.Targets.IsUnknown() {
@@ -868,10 +851,9 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 					}
 					externalTargets := make([]models.ExternalSplitTarget, len(targets))
 					for j, t := range targets {
-						targetType := models.ExternalSplitTargetType(t.TargetsType.ValueString())
 						externalTargets[j] = models.ExternalSplitTarget{
 							Id:    t.Id.ValueStringPointer(),
-							Type:  &targetType,
+							Type:  new(models.ExternalSplitTargetType(t.TargetsType.ValueString())),
 							Value: t.Value.ValueFloat64Pointer(),
 						}
 					}
@@ -891,12 +873,10 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 			ts.IncludeCurrent = config.TimeRange.IncludeCurrent.ValueBoolPointer()
 		}
 		if !config.TimeRange.Mode.IsNull() && !config.TimeRange.Mode.IsUnknown() {
-			mode := models.TimeSettingsMode(config.TimeRange.Mode.ValueString())
-			ts.Mode = &mode
+			ts.Mode = new(models.TimeSettingsMode(config.TimeRange.Mode.ValueString()))
 		}
 		if !config.TimeRange.Unit.IsNull() && !config.TimeRange.Unit.IsUnknown() {
-			unit := models.TimeSettingsUnit(config.TimeRange.Unit.ValueString())
-			ts.Unit = &unit
+			ts.Unit = new(models.TimeSettingsUnit(config.TimeRange.Unit.ValueString()))
 		}
 		externalConfig.TimeRange = ts
 	}
@@ -910,8 +890,7 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 			secondaryTimeRange.IncludeCurrent = config.SecondaryTimeRange.IncludeCurrent.ValueBoolPointer()
 		}
 		if !config.SecondaryTimeRange.Unit.IsNull() && !config.SecondaryTimeRange.Unit.IsUnknown() {
-			unit := models.TimeSettingsSecondaryUnit(config.SecondaryTimeRange.Unit.ValueString())
-			secondaryTimeRange.Unit = &unit
+			secondaryTimeRange.Unit = new(models.TimeSettingsSecondaryUnit(config.SecondaryTimeRange.Unit.ValueString()))
 		}
 		if !config.SecondaryTimeRange.CustomTimeRange.IsNull() && !config.SecondaryTimeRange.CustomTimeRange.IsUnknown() {
 			ctr := models.TimeSettingsSecondaryCustomTimeRange{}
@@ -939,24 +918,19 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 	if !config.DisplaySettings.IsNull() && !config.DisplaySettings.IsUnknown() {
 		ds := &models.ExternalDisplaySettings{}
 		if !config.DisplaySettings.AxisLabelFontSize.IsNull() && !config.DisplaySettings.AxisLabelFontSize.IsUnknown() {
-			v := models.ExternalDisplaySettingsAxisLabelFontSize(config.DisplaySettings.AxisLabelFontSize.ValueString())
-			ds.AxisLabelFontSize = &v
+			ds.AxisLabelFontSize = new(models.ExternalDisplaySettingsAxisLabelFontSize(config.DisplaySettings.AxisLabelFontSize.ValueString()))
 		}
 		if !config.DisplaySettings.DataLabelFontSize.IsNull() && !config.DisplaySettings.DataLabelFontSize.IsUnknown() {
-			v := models.ExternalDisplaySettingsDataLabelFontSize(config.DisplaySettings.DataLabelFontSize.ValueString())
-			ds.DataLabelFontSize = &v
+			ds.DataLabelFontSize = new(models.ExternalDisplaySettingsDataLabelFontSize(config.DisplaySettings.DataLabelFontSize.ValueString()))
 		}
 		if !config.DisplaySettings.DecimalPrecision.IsNull() && !config.DisplaySettings.DecimalPrecision.IsUnknown() {
-			v := int(config.DisplaySettings.DecimalPrecision.ValueInt64())
-			ds.DecimalPrecision = &v
+			ds.DecimalPrecision = new(int(config.DisplaySettings.DecimalPrecision.ValueInt64()))
 		}
 		if !config.DisplaySettings.NumberScale.IsNull() && !config.DisplaySettings.NumberScale.IsUnknown() {
-			v := models.ExternalDisplaySettingsNumberScale(config.DisplaySettings.NumberScale.ValueString())
-			ds.NumberScale = &v
+			ds.NumberScale = new(models.ExternalDisplaySettingsNumberScale(config.DisplaySettings.NumberScale.ValueString()))
 		}
 		if !config.DisplaySettings.ThemeId.IsNull() {
-			v := config.DisplaySettings.ThemeId.ValueString()
-			ds.ThemeId = &v
+			ds.ThemeId = new(config.DisplaySettings.ThemeId.ValueString())
 		}
 		externalConfig.DisplaySettings = ds
 	}
@@ -1301,8 +1275,7 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 				groupType = normalizeDimensionsType(groupType, existingGroupTypes[i])
 			}
 			if groupID != nil && i < len(existingGroupIDs) {
-				normalized := normalizeDimensionsType(*groupID, existingGroupIDs[i])
-				groupID = &normalized
+				groupID = new(normalizeDimensionsType(*groupID, existingGroupIDs[i]))
 			}
 			m := map[string]attr.Value{
 				"id":   types.StringPointerValue(groupID),
@@ -1593,12 +1566,10 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 func baseTypeObjectValueToExternalMetric(metricValue resource_report.MetricValue) (metric *models.ExternalMetric) {
 	metric = &models.ExternalMetric{}
 	if !metricValue.MetricType.IsNull() {
-		tString := models.ExternalMetricType(metricValue.MetricType.ValueString())
-		metric.Type = &tString
+		metric.Type = new(models.ExternalMetricType(metricValue.MetricType.ValueString()))
 	}
 	if !metricValue.Value.IsNull() && !metricValue.Value.IsUnknown() {
-		vString := metricValue.Value.ValueString()
-		metric.Value = &vString
+		metric.Value = new(metricValue.Value.ValueString())
 	}
 	return metric
 }

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -245,10 +245,9 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 	if config.Dimensions != nil {
 		dims := make([]attr.Value, len(*config.Dimensions))
 		for i, dim := range *config.Dimensions {
-			dType := string(*dim.Type)
 			m := map[string]attr.Value{
 				"id":   types.StringPointerValue(dim.Id),
-				"type": types.StringPointerValue(&dType),
+				"type": types.StringPointerValue(new(string(*dim.Type))),
 			}
 			dimVal, dimDiags := datasource_report.NewDimensionsValue(datasource_report.DimensionsValue{}.AttributeTypes(ctx), m)
 			diags.Append(dimDiags...)
@@ -303,10 +302,9 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 	if config.Group != nil {
 		groups := make([]attr.Value, len(*config.Group))
 		for i, g := range *config.Group {
-			groupType := string(*g.Type)
 			m := map[string]attr.Value{
 				"id":   types.StringPointerValue(g.Id),
-				"type": types.StringPointerValue(&groupType),
+				"type": types.StringPointerValue(new(string(*g.Type))),
 			}
 			m["limit"] = datasource_report.NewLimitValueNull()
 

--- a/tools/linters/newexpr/analyzer.go
+++ b/tools/linters/newexpr/analyzer.go
@@ -54,7 +54,8 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// checkBlock scans a block's statements for the temp-var-then-address pattern.
+// checkBlock scans a block's statements for the temp-var-then-address pattern
+// and recurses into nested blocks (if, for, switch, etc.).
 func checkBlock(pass *analysis.Pass, block *ast.BlockStmt) {
 	for i := 0; i < len(block.List); i++ {
 		// Match: x := expr (short var decl, single LHS, single RHS)
@@ -105,6 +106,69 @@ func checkBlock(pass *analysis.Pass, block *ast.BlockStmt) {
 				exprString(assign.Rhs[0]), ident.Name, ident.Name)
 		}
 	}
+
+	// Recurse into nested blocks (if, for, switch, range, select).
+	for _, stmt := range block.List {
+		for _, child := range childBlocks(stmt) {
+			checkBlock(pass, child)
+		}
+	}
+}
+
+// childBlocks extracts nested BlockStmt nodes from control-flow statements.
+func childBlocks(stmt ast.Stmt) []*ast.BlockStmt {
+	var blocks []*ast.BlockStmt
+	switch s := stmt.(type) {
+	case *ast.IfStmt:
+		if s.Body != nil {
+			blocks = append(blocks, s.Body)
+		}
+		if s.Else != nil {
+			// else if or else block.
+			if elseBlock, ok := s.Else.(*ast.BlockStmt); ok {
+				blocks = append(blocks, elseBlock)
+			} else if elseIf, ok := s.Else.(*ast.IfStmt); ok {
+				blocks = append(blocks, childBlocks(elseIf)...)
+			}
+		}
+	case *ast.ForStmt:
+		if s.Body != nil {
+			blocks = append(blocks, s.Body)
+		}
+	case *ast.RangeStmt:
+		if s.Body != nil {
+			blocks = append(blocks, s.Body)
+		}
+	case *ast.SwitchStmt:
+		if s.Body != nil {
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					// Case clauses don't have a BlockStmt, but their Body is []Stmt.
+					// Wrap in a synthetic block for scanning.
+					blocks = append(blocks, &ast.BlockStmt{List: cc.Body})
+				}
+			}
+		}
+	case *ast.TypeSwitchStmt:
+		if s.Body != nil {
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CaseClause); ok {
+					blocks = append(blocks, &ast.BlockStmt{List: cc.Body})
+				}
+			}
+		}
+	case *ast.SelectStmt:
+		if s.Body != nil {
+			for _, clause := range s.Body.List {
+				if cc, ok := clause.(*ast.CommClause); ok {
+					blocks = append(blocks, &ast.BlockStmt{List: cc.Body})
+				}
+			}
+		}
+	case *ast.BlockStmt:
+		blocks = append(blocks, s)
+	}
+	return blocks
 }
 
 // exprString returns a short human-readable representation of an expression.

--- a/tools/linters/newexpr/testdata/src/newexprtest/newexprtest.go
+++ b/tools/linters/newexpr/testdata/src/newexprtest/newexprtest.go
@@ -51,3 +51,60 @@ func goodCompositeLit() {
 	s := myStruct{}
 	_ = &s
 }
+
+// BAD: temp var inside if block
+func badInsideIf() {
+	var p params
+	var d data
+	if true {
+		filter := d.ValueString() // want `use new\(d.ValueString\(\.\.\.\)\) instead of temp variable "filter" then \&filter`
+		p.Filter = &filter
+	}
+	_ = p
+}
+
+// BAD: temp var inside for loop
+func badInsideFor() {
+	var p params
+	var d data
+	for i := 0; i < 1; i++ {
+		sortBy := d.ValueString() // want `use new\(d.ValueString\(\.\.\.\)\) instead of temp variable "sortBy" then \&sortBy`
+		p.SortBy = &sortBy
+	}
+	_ = p
+}
+
+// BAD: temp var inside range loop
+func badInsideRange() {
+	var p params
+	for range []int{1} {
+		name := "hello" // want `use new\(expr\) instead of temp variable "name" then \&name`
+		p.Name = &name
+	}
+	_ = p
+}
+
+// BAD: temp var in deeply nested blocks
+func badDeeplyNested() {
+	var p params
+	var d data
+	if true {
+		if true {
+			filter := d.ValueString() // want `use new\(d.ValueString\(\.\.\.\)\) instead of temp variable "filter" then \&filter`
+			p.Filter = &filter
+		}
+	}
+	_ = p
+}
+
+// GOOD: variable used elsewhere inside nested block
+func goodUsedElsewhereNested() {
+	var p params
+	var d data
+	if true {
+		filter := d.ValueString()
+		_ = filter // used here
+		p.Filter = &filter
+	}
+	_ = p
+}

--- a/tools/linters/newexpr/testdata/src/newexprtest/newexprtest.go
+++ b/tools/linters/newexpr/testdata/src/newexprtest/newexprtest.go
@@ -108,3 +108,38 @@ func goodUsedElsewhereNested() {
 	}
 	_ = p
 }
+
+// BAD: temp var in else block
+func badInsideElse() {
+	var p params
+	var d data
+	if false {
+		_ = d
+	} else {
+		filter := d.ValueString() // want `use new\(d.ValueString\(\.\.\.\)\) instead of temp variable "filter" then \&filter`
+		p.Filter = &filter
+	}
+	_ = p
+}
+
+// BAD: temp var in switch case
+func badInsideSwitch(x int) {
+	var p params
+	switch x {
+	case 1:
+		name := "hello" // want `use new\(expr\) instead of temp variable "name" then \&name`
+		p.Name = &name
+	}
+	_ = p
+}
+
+// BAD: temp var in type switch case
+func badInsideTypeSwitch(v any) {
+	var p params
+	switch v.(type) {
+	case string:
+		name := "typed" // want `use new\(expr\) instead of temp variable "name" then \&name`
+		p.Name = &name
+	}
+	_ = p
+}

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -367,12 +367,18 @@ func modelTypeToSchema(typeName string) string {
 }
 
 // findPlanParam returns the name of the plan parameter in a request builder.
-// It looks for a parameter named "plan" or a receiver (method on model).
+// It looks for a receiver that is a model type, a parameter named "plan", or
+// a parameter whose type name ends in "Model" or "Value".
+// When the receiver is a non-model type (e.g., a service struct), it falls
+// through to check parameters instead.
 func findPlanParam(fn *ast.FuncDecl) string {
-	// If method, the receiver acts as the plan.
+	// If method, use the receiver only if it's a Model/Value type.
 	if fn.Recv != nil && len(fn.Recv.List) > 0 {
-		for _, name := range fn.Recv.List[0].Names {
-			return name.Name
+		recvType := extractStarTypeName(fn.Recv.List[0].Type)
+		if recvType != "" && (strings.HasSuffix(recvType, "Model") || strings.HasSuffix(recvType, "Value")) {
+			for _, name := range fn.Recv.List[0].Names {
+				return name.Name
+			}
 		}
 	}
 	// Look for a parameter named "plan" or a *XxxModel parameter.

--- a/tools/linters/requestguard/analyzer.go
+++ b/tools/linters/requestguard/analyzer.go
@@ -348,10 +348,13 @@ func resolveSchema(fn *ast.FuncDecl, receiverToSchema map[string]string, perSche
 }
 
 // modelTypeToSchema derives the schema function name from a model type name.
-// E.g., "budgetResourceModel" → "BudgetResourceSchema".
+// E.g., "budgetResourceModel" → "BudgetResourceSchema",
+//       "cloudDiagramSearchDataSourceModel" → "CloudDiagramSearchDataSourceSchema".
 func modelTypeToSchema(typeName string) string {
 	base := ""
 	if strings.HasSuffix(typeName, "ResourceModel") {
+		base = strings.TrimSuffix(typeName, "Model")
+	} else if strings.HasSuffix(typeName, "DataSourceModel") {
 		base = strings.TrimSuffix(typeName, "Model")
 	} else if strings.HasSuffix(typeName, "Model") {
 		base = strings.TrimSuffix(typeName, "Model") + "Resource"

--- a/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/datasource/schema/schema.go
+++ b/tools/linters/requestguard/testdata/src/github.com/hashicorp/terraform-plugin-framework/datasource/schema/schema.go
@@ -1,0 +1,23 @@
+// Stub package for analysistest (datasource schema).
+package schema
+
+import "context"
+
+type Schema struct {
+	Attributes          map[string]Attribute
+	Description         string
+	MarkdownDescription string
+}
+
+type Attribute interface{}
+
+type StringAttribute struct {
+	Required            bool
+	Optional            bool
+	Computed            bool
+	Default             interface{}
+	Description         string
+	MarkdownDescription string
+}
+
+var _ context.Context

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest.go
@@ -217,3 +217,31 @@ func standaloneHelper(config ConfigValue) {
 		_ = config.Type.ValueStringPointer()
 	}
 }
+
+// --- Data source builder tests ---
+// Tests that requestguard works when:
+// 1. The receiver is a non-model service type (searchDataSource)
+// 2. The model is passed as a parameter (data searchDataSourceModel)
+// 3. The schema is derived via DataSourceModel → DataSourceSchema
+
+// buildSearchRequest is a data source request builder with a non-model receiver.
+func (d *searchDataSource) buildSearchRequest(data searchDataSourceModel) SearchRequest {
+	req := SearchRequest{}
+
+	// BAD: Required field — IsUnknown() guard is dead code.
+	if !data.Query.IsNull() && !data.Query.IsUnknown() { // want `IsUnknown\(\) on Required field "query" is dead code \(Required fields are always Known\)`
+		req.Query = data.Query.ValueStringPointer()
+	}
+
+	// BAD: Optional field — IsUnknown() guard is dead code.
+	if !data.SsId.IsNull() && !data.SsId.IsUnknown() { // want `IsUnknown\(\) on Optional \(not Computed\) field "ss_id" is dead code \(Optional \(not Computed\) fields are always Known\)`
+		req.SsId = data.SsId.ValueStringPointer()
+	}
+
+	// GOOD: Optional field with only IsNull() guard — correct pattern.
+	if !data.SsId.IsNull() {
+		req.SsId = data.SsId.ValueStringPointer()
+	}
+
+	return req
+}

--- a/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
+++ b/tools/linters/requestguard/testdata/src/guardtest/guardtest_gen.go
@@ -4,6 +4,7 @@ package guardtest
 import (
 	"context"
 
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -161,4 +162,43 @@ type FilterRequest struct {
 // DisplaySettingsRequest is a mock 2nd-level nested request type.
 type DisplaySettingsRequest struct {
 	ThemeId *string
+}
+
+// --- Data source fixtures ---
+
+// searchDataSourceModel is a data source model (not a resource model).
+// It tests the DataSourceModel → DataSourceSchema derivation path.
+type searchDataSourceModel struct {
+	Query types.String
+	SsId  types.String
+}
+
+// searchDataSource is a non-model service struct (data source type).
+type searchDataSource struct{}
+
+// SearchDataSourceSchema defines the data source schema (simulated _gen.go).
+func SearchDataSourceSchema(ctx context.Context) dsschema.Schema {
+	return dsschema.Schema{
+		Attributes: map[string]dsschema.Attribute{
+			"query": dsschema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+// Schema wires the data source type to the schema.
+func (d *searchDataSource) Schema(ctx context.Context) dsschema.Schema {
+	s := SearchDataSourceSchema(ctx)
+	// Add a manual attribute (simulates runtime override like cloud_diagram_search).
+	s.Attributes["ss_id"] = dsschema.StringAttribute{
+		Optional: true,
+	}
+	return s
+}
+
+// SearchRequest is a mock API request for the data source.
+type SearchRequest struct {
+	Query *string
+	SsId  *string
 }


### PR DESCRIPTION
## Summary

Fixes two linter gaps discovered during [Cloud Diagram Search data source PR review](https://github.com/doitintl/terraform-provider-doit/pull/new/feat/cloud-diagram-search-datasource):

1. **`newexpr`** only scanned the top-level `BlockStmt` of each function, missing 64 instances of the temp-var-then-address pattern inside `if`/`for`/`switch` blocks
2. **`requestguard`** `modelTypeToSchema` assumed all models are resources, breaking schema resolution for data source request builders

## Changes

### `newexpr` linter

- Add recursive descent into nested blocks via `childBlocks` helper
- Covers: `if`/`else`, `for`, `range`, `switch`, `type switch`, `select`, bare blocks
- 5 new test cases (if, for, range, deeply nested, negative)

### `requestguard` linter

- Handle `DataSourceModel` suffix in `modelTypeToSchema`
- `cloudDiagramSearchDataSourceModel` → `CloudDiagramSearchDataSourceSchema` (was incorrectly → `CloudDiagramSearchDataSourceResourceSchema`)

### Code cleanup (64 findings → 0)

All 64 existing `newexpr` findings cleaned up across 8 files, converting `x := expr; thing = &x` to `thing = new(expr)` (Go 1.26+). Purely mechanical, zero behavior change.

| File | Fixes |
|---|---|
| `report.go` | 25 |
| `insight_resource_results_resource.go` | 12 |
| `insight_resource.go` | 7 |
| `alert.go` | 5 |
| `label_assignments_resource.go` | 4 |
| `budget.go` | 4 |
| `report_data_source.go` | 2 |
| `asset_resource.go` | 1 |
| **Total** | **64** |  

## Validation

- `go test ./... -count=1` — all 22 linter suites PASS
- `go build ./...` — compiles clean
- `./custom-gcl run --enable-only=newexpr` — 0 issues
- `./custom-gcl run --enable-only=requestguard` — 0 issues
- Pre-commit hooks pass