### PR TITLE
feat(anomalies): add include_notifications query parameter

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -1267,6 +1267,13 @@
 						}
 					},
 					{
+						"name": "include_notifications",
+						"bool": {
+							"computed_optional_required": "computed_optional",
+							"description": "Include anomaly notifications from the subcollection. Defaults to false."
+						}
+					},
+					{
 						"name": "anomalies",
 						"list_nested": {
 							"computed_optional_required": "computed",

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -2035,6 +2035,7 @@ paths:
       description: |-
         Returns a list of detected anomalies.
         Anomalies are returned in reverse chronological order by default.
+        The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
       operationId: listAnomalies
       parameters:
         - name: minCreationTime
@@ -2059,6 +2060,12 @@ paths:
             type: integer
             format: int64
         - $ref: "#/components/parameters/pageToken"
+        - name: includeNotifications
+          in: query
+          description: Include anomaly notifications from the subcollection. Defaults to false.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: OK - The request succeeded.
@@ -6210,7 +6217,9 @@ components:
         - top3SKUs
         - notifications
       type: object
-      description: Detailed information about a detected anomaly.
+      description: >-
+        Detailed information about a detected anomaly. The `notifications` array is always present; list responses
+        return an empty array unless `includeNotifications=true` is requested.
       properties:
         attribution:
           type: string

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -1929,6 +1929,7 @@ paths:
       description: |-
         Returns a list of detected anomalies.
         Anomalies are returned in reverse chronological order by default.
+        The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
       operationId: listAnomalies
       parameters:
         - name: minCreationTime
@@ -1953,6 +1954,12 @@ paths:
             type: integer
             format: int64
         - $ref: "#/components/parameters/pageToken"
+        - name: includeNotifications
+          in: query
+          description: Include anomaly notifications from the subcollection. Defaults to false.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: OK - The request succeeded.
@@ -4325,7 +4332,8 @@ components:
         - top3SKUs
         - notifications
       type: object
-      description: Detailed information about a detected anomaly.
+      description: >-
+        Detailed information about a detected anomaly. The `notifications` array is always present; list responses return an empty array unless `includeNotifications=true` is requested.
       properties:
         attribution:
           type: string

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -20,6 +20,23 @@ data "doit_anomalies" "critical" {
   filter = "severityLevel:critical"
 }
 
+# Include notification events for each anomaly
+data "doit_anomalies" "with_notifications" {
+  include_notifications = true
+}
+
+output "notification_audit" {
+  value = [for a in data.doit_anomalies.with_notifications.anomalies : {
+    id           = a.id
+    service      = a.service_name
+    severity     = a.severity_level
+    notifications = [for n in a.notifications : {
+      channel   = n.channel
+      timestamp = n.timestamp
+    }]
+  }]
+}
+
 # Output anomaly details
 output "total_anomalies" {
   value = data.doit_anomalies.all.row_count
@@ -242,6 +259,7 @@ output "acknowledgment_audit" {
 ### Optional
 
 - `filter` (String) An expression for filtering the results of the request
+- `include_notifications` (Boolean) Include anomaly notifications from the subcollection. Defaults to false.
 - `max_creation_time` (String) Max value for the anomaly detection time
 - `max_results` (Number) The maximum number of results to return in a single page
 - `min_creation_time` (String) Min value for the anomaly detection time

--- a/examples/data-sources/doit_anomalies/data-source.tf
+++ b/examples/data-sources/doit_anomalies/data-source.tf
@@ -6,6 +6,23 @@ data "doit_anomalies" "critical" {
   filter = "severityLevel:critical"
 }
 
+# Include notification events for each anomaly
+data "doit_anomalies" "with_notifications" {
+  include_notifications = true
+}
+
+output "notification_audit" {
+  value = [for a in data.doit_anomalies.with_notifications.anomalies : {
+    id           = a.id
+    service      = a.service_name
+    severity     = a.severity_level
+    notifications = [for n in a.notifications : {
+      channel   = n.channel
+      timestamp = n.timestamp
+    }]
+  }]
+}
+
 # Output anomaly details
 output "total_anomalies" {
   value = data.doit_anomalies.all.row_count

--- a/internal/provider/anomalies_data_source.go
+++ b/internal/provider/anomalies_data_source.go
@@ -76,7 +76,7 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 	defer cancel()
 
 	// If any filter/pagination input is unknown, return unknown list
-	if data.Filter.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
+	if data.Filter.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() || data.IncludeNotifications.IsUnknown() {
 		data.Anomalies = types.ListUnknown(datasource_anomalies.AnomaliesValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -91,6 +91,9 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 	if !data.MaxCreationTime.IsNull() {
 		params.MaxCreationTime = new(data.MaxCreationTime.ValueString())
+	}
+	if !data.IncludeNotifications.IsNull() {
+		params.IncludeNotifications = data.IncludeNotifications.ValueBoolPointer()
 	}
 
 	// Smart pagination: honor user-provided values, otherwise auto-paginate

--- a/internal/provider/anomalies_data_source_test.go
+++ b/internal/provider/anomalies_data_source_test.go
@@ -257,6 +257,80 @@ output "anomaly_notifications" {
 `
 }
 
+// TestAccAnomaliesDataSource_IncludeNotifications verifies that setting
+// include_notifications = true causes the API to return notification events
+// in each anomaly's notifications list.
+func TestAccAnomaliesDataSource_IncludeNotifications(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomaliesDataSourceIncludeNotificationsConfig(true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.with_notifications", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.with_notifications", "include_notifications", "true"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceIncludeNotificationsConfig(true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAnomaliesDataSource_IncludeNotificationsFalse verifies that setting
+// include_notifications = false also produces no drift.
+func TestAccAnomaliesDataSource_IncludeNotificationsFalse(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomaliesDataSourceIncludeNotificationsConfig(false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.with_notifications", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.with_notifications", "include_notifications", "false"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceIncludeNotificationsConfig(false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAnomaliesDataSourceIncludeNotificationsConfig(includeNotifications bool) string {
+	return fmt.Sprintf(`
+data "doit_anomalies" "with_notifications" {
+  max_results            = 1
+  include_notifications  = %t
+}
+
+output "notification_channels" {
+  value = [
+    for a in data.doit_anomalies.with_notifications.anomalies : [
+      for n in a.notifications : n.channel
+    ]
+  ]
+}
+`, includeNotifications)
+}
+
 // Helper functions
 
 var (

--- a/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
+++ b/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
@@ -208,6 +208,12 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "An expression for filtering the results of the request",
 				MarkdownDescription: "An expression for filtering the results of the request",
 			},
+			"include_notifications": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Include anomaly notifications from the subcollection. Defaults to false.",
+				MarkdownDescription: "Include anomaly notifications from the subcollection. Defaults to false.",
+			},
 			"max_creation_time": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -242,13 +248,14 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type AnomaliesModel struct {
-	Anomalies       types.List   `tfsdk:"anomalies"`
-	Filter          types.String `tfsdk:"filter"`
-	MaxCreationTime types.String `tfsdk:"max_creation_time"`
-	MaxResults      types.Int64  `tfsdk:"max_results"`
-	MinCreationTime types.String `tfsdk:"min_creation_time"`
-	PageToken       types.String `tfsdk:"page_token"`
-	RowCount        types.Int64  `tfsdk:"row_count"`
+	Anomalies            types.List   `tfsdk:"anomalies"`
+	Filter               types.String `tfsdk:"filter"`
+	IncludeNotifications types.Bool   `tfsdk:"include_notifications"`
+	MaxCreationTime      types.String `tfsdk:"max_creation_time"`
+	MaxResults           types.Int64  `tfsdk:"max_results"`
+	MinCreationTime      types.String `tfsdk:"min_creation_time"`
+	PageToken            types.String `tfsdk:"page_token"`
+	RowCount             types.Int64  `tfsdk:"row_count"`
 }
 
 var _ basetypes.ObjectTypable = AnomaliesType{}

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3832,7 +3832,7 @@ type AnomaliesResponse struct {
 	RowCount  *int64         `json:"rowCount,omitempty"`
 }
 
-// AnomalyItem Detailed information about a detected anomaly.
+// AnomalyItem Detailed information about a detected anomaly. The `notifications` array is always present; list responses return an empty array unless `includeNotifications=true` is requested.
 type AnomalyItem struct {
 	// Acknowledged Has the anomaly been acknowledged
 	Acknowledged *bool `json:"acknowledged,omitempty"`
@@ -7744,6 +7744,9 @@ type ListAnomaliesParams struct {
 
 	// PageToken Page token, returned by a previous call, to request the next page of results
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
+
+	// IncludeNotifications Include anomaly notifications from the subcollection. Defaults to false.
+	IncludeNotifications *bool `form:"includeNotifications,omitempty" json:"includeNotifications,omitempty"`
 }
 
 // IdOfAssetsParams defines parameters for IdOfAssets.
@@ -12937,6 +12940,18 @@ func NewListAnomaliesRequest(server string, params *ListAnomaliesParams) (*http.
 		if params.PageToken != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "pageToken", *params.PageToken, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.IncludeNotifications != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "includeNotifications", *params.IncludeNotifications, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {


### PR DESCRIPTION
## What

Adds support for the new `include_notifications` attribute on the `doit_anomalies` data source. This boolean query parameter controls whether anomaly notification events are fetched from the subcollection (defaults to `false`).

## Why

The upstream API spec added the `includeNotifications` parameter to the list anomalies endpoint. The spec was synced downstream and code generation (`make generate` + `make docs`) was already run. This PR wires the generated attribute into the data source implementation and adds test coverage.

## Changes

- **`anomalies_data_source.go`**: Added `IncludeNotifications` to the unknown-input guard (required for Optional+Computed fields without Default) and pass-through to `ListAnomaliesParams`
- **`anomalies_data_source_test.go`**: Two new acceptance tests (`true`/`false`) with drift verification
- **`data-source.tf` example**: New example showing `include_notifications = true` with notification channel output
- **`docs/`**: Regenerated via `make docs`

## Validation

- `go build ./...` — clean
- `go vet ./internal/provider/...` — clean
- Pre-commit hooks — all passed