### PR TITLE
fix(cloud-diagrams): return empty maps instead of null for computed component maps

### DIFF
--- a/internal/provider/cloud_diagrams_schemes_data_source.go
+++ b/internal/provider/cloud_diagrams_schemes_data_source.go
@@ -304,7 +304,9 @@ func mapSchemeMap(
 	var diags diag.Diagnostics
 
 	if scheme == nil || len(*scheme) == 0 {
-		data.Scheme = types.MapNull(datasource_cloud_diagrams_schemes.SchemeValue{}.Type(ctx))
+		emptyMap, mapDiags := types.MapValueFrom(ctx, datasource_cloud_diagrams_schemes.SchemeValue{}.Type(ctx), map[string]datasource_cloud_diagrams_schemes.SchemeValue{})
+		diags.Append(mapDiags...)
+		data.Scheme = emptyMap
 		return diags
 	}
 
@@ -379,7 +381,9 @@ func mapStatussheetMap(
 	var diags diag.Diagnostics
 
 	if statussheet == nil || len(*statussheet) == 0 {
-		data.Statussheet = types.MapNull(datasource_cloud_diagrams_schemes.StatussheetValue{}.Type(ctx))
+		emptyMap, mapDiags := types.MapValueFrom(ctx, datasource_cloud_diagrams_schemes.StatussheetValue{}.Type(ctx), map[string]datasource_cloud_diagrams_schemes.StatussheetValue{})
+		diags.Append(mapDiags...)
+		data.Statussheet = emptyMap
 		return diags
 	}
 
@@ -571,7 +575,7 @@ func mapNodeMap(ctx context.Context, nodes *map[string]models.CloudDiagramNode) 
 	nodeType := datasource_cloud_diagrams_schemes.NodeValue{}.Type(ctx)
 
 	if nodes == nil || len(*nodes) == 0 {
-		return types.MapNull(nodeType), nil
+		return types.MapValueFrom(ctx, nodeType, map[string]datasource_cloud_diagrams_schemes.NodeValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -644,7 +648,7 @@ func mapElementMap(ctx context.Context, elements *map[string]models.CloudDiagram
 	elemType := datasource_cloud_diagrams_schemes.ElementValue{}.Type(ctx)
 
 	if elements == nil || len(*elements) == 0 {
-		return types.MapNull(elemType), nil
+		return types.MapValueFrom(ctx, elemType, map[string]datasource_cloud_diagrams_schemes.ElementValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -697,7 +701,7 @@ func mapGroupMap(ctx context.Context, groups *map[string]models.CloudDiagramGrou
 	groupType := datasource_cloud_diagrams_schemes.GroupValue{}.Type(ctx)
 
 	if groups == nil || len(*groups) == 0 {
-		return types.MapNull(groupType), nil
+		return types.MapValueFrom(ctx, groupType, map[string]datasource_cloud_diagrams_schemes.GroupValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -787,7 +791,7 @@ func mapLinkMap(ctx context.Context, links *map[string]models.CloudDiagramLink) 
 	linkType := datasource_cloud_diagrams_schemes.LinkValue{}.Type(ctx)
 
 	if links == nil || len(*links) == 0 {
-		return types.MapNull(linkType), nil
+		return types.MapValueFrom(ctx, linkType, map[string]datasource_cloud_diagrams_schemes.LinkValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -839,7 +843,7 @@ func mapAttachmentMap(ctx context.Context, attachments *map[string]models.CloudD
 	attType := datasource_cloud_diagrams_schemes.AttachmentValue{}.Type(ctx)
 
 	if attachments == nil || len(*attachments) == 0 {
-		return types.MapNull(attType), nil
+		return types.MapValueFrom(ctx, attType, map[string]datasource_cloud_diagrams_schemes.AttachmentValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -892,7 +896,7 @@ func mapCombinerMap(ctx context.Context, combiners *map[string]models.CloudDiagr
 	cmbType := datasource_cloud_diagrams_schemes.CombinerValue{}.Type(ctx)
 
 	if combiners == nil || len(*combiners) == 0 {
-		return types.MapNull(cmbType), nil
+		return types.MapValueFrom(ctx, cmbType, map[string]datasource_cloud_diagrams_schemes.CombinerValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -961,7 +965,7 @@ func mapNoteMap(ctx context.Context, notes *map[string]models.CloudDiagramNote) 
 	noteType := datasource_cloud_diagrams_schemes.NoteValue{}.Type(ctx)
 
 	if notes == nil || len(*notes) == 0 {
-		return types.MapNull(noteType), nil
+		return types.MapValueFrom(ctx, noteType, map[string]datasource_cloud_diagrams_schemes.NoteValue{})
 	}
 
 	var diags diag.Diagnostics

--- a/internal/provider/cloud_diagrams_schemes_data_source_test.go
+++ b/internal/provider/cloud_diagrams_schemes_data_source_test.go
@@ -2,6 +2,7 @@ package provider_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -150,4 +151,30 @@ func testCheckAtLeastOneDiagramWithLayers(name string) resource.TestCheckFunc {
 
 		return fmt.Errorf("expected at least one diagram with layers, but none found")
 	}
+}
+
+func TestAccCloudDiagramsSchemesDataSource_ComponentMapsIterable(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudDiagramsSchemesDataSourceConfigChained() + `
+# Verify that scheme and statussheet maps are iterable (not null).
+# keys() on null maps would produce "Call to function 'keys' failed: argument is null."
+output "scheme_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_schemes.detailed.scheme))
+}
+
+output "statussheet_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_schemes.detailed.statussheet))
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchOutput("scheme_key_count", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchOutput("statussheet_key_count", regexp.MustCompile(`^\d+$`)),
+				),
+			},
+		},
+	})
 }

--- a/internal/provider/cloud_diagrams_statussheet_data_source.go
+++ b/internal/provider/cloud_diagrams_statussheet_data_source.go
@@ -377,7 +377,7 @@ func mapSSNodeMap(ctx context.Context, nodes *map[string]models.CloudDiagramNode
 	nodeType := datasource_cloud_diagrams_statussheet.NodeValue{}.Type(ctx)
 
 	if nodes == nil || len(*nodes) == 0 {
-		return types.MapNull(nodeType), nil
+		return types.MapValueFrom(ctx, nodeType, map[string]datasource_cloud_diagrams_statussheet.NodeValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -450,7 +450,7 @@ func mapSSElementMap(ctx context.Context, elements *map[string]models.CloudDiagr
 	elemType := datasource_cloud_diagrams_statussheet.ElementValue{}.Type(ctx)
 
 	if elements == nil || len(*elements) == 0 {
-		return types.MapNull(elemType), nil
+		return types.MapValueFrom(ctx, elemType, map[string]datasource_cloud_diagrams_statussheet.ElementValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -503,7 +503,7 @@ func mapSSGroupMap(ctx context.Context, groups *map[string]models.CloudDiagramGr
 	groupType := datasource_cloud_diagrams_statussheet.GroupValue{}.Type(ctx)
 
 	if groups == nil || len(*groups) == 0 {
-		return types.MapNull(groupType), nil
+		return types.MapValueFrom(ctx, groupType, map[string]datasource_cloud_diagrams_statussheet.GroupValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -592,7 +592,7 @@ func mapSSLinkMap(ctx context.Context, links *map[string]models.CloudDiagramLink
 	linkType := datasource_cloud_diagrams_statussheet.LinkValue{}.Type(ctx)
 
 	if links == nil || len(*links) == 0 {
-		return types.MapNull(linkType), nil
+		return types.MapValueFrom(ctx, linkType, map[string]datasource_cloud_diagrams_statussheet.LinkValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -644,7 +644,7 @@ func mapSSAttachmentMap(ctx context.Context, attachments *map[string]models.Clou
 	attType := datasource_cloud_diagrams_statussheet.AttachmentValue{}.Type(ctx)
 
 	if attachments == nil || len(*attachments) == 0 {
-		return types.MapNull(attType), nil
+		return types.MapValueFrom(ctx, attType, map[string]datasource_cloud_diagrams_statussheet.AttachmentValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -697,7 +697,7 @@ func mapSSCombinerMap(ctx context.Context, combiners *map[string]models.CloudDia
 	cmbType := datasource_cloud_diagrams_statussheet.CombinerValue{}.Type(ctx)
 
 	if combiners == nil || len(*combiners) == 0 {
-		return types.MapNull(cmbType), nil
+		return types.MapValueFrom(ctx, cmbType, map[string]datasource_cloud_diagrams_statussheet.CombinerValue{})
 	}
 
 	var diags diag.Diagnostics
@@ -766,7 +766,7 @@ func mapSSNoteMap(ctx context.Context, notes *map[string]models.CloudDiagramNote
 	noteType := datasource_cloud_diagrams_statussheet.NoteValue{}.Type(ctx)
 
 	if notes == nil || len(*notes) == 0 {
-		return types.MapNull(noteType), nil
+		return types.MapValueFrom(ctx, noteType, map[string]datasource_cloud_diagrams_statussheet.NoteValue{})
 	}
 
 	var diags diag.Diagnostics

--- a/internal/provider/cloud_diagrams_statussheet_data_source_test.go
+++ b/internal/provider/cloud_diagrams_statussheet_data_source_test.go
@@ -1,6 +1,7 @@
 package provider_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -104,8 +105,65 @@ data "doit_cloud_diagrams_schemes" "with_components" {
 # is not triggered on empty lists.
 locals {
   ss_data   = data.doit_cloud_diagrams_schemes.with_components.statussheet[local.first_layer_id]
-  node_ids  = local.ss_data != null && local.ss_data.node != null && length(keys(local.ss_data.node)) > 0 ? keys(local.ss_data.node) : null
-  group_ids = local.ss_data != null && local.ss_data.group != null && length(keys(local.ss_data.group)) > 0 ? keys(local.ss_data.group) : null
+  node_ids  = local.ss_data != null && length(keys(local.ss_data.node)) > 0 ? keys(local.ss_data.node) : null
+  group_ids = local.ss_data != null && length(keys(local.ss_data.group)) > 0 ? keys(local.ss_data.group) : null
 }
 `
+}
+
+func TestAccCloudDiagramsStatussheetDataSource_ComponentMapsIterable(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudDiagramsStatussheetDiscovery() + `
+data "doit_cloud_diagrams_statussheet" "test" {
+  id       = local.first_layer_id
+  node_ids = local.node_ids
+}
+
+# Iterate over all component maps to verify they are not null.
+# keys() and length() would fail on null maps.
+output "ss_node_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_statussheet.test.node))
+}
+
+output "ss_element_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_statussheet.test.element))
+}
+
+output "ss_group_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_statussheet.test.group))
+}
+
+output "ss_link_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_statussheet.test.link))
+}
+
+output "ss_attachment_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_statussheet.test.attachment))
+}
+
+output "ss_combiner_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_statussheet.test.combiner))
+}
+
+output "ss_note_key_count" {
+  value = length(keys(data.doit_cloud_diagrams_statussheet.test.note))
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_cloud_diagrams_statussheet.test", "id"),
+					resource.TestMatchOutput("ss_node_key_count", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchOutput("ss_element_key_count", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchOutput("ss_group_key_count", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchOutput("ss_link_key_count", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchOutput("ss_attachment_key_count", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchOutput("ss_combiner_key_count", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchOutput("ss_note_key_count", regexp.MustCompile(`^\d+$`)),
+				),
+			},
+		},
+	})
 }


### PR DESCRIPTION
## Summary

Replace `MapNull` with empty maps for all computed component map attributes in the `schemes` and `statussheet` data sources. Null maps cause "iteration over null value" errors when users call `keys()`, `length()`, or `for`/`for_each` on component maps that happen to be empty.

## What changed

| File | Change |
|------|--------|
| `internal/provider/cloud_diagrams_schemes_data_source.go` | 9 `MapNull` → empty map (scheme, statussheet, node, element, group, link, attachment, combiner, note) |
| `internal/provider/cloud_diagrams_statussheet_data_source.go` | 7 `MapNull` → empty map (node, element, group, link, attachment, combiner, note) |
| `internal/provider/cloud_diagrams_schemes_data_source_test.go` | Add `ComponentMapsIterable` test — calls `keys()`/`length()` on scheme and statussheet maps |
| `internal/provider/cloud_diagrams_statussheet_data_source_test.go` | Add `ComponentMapsIterable` test — calls `keys()`/`length()` on all 7 component maps |

## Validation

- ✅ `go build ./...`
- ✅ `make lint` — 0 issues
- ✅ All 9 acceptance tests PASS (including 2 new iteration tests)
- ✅ Pre-commit hooks passed