### PR TITLE
feat(provider): flatten allOf schemas, make filter/scope mode optional and clearable

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -207,7 +207,7 @@
 												}
 											]
 										},
-										"description": "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert."
+										"description": "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead."
 									}
 								},
 								{
@@ -473,7 +473,7 @@
 																}
 															]
 														},
-														"description": "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert."
+														"description": "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead."
 													}
 												},
 												{
@@ -520,6 +520,13 @@
 										"string": {
 											"computed_optional_required": "computed",
 											"description": "Alert Name."
+										}
+									},
+									{
+										"name": "owner",
+										"string": {
+											"computed_optional_required": "computed",
+											"description": "Email of the alert owner (the collaborator with the owner role)."
 										}
 									},
 									{

--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -194,7 +194,7 @@
 												{
 													"name": "mode",
 													"string": {
-														"computed_optional_required": "required",
+														"computed_optional_required": "computed_optional",
 														"description": "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.",
 														"validators": [
 															{
@@ -241,7 +241,7 @@
 												}
 											]
 										},
-										"description": "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert."
+										"description": "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead."
 									}
 								},
 								{
@@ -1278,7 +1278,7 @@
 									{
 										"name": "mode",
 										"string": {
-											"computed_optional_required": "required",
+											"computed_optional_required": "computed_optional",
 											"description": "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.",
 											"validators": [
 												{
@@ -2756,7 +2756,7 @@
 												{
 													"name": "mode",
 													"string": {
-														"computed_optional_required": "required",
+														"computed_optional_required": "computed_optional",
 														"description": "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.",
 														"validators": [
 															{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -6045,6 +6045,18 @@ components:
           timeInterval: month
           dataSource: billing
           value: 500
+    AlertListItem:
+      description: >-
+        Alert as returned by the list endpoint. Identical to `Alert` but also
+        includes `owner`. The `owner` field is only populated in list results;
+        it is not returned by the get, create, or update endpoints.
+      allOf:
+        - $ref: "#/components/schemas/Alert"
+        - type: object
+          properties:
+            owner:
+              type: string
+              description: Email of the alert owner (the collaborator with the owner role).
     AlertConfig:
       type: object
       description: Parameters that define when and how an alert is evaluated.
@@ -6065,7 +6077,8 @@ components:
             billing-datahub: Billing data plus DataHub custom dimensions and metrics (requires a DataHub subscription).
         scopes:
           type: array
-          description: The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.
+          description: >-
+            The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.
           items:
             $ref: "#/components/schemas/ExternalConfigFilter"
         metric:
@@ -7469,7 +7482,7 @@ components:
           type: array
           description: Array of alerts.
           items:
-            $ref: "#/components/schemas/Alert"
+            $ref: "#/components/schemas/AlertListItem"
     ExternalBudgetAlert:
       type: object
       description: Budget alert status details.
@@ -7724,7 +7737,6 @@ components:
       required:
         - id
         - type
-        - mode
       properties:
         id:
           type: string

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -3998,7 +3998,8 @@ components:
             billing-datahub: Billing data plus DataHub custom dimensions and metrics (requires a DataHub subscription).
         scopes:
           type: array
-          description: The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.
+          description: >-
+            The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.
           items:
             $ref: "#/components/schemas/ExternalConfigFilter"
         metric:
@@ -4033,6 +4034,64 @@ components:
           description: Use 'scopes' instead. The attributions selected define the scope to monitor.
           items:
             type: string
+    AlertListItem:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+          description: Alert ID.
+        name:
+          type: string
+          description: Alert Name.
+          default: ""
+        createTime:
+          type: integer
+          description: The time when the alert was created (in UNIX timestamp).
+          format: int64
+        updateTime:
+          type: integer
+          description: Last time the alert was modified (in UNIX timestamp).
+          format: int64
+        lastAlerted:
+          type: integer
+          description: Last time the alert was triggered (in UNIX timestamp).
+          format: int64
+        recipients:
+          type: array
+          description: List of emails that will be notified when the alert is triggered.
+          items:
+            type: string
+        config:
+          $ref: "#/components/schemas/AlertConfig"
+        owner:
+          type: string
+          description: Email of the alert owner (the collaborator with the owner role).
+      description: Configuration and runtime metadata of an alert.
+      example:
+        id: 7jyrczd6CSh3M8TuQ6Qq
+        name: fgfgh
+        createTime: 1678628817062
+        updateTime: 1678628938891
+        lastAlerted: null
+        recipients:
+          - user1@example.com
+          - user2@example.com
+        config:
+          condition: value
+          currency: USD
+          metric:
+            type: basic
+            value: cost
+          operator: gt
+          evaluateForEach: ""
+          attributions:
+            - PvqyGcdFcTHh7aLUdGdf
+          scopes: []
+          timeInterval: month
+          dataSource: billing
+          value: 500
     AlertRequest:
       required:
         - config
@@ -6851,7 +6910,7 @@ components:
           type: array
           description: Array of alerts.
           items:
-            $ref: "#/components/schemas/Alert"
+            $ref: "#/components/schemas/AlertListItem"
     ExternalBudgetAlert:
       type: object
       description: Budget alert status details.
@@ -7068,7 +7127,6 @@ components:
       required:
         - id
         - type
-        - mode
       properties:
         id:
           type: string

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -4035,6 +4035,8 @@ components:
           items:
             type: string
     AlertListItem:
+      description: >-
+        Alert as returned by the list endpoint. Identical to `Alert` but also includes `owner`. The `owner` field is only populated in list results; it is not returned by the get, create, or update endpoints.
       type: object
       required:
         - name
@@ -4068,7 +4070,6 @@ components:
         owner:
           type: string
           description: Email of the alert owner (the collaborator with the owner role).
-      description: Configuration and runtime metadata of an alert.
       example:
         id: 7jyrczd6CSh3M8TuQ6Qq
         name: fgfgh

--- a/docs/data-sources/alert.md
+++ b/docs/data-sources/alert.md
@@ -72,7 +72,7 @@ Read-Only:
 - `evaluate_for_each` (String) Add a dimension to break down the evaluation of the condition. For example, evaluate a condition over an attribution for each "Service". Must be a dimension key returned by GET /analytics/v1/dimensions. Not allowed with condition: `forecast`. Used when you Investigate an alert, the dimension becomes the report grouping.
 - `metric` (Attributes) Define how metrics are selected and filtered in reports. (see [below for nested schema](#nestedatt--config--metric))
 - `operator` (String) Text/operator used to filter metric values in metric filters (gt = greater than, lt = less than).
-- `scopes` (Attributes List) The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert. (see [below for nested schema](#nestedatt--config--scopes))
+- `scopes` (Attributes List) The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead. (see [below for nested schema](#nestedatt--config--scopes))
 - `time_interval` (String) The period each evaluation looks at.
 - `value` (Number) The `condition` threshold value. For example, actual metric threshold value for the `value` condition, or percentage change threshold value for the `percentage-change` condition.
 

--- a/docs/data-sources/alerts.md
+++ b/docs/data-sources/alerts.md
@@ -86,6 +86,7 @@ Read-Only:
 - `id` (String) Alert ID.
 - `last_alerted` (Number) Last time the alert was triggered (in UNIX timestamp).
 - `name` (String) Alert Name.
+- `owner` (String) Email of the alert owner (the collaborator with the owner role).
 - `recipients` (List of String) List of emails that will be notified when the alert is triggered.
 - `update_time` (Number) Last time the alert was modified (in UNIX timestamp).
 
@@ -101,7 +102,7 @@ Read-Only:
 - `evaluate_for_each` (String) Add a dimension to break down the evaluation of the condition. For example, evaluate a condition over an attribution for each "Service". Must be a dimension key returned by GET /analytics/v1/dimensions. Not allowed with condition: `forecast`. Used when you Investigate an alert, the dimension becomes the report grouping.
 - `metric` (Attributes) Define how metrics are selected and filtered in reports. (see [below for nested schema](#nestedatt--alerts--config--metric))
 - `operator` (String) Text/operator used to filter metric values in metric filters (gt = greater than, lt = less than).
-- `scopes` (Attributes List) The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert. (see [below for nested schema](#nestedatt--alerts--config--scopes))
+- `scopes` (Attributes List) The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead. (see [below for nested schema](#nestedatt--alerts--config--scopes))
 - `time_interval` (String) The period each evaluation looks at.
 - `value` (Number) The `condition` threshold value. For example, actual metric threshold value for the `value` condition, or percentage change threshold value for the `percentage-change` condition.
 

--- a/docs/data-sources/report_query.md
+++ b/docs/data-sources/report_query.md
@@ -189,8 +189,6 @@ to leave the stored value unchanged.
 Required:
 
 - `id` (String) Dimension key to filter on. Must pair with `type` and match a dimension returned by `GET /analytics/v1/dimensions` (for example, `service_description` with `type: fixed`). For `allocation_rule`, use `allocation_rule`. For `allocation`, use the allocation group ID. See `DimensionsTypes` for how each `type` uses `id`.
-- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
-Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `allocation`, `allocation_rule`, `gke`, `gke_label`
 
@@ -199,6 +197,8 @@ Optional:
 - `case_insensitive` (Boolean) If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
 - `include_null` (Boolean) Include rows where the dimension is null. If includeNull is omitted, behavior defaults to `false`.
 - `inverse` (Boolean) Set to `true` to exclude the set values. If inverse is omitted, behavior defaults to `false`.
+- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
+Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `values` (List of String) List of values to include or exclude. Must match exact strings from your billing or DataHub data for the dimension (for example, `Amazon Simple Storage Service` for AWS S3 on `service_description`). For `allocation_rule`, use allocation rule IDs.
 
 

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -208,7 +208,7 @@ Possible values: `billing`, `billing-datahub`
 - `evaluate_for_each` (String) Add a dimension to break down the evaluation of the condition. For example, evaluate a condition over an attribution for each "Service". Must be a dimension key returned by GET /analytics/v1/dimensions. Not allowed with condition: `forecast`. Used when you Investigate an alert, the dimension becomes the report grouping.
 - `operator` (String) Text/operator used to filter metric values in metric filters (gt = greater than, lt = less than).
 Possible values: `gt`, `lt`
-- `scopes` (Attributes List) The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert. (see [below for nested schema](#nestedatt--config--scopes))
+- `scopes` (Attributes List) The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead. (see [below for nested schema](#nestedatt--config--scopes))
 - `time_interval` (String) The period each evaluation looks at.
 Possible values: `day`, `week`, `month`, `quarter`, `year`
 
@@ -227,8 +227,6 @@ Required:
 Required:
 
 - `id` (String) Dimension key to filter on. Must pair with `type` and match a dimension returned by `GET /analytics/v1/dimensions` (for example, `service_description` with `type: fixed`). For `allocation_rule`, use `allocation_rule`. For `allocation`, use the allocation group ID. See `DimensionsTypes` for how each `type` uses `id`.
-- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
-Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `allocation`, `allocation_rule`, `gke`, `gke_label`
 
@@ -237,6 +235,8 @@ Optional:
 - `case_insensitive` (Boolean) If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
 - `include_null` (Boolean) Include rows where the dimension is null. If includeNull is omitted, behavior defaults to `false`.
 - `inverse` (Boolean) Set to `true` to exclude the set values. If inverse is omitted, behavior defaults to `false`.
+- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
+Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `values` (List of String) List of values to include or exclude. Must match exact strings from your billing or DataHub data for the dimension (for example, `Amazon Simple Storage Service` for AWS S3 on `service_description`). For `allocation_rule`, use allocation rule IDs.
 
 

--- a/docs/resources/budget.md
+++ b/docs/resources/budget.md
@@ -241,8 +241,6 @@ Optional:
 Required:
 
 - `id` (String) Dimension key to filter on. Must pair with `type` and match a dimension returned by `GET /analytics/v1/dimensions` (for example, `service_description` with `type: fixed`). For `allocation_rule`, use `allocation_rule`. For `allocation`, use the allocation group ID. See `DimensionsTypes` for how each `type` uses `id`.
-- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
-Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `allocation`, `allocation_rule`, `gke`, `gke_label`
 
@@ -251,6 +249,8 @@ Optional:
 - `case_insensitive` (Boolean) If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
 - `include_null` (Boolean) Include rows where the dimension is null. If includeNull is omitted, behavior defaults to `false`.
 - `inverse` (Boolean) Set to `true` to exclude the set values. If inverse is omitted, behavior defaults to `false`.
+- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
+Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `values` (List of String) List of values to include or exclude. Must match exact strings from your billing or DataHub data for the dimension (for example, `Amazon Simple Storage Service` for AWS S3 on `service_description`). For `allocation_rule`, use allocation rule IDs.
 
 

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -421,8 +421,6 @@ to leave the stored value unchanged.
 Required:
 
 - `id` (String) Dimension key to filter on. Must pair with `type` and match a dimension returned by `GET /analytics/v1/dimensions` (for example, `service_description` with `type: fixed`). For `allocation_rule`, use `allocation_rule`. For `allocation`, use the allocation group ID. See `DimensionsTypes` for how each `type` uses `id`.
-- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
-Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 Possible values: `datetime`, `fixed`, `optional`, `label`, `tag`, `project_label`, `system_label`, `attribution`, `attribution_group`, `allocation`, `allocation_rule`, `gke`, `gke_label`
 
@@ -431,6 +429,8 @@ Optional:
 - `case_insensitive` (Boolean) If true, string matching is case-insensitive. Effective only for starts_with, ends_with, and contains modes; ignored otherwise.
 - `include_null` (Boolean) Include rows where the dimension is null. If includeNull is omitted, behavior defaults to `false`.
 - `inverse` (Boolean) Set to `true` to exclude the set values. If inverse is omitted, behavior defaults to `false`.
+- `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
+Possible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`
 - `values` (List of String) List of values to include or exclude. Must match exact strings from your billing or DataHub data for the dimension (for example, `Amazon Simple Storage Service` for AWS S3 on `service_description`). For `allocation_rule`, use allocation rule IDs.
 
 

--- a/internal/provider/alert.go
+++ b/internal/provider/alert.go
@@ -38,8 +38,13 @@ func overlayAlertComputedFields(ctx context.Context, apiResp *models.Alert, plan
 	// ── Computed-only fields: always from resolved ──
 	plan.Id = resolved.Id
 	plan.CreateTime = resolved.CreateTime
-	plan.UpdateTime = resolved.UpdateTime
-	plan.LastAlerted = resolved.LastAlerted
+	// Guarded: on Update the prior state is Known, but the API returns a new timestamp.
+	if plan.UpdateTime.IsUnknown() {
+		plan.UpdateTime = resolved.UpdateTime //nolint:overlaycheck // guarded to avoid inconsistent result on Update
+	}
+	if plan.LastAlerted.IsUnknown() {
+		plan.LastAlerted = resolved.LastAlerted //nolint:overlaycheck // guarded to avoid inconsistent result on Update
+	}
 
 	// ── Name: Required — never touch ──
 
@@ -100,6 +105,10 @@ func overlayAlertScope(_ context.Context, resolved, plan *resource_alert.ScopesV
 
 	if plan.Inverse.IsUnknown() {
 		plan.Inverse = resolved.Inverse
+	}
+
+	if plan.Mode.IsUnknown() {
+		plan.Mode = resolved.Mode
 	}
 
 	if plan.Values.IsUnknown() {
@@ -215,15 +224,16 @@ func (plan *alertResourceModel) toAlertConfig(ctx context.Context) (config model
 		apiScopes := make([]models.ExternalConfigFilter, len(scopes))
 		for i, scope := range scopes {
 			filterType := models.DimensionsTypes(scope.ScopesType.ValueString())
-			filterMode := models.ExternalConfigFilterMode(scope.Mode.ValueString())
 
 			apiScopes[i] = models.ExternalConfigFilter{
 				CaseInsensitive: scope.CaseInsensitive.ValueBoolPointer(),
 				Id:              scope.Id.ValueString(),
 				IncludeNull:     scope.IncludeNull.ValueBoolPointer(),
 				Inverse:         scope.Inverse.ValueBoolPointer(),
-				Mode:            filterMode,
 				Type:            filterType,
+			}
+			if !scope.Mode.IsNull() && !scope.Mode.IsUnknown() {
+				apiScopes[i].Mode = new(models.ExternalConfigFilterMode(scope.Mode.ValueString()))
 			}
 			if !scope.Values.IsNull() && !scope.Values.IsUnknown() {
 				var values []string
@@ -416,7 +426,7 @@ func mapAlertConfigToModel(ctx context.Context, config *models.AlertConfig, exis
 				"id":               types.StringValue(scopeID),
 				"include_null":     includeNullVal,
 				"inverse":          types.BoolPointerValue(scope.Inverse),
-				"mode":             types.StringValue(string(scope.Mode)),
+				"mode":             types.StringPointerValue((*string)(scope.Mode)),
 				"type":             types.StringValue(scopeType),
 				"values":           valuesVal,
 			}

--- a/internal/provider/alert_data_source.go
+++ b/internal/provider/alert_data_source.go
@@ -277,8 +277,13 @@ func (ds *alertDataSource) mapScopeToModel(ctx context.Context, scope *models.Ex
 		values = emptyList3
 	}
 
-	// Map mode - Mode is not a pointer, it's a string type
-	mode := types.StringValue(string(scope.Mode))
+	// Map mode - Mode is now a pointer (optional field)
+	var mode types.String
+	if scope.Mode != nil {
+		mode = types.StringValue(string(*scope.Mode))
+	} else {
+		mode = types.StringNull()
+	}
 
 	// Map inverse
 	var inverse types.Bool

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -91,6 +91,18 @@ func (r *alertResource) Schema(ctx context.Context, _ resource.SchemaRequest, re
 		"config.scopes[*].values",  // API defaults scope values
 	)
 
+	// Category A: nested clearable attributes.
+	if configAttr, ok := s.Attributes["config"].(schema.SingleNestedAttribute); ok {
+		if scopesAttr, ok := configAttr.Attributes["scopes"].(schema.ListNestedAttribute); ok {
+			if attr, ok := scopesAttr.NestedObject.Attributes["mode"].(schema.StringAttribute); ok {
+				attr.PlanModifiers = append(attr.PlanModifiers, useNullForUnknownStringWhenConfigNull())
+				scopesAttr.NestedObject.Attributes["mode"] = attr
+			}
+			configAttr.Attributes["scopes"] = scopesAttr
+		}
+		s.Attributes["config"] = configAttr
+	}
+
 	s.Attributes["timeouts"] = timeouts.Attributes(ctx, timeouts.Opts{
 		Create: true,
 		Read:   true,

--- a/internal/provider/alert_resource_test.go
+++ b/internal/provider/alert_resource_test.go
@@ -751,6 +751,129 @@ resource "doit_alert" "this" {
 `, i)
 }
 
+// TestAccAlert_ClearScopeMode verifies the clearing lifecycle for scopes[*].mode.
+// The API returns null when mode is unset, so omitting it from config clears it.
+func TestAccAlert_ClearScopeMode(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with mode explicitly set
+			{
+				Config: testAccAlertWithScopeMode(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_alert.this",
+						tfjsonpath.New("config").AtMapKey("scopes"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":   knownvalue.StringExact("fixed"),
+								"id":     knownvalue.StringExact("cloud_provider"),
+								"mode":   knownvalue.StringExact("contains"),
+								"values": knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("amazon")}),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 2: Drift check
+			{
+				Config: testAccAlertWithScopeMode(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Clear mode by omitting it from config
+			{
+				Config: testAccAlertWithScopeModeCleared(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"doit_alert.this",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("doit_alert.this", "config.scopes.0.mode"),
+				),
+			},
+			// Step 4: Drift check — cleared mode should produce no drift
+			{
+				Config: testAccAlertWithScopeModeCleared(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAlertWithScopeMode(i int) string {
+	return fmt.Sprintf(`
+resource "doit_alert" "this" {
+  name = "test-alert-clear-mode-%d"
+  config = {
+    metric = {
+      type  = "basic"
+      value = "cost"
+    }
+    time_interval = "month"
+    value         = 500
+    currency      = "USD"
+    condition     = "value"
+    operator      = "gt"
+    scopes = [
+      {
+        type   = "fixed"
+        id     = "cloud_provider"
+        mode   = "contains"
+        values = ["amazon"]
+      }
+    ]
+  }
+}
+`, i)
+}
+
+func testAccAlertWithScopeModeCleared(i int) string {
+	return fmt.Sprintf(`
+resource "doit_alert" "this" {
+  name = "test-alert-clear-mode-%d"
+  config = {
+    metric = {
+      type  = "basic"
+      value = "cost"
+    }
+    time_interval = "month"
+    value         = 500
+    currency      = "USD"
+    condition     = "value"
+    operator      = "gt"
+    scopes = [
+      {
+        type   = "fixed"
+        id     = "cloud_provider"
+        values = ["amazon"]
+      }
+    ]
+  }
+}
+`, i)
+}
+
 // TestAccAlert_Disappears verifies that Terraform correctly handles
 // resources that are deleted outside of Terraform (externally deleted).
 // This tests the Read method's 404 handling and RemoveResource call.

--- a/internal/provider/alerts_data_source.go
+++ b/internal/provider/alerts_data_source.go
@@ -96,7 +96,7 @@ func (d *alertsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	// Smart pagination: honor user-provided values, otherwise auto-paginate
 	userControlsPagination := !data.MaxResults.IsNull()
 
-	var allAlerts []models.Alert
+	var allAlerts []models.AlertListItem
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
@@ -206,6 +206,7 @@ func (d *alertsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 					"create_time":  types.Int64PointerValue(alert.CreateTime),
 					"update_time":  types.Int64PointerValue(alert.UpdateTime),
 					"last_alerted": types.Int64PointerValue(alert.LastAlerted),
+					"owner":        types.StringPointerValue(alert.Owner),
 					"recipients":   recipientsList,
 					"config":       configVal,
 				},
@@ -340,7 +341,7 @@ func mapAlertScopes(ctx context.Context, scopes *[]models.ExternalConfigFilter, 
 				"id":               types.StringValue(s.Id),
 				"include_null":     types.BoolPointerValue(s.IncludeNull),
 				"inverse":          types.BoolPointerValue(s.Inverse),
-				"mode":             types.StringValue(string(s.Mode)),
+				"mode":             types.StringPointerValue((*string)(s.Mode)),
 				"type":             types.StringValue(string(s.Type)),
 				"values":           valuesList,
 			},

--- a/internal/provider/alerts_data_source_test.go
+++ b/internal/provider/alerts_data_source_test.go
@@ -153,6 +153,25 @@ func TestAccAlertsDataSource_AutoPagination(t *testing.T) {
 	})
 }
 
+// TestAccAlertsDataSource_OwnerAttribute verifies that the owner field is populated
+// in list results. The owner field is only returned by the list endpoint.
+func TestAccAlertsDataSource_OwnerAttribute(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertsDataSourceMaxResultsConfig("1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.doit_alerts.limited", "alerts.#", "1"),
+					resource.TestCheckResourceAttrSet("data.doit_alerts.limited", "alerts.0.owner"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAlertsDataSourceConfig() string {
 	return `
 data "doit_alerts" "test" {

--- a/internal/provider/budget.go
+++ b/internal/provider/budget.go
@@ -175,6 +175,10 @@ func overlayBudgetScope(_ context.Context, resolved, plan *resource_budget.Scope
 		plan.Inverse = resolved.Inverse
 	}
 
+	if plan.Mode.IsUnknown() {
+		plan.Mode = resolved.Mode
+	}
+
 	if plan.Values.IsUnknown() {
 		plan.Values = resolved.Values
 	}
@@ -295,15 +299,16 @@ func (plan *budgetResourceModel) toUpdateRequest(ctx context.Context) (req model
 		reqScopes := make([]models.ExternalConfigFilter, len(scopes))
 		for i, scope := range scopes {
 			filterType := models.DimensionsTypes(scope.ScopesType.ValueString())
-			filterMode := models.ExternalConfigFilterMode(scope.Mode.ValueString())
 
 			reqScopes[i] = models.ExternalConfigFilter{
 				CaseInsensitive: scope.CaseInsensitive.ValueBoolPointer(),
 				Id:              scope.Id.ValueString(),
 				IncludeNull:     scope.IncludeNull.ValueBoolPointer(),
 				Inverse:         scope.Inverse.ValueBoolPointer(),
-				Mode:            filterMode,
 				Type:            filterType,
+			}
+			if !scope.Mode.IsNull() && !scope.Mode.IsUnknown() {
+				reqScopes[i].Mode = new(models.ExternalConfigFilterMode(scope.Mode.ValueString()))
 			}
 			if !scope.Values.IsNull() && !scope.Values.IsUnknown() {
 				var values []string
@@ -614,7 +619,7 @@ func mapBudgetToModel(ctx context.Context, resp *models.BudgetAPI, state *budget
 				"id":               types.StringValue(scopeID),
 				"include_null":     includeNullVal,
 				"inverse":          types.BoolPointerValue(scope.Inverse),
-				"mode":             types.StringValue(string(scope.Mode)),
+				"mode":             types.StringPointerValue((*string)(scope.Mode)),
 				"type":             types.StringValue(scopeType),
 				"values":           valuesVal,
 			}

--- a/internal/provider/budget_data_source.go
+++ b/internal/provider/budget_data_source.go
@@ -286,7 +286,7 @@ func (d *budgetDataSource) mapBudgetToModel(ctx context.Context, budget *models.
 				"id":               types.StringValue(scope.Id),
 				"include_null":     types.BoolPointerValue(scope.IncludeNull),
 				"inverse":          types.BoolPointerValue(scope.Inverse),
-				"mode":             types.StringValue(string(scope.Mode)),
+				"mode":             types.StringPointerValue((*string)(scope.Mode)),
 				"type":             types.StringValue(string(scope.Type)),
 				"values":           valuesVal,
 			}

--- a/internal/provider/budget_resource.go
+++ b/internal/provider/budget_resource.go
@@ -128,11 +128,15 @@ func (r *budgetResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 		"scopes[*].inverse", // API defaults to false
 	)
 
-	// Category A: nested scopes[*].values — clearable.
+	// Category A: nested clearable attributes.
 	if scopesAttr, ok := s.Attributes["scopes"].(schema.ListNestedAttribute); ok {
 		if attr, ok := scopesAttr.NestedObject.Attributes["values"].(schema.ListAttribute); ok {
 			attr.PlanModifiers = append(attr.PlanModifiers, useNullForUnknownListWhenConfigNull())
 			scopesAttr.NestedObject.Attributes["values"] = attr
+		}
+		if attr, ok := scopesAttr.NestedObject.Attributes["mode"].(schema.StringAttribute); ok {
+			attr.PlanModifiers = append(attr.PlanModifiers, useNullForUnknownStringWhenConfigNull())
+			scopesAttr.NestedObject.Attributes["mode"] = attr
 		}
 		s.Attributes["scopes"] = scopesAttr
 	}

--- a/internal/provider/budget_resource_test.go
+++ b/internal/provider/budget_resource_test.go
@@ -2289,3 +2289,142 @@ resource "doit_budget" "this" {
 }
 `, budgetStartPeriod(), i, testAttribution(), testUser())
 }
+
+// TestAccBudget_ClearScopeMode verifies the clearing lifecycle for scopes[*].mode.
+// The API returns null when mode is unset, so omitting it from config clears it.
+func TestAccBudget_ClearScopeMode(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "~> 0.13.1",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with mode explicitly set.
+			{
+				Config: testAccBudgetWithScopeMode(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_budget.this",
+						tfjsonpath.New("scopes"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":   knownvalue.StringExact("fixed"),
+								"id":     knownvalue.StringExact("cloud_provider"),
+								"mode":   knownvalue.StringExact("contains"),
+								"values": knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("amazon")}),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 2: Drift check.
+			{
+				Config: testAccBudgetWithScopeMode(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Clear mode by omitting it from config.
+			{
+				Config: testAccBudgetWithScopeModeCleared(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"doit_budget.this",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("doit_budget.this", "scopes.0.mode"),
+				),
+			},
+			// Step 4: Drift check — cleared mode should produce no drift.
+			{
+				Config: testAccBudgetWithScopeModeCleared(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetWithScopeMode(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name          = "test-clear-mode-%d"
+  amount        = 100
+  currency      = "USD"
+  time_interval = "month"
+  type          = "recurring"
+  start_period  = local.start_period
+  scopes = [
+    {
+      type   = "fixed"
+      id     = "cloud_provider"
+      mode   = "contains"
+      values = ["amazon"]
+    }
+  ]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 }
+  ]
+}
+`, budgetStartPeriod(), i, testUser())
+}
+
+func testAccBudgetWithScopeModeCleared(i int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "doit_budget" "this" {
+  name          = "test-clear-mode-%d"
+  amount        = 100
+  currency      = "USD"
+  time_interval = "month"
+  type          = "recurring"
+  start_period  = local.start_period
+  scopes = [
+    {
+      type   = "fixed"
+      id     = "cloud_provider"
+      values = ["amazon"]
+    }
+  ]
+  collaborators = [
+    {
+      "email" : "%s",
+      "role" : "owner"
+    }
+  ]
+  alerts = [
+    { "percentage" : 100 }
+  ]
+}
+`, budgetStartPeriod(), i, testUser())
+}

--- a/internal/provider/budgets_data_source.go
+++ b/internal/provider/budgets_data_source.go
@@ -299,7 +299,7 @@ func mapBudgetScopes(ctx context.Context, scopes *[]models.ExternalConfigFilter)
 				"id":               types.StringValue(s.Id),
 				"include_null":     types.BoolPointerValue(s.IncludeNull),
 				"inverse":          types.BoolPointerValue(s.Inverse),
-				"mode":             types.StringValue(string(s.Mode)),
+				"mode":             types.StringPointerValue((*string)(s.Mode)),
 				"type":             types.StringValue(string(s.Type)),
 				"values":           valuesList,
 			},

--- a/internal/provider/datasource_alert/alert_data_source_gen.go
+++ b/internal/provider/datasource_alert/alert_data_source_gen.go
@@ -119,8 +119,8 @@ func AlertDataSourceSchema(ctx context.Context) schema.Schema {
 							},
 						},
 						Computed:            true,
-						Description:         "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.",
-						MarkdownDescription: "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.",
+						Description:         "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.",
+						MarkdownDescription: "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.",
 					},
 					"time_interval": schema.StringAttribute{
 						Computed:            true,

--- a/internal/provider/datasource_alerts/alerts_data_source_gen.go
+++ b/internal/provider/datasource_alerts/alerts_data_source_gen.go
@@ -124,8 +124,8 @@ func AlertsDataSourceSchema(ctx context.Context) schema.Schema {
 										},
 									},
 									Computed:            true,
-									Description:         "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.",
-									MarkdownDescription: "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.",
+									Description:         "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.",
+									MarkdownDescription: "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.",
 								},
 								"time_interval": schema.StringAttribute{
 									Computed:            true,
@@ -166,6 +166,11 @@ func AlertsDataSourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "Alert Name.",
 							MarkdownDescription: "Alert Name.",
+						},
+						"owner": schema.StringAttribute{
+							Computed:            true,
+							Description:         "Email of the alert owner (the collaborator with the owner role).",
+							MarkdownDescription: "Email of the alert owner (the collaborator with the owner role).",
 						},
 						"recipients": schema.ListAttribute{
 							ElementType:         types.StringType,
@@ -369,6 +374,24 @@ func (t AlertsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 			fmt.Sprintf(`name expected to be basetypes.StringValue, was: %T`, nameAttribute))
 	}
 
+	ownerAttribute, ok := attributes["owner"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`owner is missing from object`)
+
+		return nil, diags
+	}
+
+	ownerVal, ok := ownerAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`owner expected to be basetypes.StringValue, was: %T`, ownerAttribute))
+	}
+
 	recipientsAttribute, ok := attributes["recipients"]
 
 	if !ok {
@@ -415,6 +438,7 @@ func (t AlertsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		Id:          idVal,
 		LastAlerted: lastAlertedVal,
 		Name:        nameVal,
+		Owner:       ownerVal,
 		Recipients:  recipientsVal,
 		UpdateTime:  updateTimeVal,
 		state:       attr.ValueStateKnown,
@@ -574,6 +598,24 @@ func NewAlertsValue(attributeTypes map[string]attr.Type, attributes map[string]a
 			fmt.Sprintf(`name expected to be basetypes.StringValue, was: %T`, nameAttribute))
 	}
 
+	ownerAttribute, ok := attributes["owner"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`owner is missing from object`)
+
+		return NewAlertsValueUnknown(), diags
+	}
+
+	ownerVal, ok := ownerAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`owner expected to be basetypes.StringValue, was: %T`, ownerAttribute))
+	}
+
 	recipientsAttribute, ok := attributes["recipients"]
 
 	if !ok {
@@ -620,6 +662,7 @@ func NewAlertsValue(attributeTypes map[string]attr.Type, attributes map[string]a
 		Id:          idVal,
 		LastAlerted: lastAlertedVal,
 		Name:        nameVal,
+		Owner:       ownerVal,
 		Recipients:  recipientsVal,
 		UpdateTime:  updateTimeVal,
 		state:       attr.ValueStateKnown,
@@ -699,13 +742,14 @@ type AlertsValue struct {
 	Id          basetypes.StringValue `tfsdk:"id"`
 	LastAlerted basetypes.Int64Value  `tfsdk:"last_alerted"`
 	Name        basetypes.StringValue `tfsdk:"name"`
+	Owner       basetypes.StringValue `tfsdk:"owner"`
 	Recipients  basetypes.ListValue   `tfsdk:"recipients"`
 	UpdateTime  basetypes.Int64Value  `tfsdk:"update_time"`
 	state       attr.ValueState
 }
 
 func (v AlertsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 7)
+	attrTypes := make(map[string]tftypes.Type, 8)
 
 	var val tftypes.Value
 	var err error
@@ -719,6 +763,7 @@ func (v AlertsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["last_alerted"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["owner"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["recipients"] = basetypes.ListType{
 		ElemType: types.StringType,
 	}.TerraformType(ctx)
@@ -728,7 +773,7 @@ func (v AlertsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 7)
+		vals := make(map[string]tftypes.Value, 8)
 
 		val, err = v.Config.ToTerraformValue(ctx)
 
@@ -769,6 +814,14 @@ func (v AlertsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 		}
 
 		vals["name"] = val
+
+		val, err = v.Owner.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["owner"] = val
 
 		val, err = v.Recipients.ToTerraformValue(ctx)
 
@@ -844,6 +897,7 @@ func (v AlertsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 			"id":           basetypes.StringType{},
 			"last_alerted": basetypes.Int64Type{},
 			"name":         basetypes.StringType{},
+			"owner":        basetypes.StringType{},
 			"recipients": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -861,6 +915,7 @@ func (v AlertsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		"id":           basetypes.StringType{},
 		"last_alerted": basetypes.Int64Type{},
 		"name":         basetypes.StringType{},
+		"owner":        basetypes.StringType{},
 		"recipients": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -883,6 +938,7 @@ func (v AlertsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 			"id":           v.Id,
 			"last_alerted": v.LastAlerted,
 			"name":         v.Name,
+			"owner":        v.Owner,
 			"recipients":   recipientsVal,
 			"update_time":  v.UpdateTime,
 		})
@@ -925,6 +981,10 @@ func (v AlertsValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.Owner.Equal(other.Owner) {
+		return false
+	}
+
 	if !v.Recipients.Equal(other.Recipients) {
 		return false
 	}
@@ -955,6 +1015,7 @@ func (v AlertsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"id":           basetypes.StringType{},
 		"last_alerted": basetypes.Int64Type{},
 		"name":         basetypes.StringType{},
+		"owner":        basetypes.StringType{},
 		"recipients": basetypes.ListType{
 			ElemType: types.StringType,
 		},

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3670,7 +3670,7 @@ type AlertConfigDataSource string
 // AlertConfigTimeInterval The period each evaluation looks at.
 type AlertConfigTimeInterval string
 
-// AlertListItem Configuration and runtime metadata of an alert.
+// AlertListItem Alert as returned by the list endpoint. Identical to `Alert` but also includes `owner`. The `owner` field is only populated in list results; it is not returned by the get, create, or update endpoints.
 type AlertListItem struct {
 	// Config Parameters that define when and how an alert is evaluated.
 	Config *AlertConfig `json:"config,omitempty"`

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3654,7 +3654,7 @@ type AlertConfig struct {
 	// Operator Text/operator used to filter metric values in metric filters (gt = greater than, lt = less than).
 	Operator *MetricFilterText `json:"operator,omitempty"`
 
-	// Scopes The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.
+	// Scopes The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.
 	Scopes *[]ExternalConfigFilter `json:"scopes,omitempty"`
 
 	// TimeInterval The period each evaluation looks at.
@@ -3669,6 +3669,33 @@ type AlertConfigDataSource string
 
 // AlertConfigTimeInterval The period each evaluation looks at.
 type AlertConfigTimeInterval string
+
+// AlertListItem Configuration and runtime metadata of an alert.
+type AlertListItem struct {
+	// Config Parameters that define when and how an alert is evaluated.
+	Config *AlertConfig `json:"config,omitempty"`
+
+	// CreateTime The time when the alert was created (in UNIX timestamp).
+	CreateTime *int64 `json:"createTime,omitempty"`
+
+	// Id Alert ID.
+	Id *string `json:"id,omitempty"`
+
+	// LastAlerted Last time the alert was triggered (in UNIX timestamp).
+	LastAlerted *int64 `json:"lastAlerted,omitempty"`
+
+	// Name Alert Name.
+	Name string `json:"name"`
+
+	// Owner Email of the alert owner (the collaborator with the owner role).
+	Owner *string `json:"owner,omitempty"`
+
+	// Recipients List of emails that will be notified when the alert is triggered.
+	Recipients *[]string `json:"recipients,omitempty"`
+
+	// UpdateTime Last time the alert was modified (in UNIX timestamp).
+	UpdateTime *int64 `json:"updateTime,omitempty"`
+}
 
 // AlertRequest Request body for creating a new alert.
 type AlertRequest struct {
@@ -5615,7 +5642,7 @@ type ExternalAPIGetValue struct {
 // ExternalAlertList List of alerts.
 type ExternalAlertList struct {
 	// Alerts Array of alerts.
-	Alerts *[]Alert `json:"alerts,omitempty"`
+	Alerts *[]AlertListItem `json:"alerts,omitempty"`
 
 	// PageToken Page token. It is used to request a specific page of the list results.
 	PageToken *string `json:"pageToken,omitempty"`
@@ -5748,7 +5775,7 @@ type ExternalConfigFilter struct {
 	Inverse *bool `json:"inverse,omitempty"`
 
 	// Mode Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
-	Mode ExternalConfigFilterMode `json:"mode"`
+	Mode *ExternalConfigFilterMode `json:"mode,omitempty"`
 
 	// Type Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 	Type DimensionsTypes `json:"type"`

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -372,6 +372,10 @@ func overlayFilter(_ context.Context, resolved, plan *resource_report.FiltersVal
 		plan.Inverse = resolved.Inverse
 	}
 
+	if plan.Mode.IsUnknown() {
+		plan.Mode = resolved.Mode
+	}
+
 	if plan.Values.IsUnknown() {
 		plan.Values = resolved.Values
 	}
@@ -743,7 +747,9 @@ func toExternalConfig(ctx context.Context, config resource_report.ConfigValue) (
 					}
 					externalFilters[i].Values = &values
 				}
-				externalFilters[i].Mode = models.ExternalConfigFilterMode(f.Mode.ValueString())
+				if !f.Mode.IsNull() && !f.Mode.IsUnknown() {
+					externalFilters[i].Mode = new(models.ExternalConfigFilterMode(f.Mode.ValueString()))
+				}
 			}
 			externalConfig.Filters = &externalFilters
 		}
@@ -1196,7 +1202,7 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 				"inverse":          inverseVal,
 				// filters type enum cast
 				"type": types.StringValue(fType),
-				"mode": types.StringValue(string(f.Mode)),
+				"mode": types.StringPointerValue((*string)(f.Mode)),
 			}
 
 			// The API silently strips legacy "[... N/A]" NullFallback sentinels from filter

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -273,7 +273,7 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 				"include_null":     types.BoolPointerValue(f.IncludeNull),
 				"inverse":          types.BoolPointerValue(f.Inverse),
 				"type":             types.StringValue(fType),
-				"mode":             types.StringValue(string(f.Mode)),
+				"mode":             types.StringPointerValue((*string)(f.Mode)),
 			}
 
 			if f.Values != nil {

--- a/internal/provider/report_query_data_source_test.go
+++ b/internal/provider/report_query_data_source_test.go
@@ -208,3 +208,62 @@ data "doit_report_query" "test" {
 }
 `
 }
+
+// TestAccReportQueryDataSource_FilterWithoutMode verifies that the query
+// data source works when a filter omits mode (optional field).
+func TestAccReportQueryDataSource_FilterWithoutMode(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportQueryDataSourceFilterNoMode(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.doit_report_query.test",
+						tfjsonpath.New("result_json"),
+						knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(
+						"data.doit_report_query.test",
+						tfjsonpath.New("row_count"),
+						knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+func testAccReportQueryDataSourceFilterNoMode() string {
+	return `
+data "doit_report_query" "test" {
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode            = "last"
+          amount          = 3
+          unit            = "month"
+          include_current = false
+        }
+        filters = [
+          {
+            id      = "cloud_provider"
+            type    = "fixed"
+            values  = ["amazon-web-services"]
+          }
+        ]
+    }
+}
+`
+}

--- a/internal/provider/report_resource.go
+++ b/internal/provider/report_resource.go
@@ -63,12 +63,16 @@ func (r *reportResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 		s.Attributes["description"] = attr
 	}
 
-	// Category A: nested clearable filter/metric_filter values.
+	// Category A: nested clearable filter/metric_filter values and mode.
 	if configAttr, ok := s.Attributes["config"].(schema.SingleNestedAttribute); ok {
 		if filtersAttr, ok := configAttr.Attributes["filters"].(schema.ListNestedAttribute); ok {
 			if attr, ok := filtersAttr.NestedObject.Attributes["values"].(schema.ListAttribute); ok {
 				attr.PlanModifiers = append(attr.PlanModifiers, useNullForUnknownListWhenConfigNull())
 				filtersAttr.NestedObject.Attributes["values"] = attr
+			}
+			if attr, ok := filtersAttr.NestedObject.Attributes["mode"].(schema.StringAttribute); ok {
+				attr.PlanModifiers = append(attr.PlanModifiers, useNullForUnknownStringWhenConfigNull())
+				filtersAttr.NestedObject.Attributes["mode"] = attr
 			}
 			configAttr.Attributes["filters"] = filtersAttr
 		}

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -3117,3 +3117,130 @@ resource "doit_report" "metric_empty_test" {
 }
 `, i)
 }
+
+// TestAccReport_ClearFilterMode verifies the clearing lifecycle for config.filters[*].mode.
+// The API returns null when mode is unset, so omitting it from config clears it.
+func TestAccReport_ClearFilterMode(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: Create with mode explicitly set.
+			{
+				Config: testAccReportWithFilterMode(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_report.this",
+						tfjsonpath.New("config").AtMapKey("filters"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":   knownvalue.StringExact("fixed"),
+								"id":     knownvalue.StringExact("cloud_provider"),
+								"mode":   knownvalue.StringExact("contains"),
+								"values": knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("amazon")}),
+							}),
+						}),
+					),
+				},
+			},
+			// Step 2: Drift check.
+			{
+				Config: testAccReportWithFilterMode(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Clear mode by omitting it from config.
+			{
+				Config: testAccReportWithFilterModeCleared(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"doit_report.this",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("doit_report.this", "config.filters.0.mode"),
+				),
+			},
+			// Step 4: Drift check — cleared mode should produce no drift.
+			{
+				Config: testAccReportWithFilterModeCleared(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportWithFilterMode(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "this" {
+    name = "test-clear-filter-mode-%d"
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation   = "total"
+        time_interval = "month"
+        filters = [
+          {
+            id      = "cloud_provider"
+            type    = "fixed"
+            inverse = false
+            mode    = "contains"
+            values  = ["amazon"]
+          }
+        ]
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+    }
+}
+`, i)
+}
+
+func testAccReportWithFilterModeCleared(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "this" {
+    name = "test-clear-filter-mode-%d"
+    config = {
+        metric = {
+          type  = "basic"
+          value = "cost"
+        }
+        aggregation   = "total"
+        time_interval = "month"
+        filters = [
+          {
+            id      = "cloud_provider"
+            type    = "fixed"
+            inverse = false
+            values  = ["amazon"]
+          }
+        ]
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+    }
+}
+`, i)
+}

--- a/internal/provider/resource_alert/alert_resource_gen.go
+++ b/internal/provider/resource_alert/alert_resource_gen.go
@@ -158,7 +158,8 @@ func AlertResourceSchema(ctx context.Context) schema.Schema {
 									MarkdownDescription: "Set to `true` to exclude the set values. If inverse is omitted, behavior defaults to `false`.",
 								},
 								"mode": schema.StringAttribute{
-									Required:            true,
+									Optional:            true,
+									Computed:            true,
 									Description:         "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.\nPossible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`",
 									MarkdownDescription: "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.\nPossible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`",
 									Validators: []validator.String{
@@ -209,8 +210,8 @@ func AlertResourceSchema(ctx context.Context) schema.Schema {
 						},
 						Optional:            true,
 						Computed:            true,
-						Description:         "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.",
-						MarkdownDescription: "The filters selected define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Only costs/usages matching all scope logic are included in the alert.",
+						Description:         "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.",
+						MarkdownDescription: "The filters that define the scope of the alert. Each item is a Cloud Analytics filter (same idea as report filters). Note: Only the first scope in the array is currently applied; any additional scopes are validated but ignored. If additional scopes are malformed the call will fail silently. Use a single, well-chosen filter, or dataSource plus evaluateForEach to slice spend instead.",
 					},
 					"time_interval": schema.StringAttribute{
 						Optional:            true,

--- a/internal/provider/resource_budget/budget_resource_gen.go
+++ b/internal/provider/resource_budget/budget_resource_gen.go
@@ -269,7 +269,8 @@ func BudgetResourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Set to `true` to exclude the set values. If inverse is omitted, behavior defaults to `false`.",
 						},
 						"mode": schema.StringAttribute{
-							Required:            true,
+							Optional:            true,
+							Computed:            true,
 							Description:         "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.\nPossible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`",
 							MarkdownDescription: "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.\nPossible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`",
 							Validators: []validator.String{

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -300,7 +300,8 @@ func ReportResourceSchema(ctx context.Context) schema.Schema {
 									MarkdownDescription: "Set to `true` to exclude the set values. If inverse is omitted, behavior defaults to `false`.",
 								},
 								"mode": schema.StringAttribute{
-									Required:            true,
+									Optional:            true,
+									Computed:            true,
 									Description:         "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.\nPossible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`",
 									MarkdownDescription: "Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.\nPossible values: `is`, `starts_with`, `ends_with`, `contains`, `regexp`",
 									Validators: []validator.String{

--- a/tools/extract-inline-schemas/main.go
+++ b/tools/extract-inline-schemas/main.go
@@ -84,6 +84,16 @@ func main() {
 		extractor.insertExtractedSchemas(schemasNode)
 	}
 
+	// Phase 3.5: Flatten multi-element allOf compositions in components/schemas.
+	// Schemas like {allOf: [$ref: Base, {properties: {extra}}]} are merged into
+	// a single {type: object, properties: {all Base props + extra}}. This allows
+	// downstream code generators (tfplugingen-openapi) that don't support allOf
+	// composition to process them.
+	schemasNode = findMapValue(doc, "components", "schemas")
+	if schemasNode != nil {
+		flattenAllOfSchemas(schemasNode)
+	}
+
 	// Phase 4: Validate functional equivalence of the extraction.
 	// This runs BEFORE pruning so that inline-schema extraction regressions
 	// are always caught, regardless of whether pruning is enabled.
@@ -519,6 +529,189 @@ func hasRef(node *yaml.Node) bool {
 	return false
 }
 
+// flattenAllOfSchemas walks all named schemas in components/schemas and flattens
+// any schema that uses allOf with 2+ sub-schemas into a single flat object.
+// Each $ref sub-schema is resolved by looking it up in the same schemasNode.
+// Properties from later sub-schemas override earlier ones on conflict (with a
+// log warning). Required arrays are merged (union, deduplicated).
+func flattenAllOfSchemas(schemasNode *yaml.Node) {
+	if schemasNode.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(schemasNode.Content)-1; i += 2 {
+		schemaName := schemasNode.Content[i].Value
+		schemaNode := schemasNode.Content[i+1]
+		if schemaNode.Kind != yaml.MappingNode {
+			continue
+		}
+		allOfNode := getMappingValue(schemaNode, "allOf")
+		if allOfNode == nil || allOfNode.Kind != yaml.SequenceNode || len(allOfNode.Content) < 2 {
+			continue
+		}
+
+		merged := flattenAllOf(allOfNode, schemasNode, schemaName)
+		if merged == nil {
+			continue
+		}
+
+		// Preserve parent-level fields (description, example) from outside the allOf.
+		parentDesc := getScalarNode(schemaNode, "description")
+		parentExample := getMappingValue(schemaNode, "example")
+
+		// Replace the schema node content with the merged result.
+		schemaNode.Content = merged.Content
+
+		// Re-add parent description if present and the merged result doesn't have one.
+		if parentDesc != nil && parentDesc.Value != "" && getScalarValue(schemaNode, "description") == "" {
+			schemaNode.Content = append(
+				[]*yaml.Node{
+					{Kind: yaml.ScalarNode, Value: "description", Tag: "!!str"},
+					{Kind: yaml.ScalarNode, Value: parentDesc.Value, Tag: "!!str", Style: parentDesc.Style},
+				},
+				schemaNode.Content...,
+			)
+		}
+
+		// Re-add parent example if present and the merged result doesn't have one.
+		if parentExample != nil && getMappingValue(schemaNode, "example") == nil {
+			schemaNode.Content = append(schemaNode.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "example", Tag: "!!str"},
+				deepCopyNode(parentExample),
+			)
+		}
+
+		fmt.Printf("Flattened allOf in schema %s\n", schemaName)
+	}
+}
+
+// flattenAllOf merges all sub-schemas of an allOf sequence node into a single
+// flat object mapping node. Returns nil if any sub-schema cannot be resolved.
+func flattenAllOf(allOfNode *yaml.Node, schemasNode *yaml.Node, contextName string) *yaml.Node {
+	// Collect resolved sub-schemas.
+	var resolved []*yaml.Node
+	for _, sub := range allOfNode.Content {
+		r := resolveSubSchema(sub, schemasNode)
+		if r == nil {
+			log.Printf("WARNING: cannot resolve allOf sub-schema in %s, skipping flatten", contextName)
+			return nil
+		}
+		resolved = append(resolved, r)
+	}
+
+	// Build the merged result.
+	result := &yaml.Node{Kind: yaml.MappingNode}
+
+	// Set type: object
+	result.Content = append(result.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "type", Tag: "!!str"},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "object", Tag: "!!str"},
+	)
+
+	// Merge required arrays.
+	requiredSet := make(map[string]bool)
+	var requiredOrder []string
+	for _, r := range resolved {
+		reqNode := getMappingValue(r, "required")
+		if reqNode == nil || reqNode.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range reqNode.Content {
+			if !requiredSet[item.Value] {
+				requiredSet[item.Value] = true
+				requiredOrder = append(requiredOrder, item.Value)
+			}
+		}
+	}
+	if len(requiredOrder) > 0 {
+		reqSeq := &yaml.Node{Kind: yaml.SequenceNode}
+		for _, name := range requiredOrder {
+			reqSeq.Content = append(reqSeq.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: name, Tag: "!!str"},
+			)
+		}
+		result.Content = append(result.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "required", Tag: "!!str"},
+			reqSeq,
+		)
+	}
+
+	// Merge properties. Later sub-schemas win on conflict.
+	mergedProps := &yaml.Node{Kind: yaml.MappingNode}
+	propIndex := make(map[string]int) // property name -> index in mergedProps.Content
+	for _, r := range resolved {
+		propsNode := getMappingValue(r, "properties")
+		if propsNode == nil || propsNode.Kind != yaml.MappingNode {
+			continue
+		}
+		for j := 0; j < len(propsNode.Content)-1; j += 2 {
+			propKey := propsNode.Content[j].Value
+			propVal := propsNode.Content[j+1]
+			if idx, exists := propIndex[propKey]; exists {
+				log.Printf("WARNING: property %q in %s defined in multiple allOf sub-schemas, using last definition", propKey, contextName)
+				mergedProps.Content[idx+1] = deepCopyNode(propVal)
+			} else {
+				propIndex[propKey] = len(mergedProps.Content)
+				mergedProps.Content = append(mergedProps.Content,
+					deepCopyNode(propsNode.Content[j]),
+					deepCopyNode(propVal),
+				)
+			}
+		}
+	}
+	if len(mergedProps.Content) > 0 {
+		result.Content = append(result.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "properties", Tag: "!!str"},
+			mergedProps,
+		)
+	}
+
+	// Copy over any other top-level keys from sub-schemas that aren't
+	// type/required/properties (e.g., description, example on sub-schemas).
+	for _, r := range resolved {
+		if r.Kind != yaml.MappingNode {
+			continue
+		}
+		for j := 0; j < len(r.Content)-1; j += 2 {
+			key := r.Content[j].Value
+			if key == "type" || key == "required" || key == "properties" {
+				continue
+			}
+			if getMappingValue(result, key) == nil {
+				result.Content = append(result.Content,
+					deepCopyNode(r.Content[j]),
+					deepCopyNode(r.Content[j+1]),
+				)
+			}
+		}
+	}
+
+	return result
+}
+
+// resolveSubSchema resolves a single allOf sub-schema. If it's a $ref, it
+// looks up the target in schemasNode and returns a deep copy. If it's an
+// inline object, it returns a deep copy directly.
+func resolveSubSchema(node *yaml.Node, schemasNode *yaml.Node) *yaml.Node {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	refVal := getScalarValue(node, "$ref")
+	if refVal != "" {
+		const prefix = "#/components/schemas/"
+		if !strings.HasPrefix(refVal, prefix) {
+			return nil
+		}
+		name := refVal[len(prefix):]
+		for i := 0; i < len(schemasNode.Content)-1; i += 2 {
+			if schemasNode.Content[i].Value == name {
+				return deepCopyNode(schemasNode.Content[i+1])
+			}
+		}
+		return nil
+	}
+	return deepCopyNode(node)
+}
+
 // isInlineObject checks if a node is an inline object definition:
 // a mapping node with type: object and properties, but no $ref.
 func isInlineObject(node *yaml.Node) bool {
@@ -857,6 +1050,15 @@ func stripDocFields(v any) any {
 				}
 			}
 		}
+		// Merge multi-element allOf: when all elements are objects, merge their
+		// properties and required arrays into a single flat object.
+		// This ensures the validator treats the original allOf as equivalent to
+		// the flattened version produced by flattenAllOfSchemas.
+		if items, ok := result["allOf"].([]any); ok && len(items) >= 2 {
+			if merged, ok := mergeAllOfItems(items); ok {
+				return merged
+			}
+		}
 		return result
 	case []any:
 		result := make([]any, len(val))
@@ -867,4 +1069,49 @@ func stripDocFields(v any) any {
 	default:
 		return v
 	}
+}
+
+// mergeAllOfItems merges multiple allOf sub-schema maps into a single flat
+// object map. Returns (merged, true) if all items are object maps, or
+// (nil, false) if any item is not a map.
+func mergeAllOfItems(items []any) (map[string]any, bool) {
+	merged := make(map[string]any)
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		for k, v := range obj {
+			switch k {
+			case "properties":
+				existing, _ := merged["properties"].(map[string]any)
+				if existing == nil {
+					existing = make(map[string]any)
+				}
+				if newProps, ok := v.(map[string]any); ok {
+					maps.Copy(existing, newProps)
+				}
+				merged["properties"] = existing
+			case "required":
+				existing, _ := merged["required"].([]any)
+				if newReq, ok := v.([]any); ok {
+					seen := make(map[string]bool, len(existing))
+					for _, r := range existing {
+						if s, ok := r.(string); ok {
+							seen[s] = true
+						}
+					}
+					for _, r := range newReq {
+						if s, ok := r.(string); ok && !seen[s] {
+							existing = append(existing, r)
+						}
+					}
+				}
+				merged["required"] = existing
+			default:
+				merged[k] = v
+			}
+		}
+	}
+	return merged, true
 }

--- a/tools/extract-inline-schemas/main.go
+++ b/tools/extract-inline-schemas/main.go
@@ -516,6 +516,16 @@ func getScalarNode(node *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
+// removeMappingKey removes a key-value pair from a mapping node by key name.
+func removeMappingKey(node *yaml.Node, key string) {
+	for k := 0; k < len(node.Content)-1; k += 2 {
+		if node.Content[k].Value == key {
+			node.Content = append(node.Content[:k], node.Content[k+2:]...)
+			return
+		}
+	}
+}
+
 // hasRef checks if a mapping node contains a $ref key.
 func hasRef(node *yaml.Node) bool {
 	if node.Kind != yaml.MappingNode {
@@ -561,8 +571,9 @@ func flattenAllOfSchemas(schemasNode *yaml.Node) {
 		// Replace the schema node content with the merged result.
 		schemaNode.Content = merged.Content
 
-		// Re-add parent description if present and the merged result doesn't have one.
-		if parentDesc != nil && parentDesc.Value != "" && getScalarValue(schemaNode, "description") == "" {
+		// Re-add parent description, overriding any inherited from sub-schemas.
+		if parentDesc != nil && parentDesc.Value != "" {
+			removeMappingKey(schemaNode, "description")
 			schemaNode.Content = append(
 				[]*yaml.Node{
 					{Kind: yaml.ScalarNode, Value: "description", Tag: "!!str"},
@@ -572,8 +583,9 @@ func flattenAllOfSchemas(schemasNode *yaml.Node) {
 			)
 		}
 
-		// Re-add parent example if present and the merged result doesn't have one.
-		if parentExample != nil && getMappingValue(schemaNode, "example") == nil {
+		// Re-add parent example, overriding any inherited from sub-schemas.
+		if parentExample != nil {
+			removeMappingKey(schemaNode, "example")
 			schemaNode.Content = append(schemaNode.Content,
 				&yaml.Node{Kind: yaml.ScalarNode, Value: "example", Tag: "!!str"},
 				deepCopyNode(parentExample),
@@ -1104,6 +1116,7 @@ func mergeAllOfItems(items []any) (map[string]any, bool) {
 					for _, r := range newReq {
 						if s, ok := r.(string); ok && !seen[s] {
 							existing = append(existing, r)
+							seen[s] = true
 						}
 					}
 				}

--- a/tools/extract-inline-schemas/main_test.go
+++ b/tools/extract-inline-schemas/main_test.go
@@ -457,16 +457,49 @@ func TestStripDocFields(t *testing.T) {
 		}
 	})
 
-	t.Run("does not unwrap multi-element allOf", func(t *testing.T) {
+	t.Run("merges multi-element allOf with object items", func(t *testing.T) {
+		input := map[string]any{
+			"allOf": []any{
+				map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+					},
+				},
+				map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"extra": map[string]any{"type": "integer"},
+					},
+				},
+			},
+		}
+		got := stripDocFields(input).(map[string]any)
+		if _, ok := got["allOf"]; ok {
+			t.Error("multi-element allOf with object items should be merged")
+		}
+		props, _ := got["properties"].(map[string]any)
+		if props == nil {
+			t.Fatal("merged result should have properties")
+		}
+		if _, ok := props["name"]; !ok {
+			t.Error("merged properties should include 'name'")
+		}
+		if _, ok := props["extra"]; !ok {
+			t.Error("merged properties should include 'extra'")
+		}
+	})
+
+	t.Run("does not merge multi-element allOf with non-object items", func(t *testing.T) {
 		input := map[string]any{
 			"allOf": []any{
 				map[string]any{"type": "object"},
-				map[string]any{"type": "string"},
+				"not a map",
 			},
 		}
 		got := stripDocFields(input).(map[string]any)
 		if _, ok := got["allOf"]; !ok {
-			t.Error("multi-element allOf should NOT be unwrapped")
+			t.Error("multi-element allOf with non-object items should NOT be merged")
 		}
 	})
 
@@ -482,6 +515,369 @@ func TestStripDocFields(t *testing.T) {
 			t.Error("allOf with sibling type should NOT be unwrapped")
 		}
 	})
+}
+
+// --- mergeAllOfItems ---
+
+func TestMergeAllOfItems(t *testing.T) {
+	t.Run("merges properties from multiple objects", func(t *testing.T) {
+		items := []any{
+			map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"id":   map[string]any{"type": "string"},
+					"name": map[string]any{"type": "string"},
+				},
+				"required": []any{"name"},
+			},
+			map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"owner": map[string]any{"type": "string"},
+				},
+			},
+		}
+		merged, ok := mergeAllOfItems(items)
+		if !ok {
+			t.Fatal("mergeAllOfItems returned false")
+		}
+		props := merged["properties"].(map[string]any)
+		if len(props) != 3 {
+			t.Errorf("expected 3 properties, got %d", len(props))
+		}
+		if _, ok := props["owner"]; !ok {
+			t.Error("missing 'owner' property")
+		}
+		req := merged["required"].([]any)
+		if len(req) != 1 || req[0] != "name" {
+			t.Errorf("expected required=[name], got %v", req)
+		}
+	})
+
+	t.Run("returns false for non-map items", func(t *testing.T) {
+		items := []any{
+			map[string]any{"type": "object"},
+			"not a map",
+		}
+		_, ok := mergeAllOfItems(items)
+		if ok {
+			t.Error("expected false for non-map item")
+		}
+	})
+
+	t.Run("later property wins on conflict", func(t *testing.T) {
+		items := []any{
+			map[string]any{
+				"properties": map[string]any{
+					"field": map[string]any{"type": "string"},
+				},
+			},
+			map[string]any{
+				"properties": map[string]any{
+					"field": map[string]any{"type": "integer"},
+				},
+			},
+		}
+		merged, ok := mergeAllOfItems(items)
+		if !ok {
+			t.Fatal("mergeAllOfItems returned false")
+		}
+		props := merged["properties"].(map[string]any)
+		field := props["field"].(map[string]any)
+		if field["type"] != "integer" {
+			t.Errorf("conflicting property should use last definition, got type=%v", field["type"])
+		}
+	})
+
+	t.Run("deduplicates required", func(t *testing.T) {
+		items := []any{
+			map[string]any{"required": []any{"name", "id"}},
+			map[string]any{"required": []any{"name", "extra"}},
+		}
+		merged, ok := mergeAllOfItems(items)
+		if !ok {
+			t.Fatal("mergeAllOfItems returned false")
+		}
+		req := merged["required"].([]any)
+		if len(req) != 3 {
+			t.Errorf("expected 3 unique required fields, got %d: %v", len(req), req)
+		}
+	})
+}
+
+// --- flattenAllOfSchemas ---
+
+func TestFlattenAllOfSchemas(t *testing.T) {
+	t.Run("ref plus inline (AlertListItem pattern)", func(t *testing.T) {
+		schemasNode := mustParseYAML(t, `
+Alert:
+  required:
+    - name
+  type: object
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    config:
+      $ref: "#/components/schemas/AlertConfig"
+AlertListItem:
+  description: Alert with owner
+  allOf:
+    - $ref: "#/components/schemas/Alert"
+    - type: object
+      properties:
+        owner:
+          type: string
+          description: The owner
+AlertConfig:
+  type: object
+  properties:
+    value:
+      type: number
+`)
+		flattenAllOfSchemas(schemasNode)
+
+		listItem := getMappingValue(schemasNode, "AlertListItem")
+		if listItem == nil {
+			t.Fatal("AlertListItem not found")
+		}
+
+		// Should be type: object now
+		if getScalarValue(listItem, "type") != "object" {
+			t.Errorf("type = %q, want %q", getScalarValue(listItem, "type"), "object")
+		}
+
+		// Should NOT have allOf anymore
+		if getMappingValue(listItem, "allOf") != nil {
+			t.Error("allOf should have been removed")
+		}
+
+		// Description preserved
+		if getScalarValue(listItem, "description") != "Alert with owner" {
+			t.Errorf("description = %q, want %q", getScalarValue(listItem, "description"), "Alert with owner")
+		}
+
+		// Required merged from Alert
+		reqNode := getMappingValue(listItem, "required")
+		if reqNode == nil || reqNode.Kind != yaml.SequenceNode {
+			t.Fatal("required should be a sequence")
+		}
+		if len(reqNode.Content) != 1 || reqNode.Content[0].Value != "name" {
+			t.Errorf("required = %v, want [name]", reqNode.Content)
+		}
+
+		// Properties should include all Alert props + owner
+		propsNode := getMappingValue(listItem, "properties")
+		if propsNode == nil {
+			t.Fatal("properties should exist")
+		}
+		for _, expected := range []string{"id", "name", "config", "owner"} {
+			if getMappingValue(propsNode, expected) == nil {
+				t.Errorf("missing property %q", expected)
+			}
+		}
+
+		// config should still be a $ref
+		configProp := getMappingValue(propsNode, "config")
+		if getScalarValue(configProp, "$ref") != "#/components/schemas/AlertConfig" {
+			t.Error("config property should preserve $ref")
+		}
+
+		// owner should have description
+		ownerProp := getMappingValue(propsNode, "owner")
+		if getScalarValue(ownerProp, "description") != "The owner" {
+			t.Errorf("owner description = %q, want %q", getScalarValue(ownerProp, "description"), "The owner")
+		}
+	})
+
+	t.Run("multiple refs", func(t *testing.T) {
+		schemasNode := mustParseYAML(t, `
+Base:
+  type: object
+  required:
+    - id
+  properties:
+    id:
+      type: string
+Extra:
+  type: object
+  required:
+    - label
+  properties:
+    label:
+      type: string
+Combined:
+  allOf:
+    - $ref: "#/components/schemas/Base"
+    - $ref: "#/components/schemas/Extra"
+`)
+		flattenAllOfSchemas(schemasNode)
+
+		combined := getMappingValue(schemasNode, "Combined")
+		if getMappingValue(combined, "allOf") != nil {
+			t.Error("allOf should have been removed")
+		}
+		propsNode := getMappingValue(combined, "properties")
+		if getMappingValue(propsNode, "id") == nil {
+			t.Error("missing 'id' from Base")
+		}
+		if getMappingValue(propsNode, "label") == nil {
+			t.Error("missing 'label' from Extra")
+		}
+
+		reqNode := getMappingValue(combined, "required")
+		if reqNode == nil || len(reqNode.Content) != 2 {
+			t.Fatalf("expected 2 required fields, got %v", reqNode)
+		}
+	})
+
+	t.Run("single element allOf is left alone", func(t *testing.T) {
+		schemasNode := mustParseYAML(t, `
+Base:
+  type: object
+  properties:
+    id:
+      type: string
+Wrapper:
+  allOf:
+    - $ref: "#/components/schemas/Base"
+`)
+		flattenAllOfSchemas(schemasNode)
+
+		wrapper := getMappingValue(schemasNode, "Wrapper")
+		if getMappingValue(wrapper, "allOf") == nil {
+			t.Error("single-element allOf should NOT be flattened (handled by codegen)")
+		}
+	})
+
+	t.Run("property conflict uses last definition", func(t *testing.T) {
+		schemasNode := mustParseYAML(t, `
+A:
+  type: object
+  properties:
+    field:
+      type: string
+      description: original
+B:
+  allOf:
+    - $ref: "#/components/schemas/A"
+    - type: object
+      properties:
+        field:
+          type: integer
+          description: override
+`)
+		flattenAllOfSchemas(schemasNode)
+
+		b := getMappingValue(schemasNode, "B")
+		fieldProp := getMappingValue(getMappingValue(b, "properties"), "field")
+		if getScalarValue(fieldProp, "type") != "integer" {
+			t.Error("conflicting property should use last definition")
+		}
+		if getScalarValue(fieldProp, "description") != "override" {
+			t.Error("conflicting property description should use last definition")
+		}
+	})
+}
+
+// --- validateEquivalence with flattened allOf ---
+
+func TestValidateEquivalence_FlattenedAllOf(t *testing.T) {
+	original := `
+openapi: "3.0.1"
+info:
+  title: Test
+  version: v1
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ItemList"
+components:
+  schemas:
+    Item:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    ItemListEntry:
+      description: Item in a list
+      allOf:
+        - $ref: "#/components/schemas/Item"
+        - type: object
+          properties:
+            owner:
+              type: string
+    ItemList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ItemListEntry"
+`
+	// Processed: ItemListEntry flattened, allOf removed
+	processed := `
+openapi: "3.0.1"
+info:
+  title: Test
+  version: v1
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ItemList"
+components:
+  schemas:
+    Item:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    ItemListEntry:
+      description: Item in a list
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+    ItemList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ItemListEntry"
+`
+	if err := validateEquivalence([]byte(original), []byte(processed)); err != nil {
+		t.Errorf("flattened allOf should be equivalent: %v", err)
+	}
 }
 
 // --- resolveRefs ---


### PR DESCRIPTION
## What

Make `mode` on filter/scope objects truly optional across alert, budget, and report resources. Previously `mode` was hidden inside an `allOf` composition in the OpenAPI spec, causing the code generator to produce a required field.

## Why

Users could not omit `mode` from their Terraform configs. The API treats `mode` as optional (returns `null` when unset), so the provider should match that behavior and support clearing.

## Changes

### `extract-inline-schemas` tool
- Add `flattenAllOfSchemas` phase that merges `allOf` composites containing only `$ref` entries into a single unified schema (last-wins for conflicts, union for required fields)

### Generated code
- Regenerated schemas: `mode` is now `Optional+Computed` in filter/scope schemas
- `ExternalConfigFilter.Mode` is now `*ExternalConfigFilterMode` (pointer) in generated models
- `owner` field added to alerts list data source

### Provider implementation
- Adapt all provider code for the `Mode` pointer change across 8 files (alert, budget, report + their data sources)
- Classify `mode` as Category A (clearable) with `useNullForUnknownStringWhenConfigNull` plan modifier
- Wire `owner` attribute in alerts data source
- Guard `update_time`/`last_alerted` with `IsUnknown()` in alert overlay

## Tests

All acceptance tests pass:

| Test | Duration |
|------|----------|
| `TestAccAlert_ClearScopeMode` | 21.8s |
| `TestAccBudget_ClearScopeMode` | 23.3s |
| `TestAccReport_ClearFilterMode` | 21.0s |
| `TestAccAlertsDataSource_OwnerAttribute` | 8.1s |
| `TestAccReportQueryDataSource_FilterWithoutMode` | 14.9s |
