### PR TITLE
feat(ava): support error field from upstream API spec

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -2085,7 +2085,7 @@
 						"name": "answer",
 						"string": {
 							"computed_optional_required": "computed",
-							"description": "The Ava response text."
+							"description": "The Ava response text. Present on success."
 						}
 					},
 					{
@@ -2100,6 +2100,13 @@
 						"string": {
 							"computed_optional_required": "computed",
 							"description": "The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint."
+						}
+					},
+					{
+						"name": "error",
+						"string": {
+							"computed_optional_required": "computed",
+							"description": "Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message."
 						}
 					}
 				],

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -3150,6 +3150,167 @@ paths:
           $ref: "#/components/responses/403"
         "500":
           $ref: "#/components/responses/500"
+  /iam/v1/users/invite:
+    post:
+      tags:
+        - Users
+      summary: Invite user
+      description: Invites a new user to the organization with specified role and organization.
+      operationId: inviteUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InviteUserRequest"
+      responses:
+        "201":
+          description: Created - User invitation created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InviteResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
+  "/iam/v1/users/{id}/actions/resend":
+    post:
+      tags:
+        - Users
+      summary: Resend invite
+      description: |
+        Resets the invite expiry to 48 hours from now, invalidates the previous invite token (so
+        old email links stop working), and triggers a fresh invitation email. Works on invites in
+        any state including `Cancelled` — resending a cancelled invite reactivates it to `Pending`.
+
+        Returns `404` if no invite exists for the given ID (never created, or already accepted and removed).
+
+        Requires `usersManager` permission.
+      operationId: resendInvite
+      parameters:
+        - name: id
+          in: path
+          description: The unique ID of the invited user.
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: true
+          description: |
+            Client-generated idempotency key (UUID v4 or ULID recommended, max 255 characters).
+            Re-submitting the same key with the same request returns the cached response without
+            re-executing side effects. The server retains the key for at least 24 hours.
+          schema:
+            type: string
+            maxLength: 255
+        - name: dryRun
+          in: query
+          required: false
+          description: |
+            If `true`, validates and simulates the operation without committing changes.
+            The response shape is identical to a real execution.
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: OK - Invite resent and expiry reset.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResendInviteResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+  "/iam/v1/users/{id}/actions/cancel":
+    post:
+      tags:
+        - Users
+      summary: Cancel invite
+      description: |
+        Marks the invite as `Cancelled` and invalidates the invite token so any outstanding email
+        links stop working. The invite document is retained (soft cancel) — the user row remains
+        visible in `GET /iam/v1/users` with `inviteStatus: Cancelled`. Use `DELETE /iam/v1/users/{id}`
+        to fully remove the record.
+
+        Returns `404` if no invite exists for the given ID, and `409` if the invite is already cancelled.
+
+        Requires `usersManager` permission.
+      operationId: cancelInvite
+      parameters:
+        - name: id
+          in: path
+          description: The unique ID of the invited user.
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: true
+          description: |
+            Client-generated idempotency key (UUID v4 or ULID recommended, max 255 characters).
+            Re-submitting the same key with the same request returns the cached response without
+            re-executing side effects. The server retains the key for at least 24 hours.
+          schema:
+            type: string
+            maxLength: 255
+        - name: dryRun
+          in: query
+          required: false
+          description: |
+            If `true`, validates and simulates the operation without committing changes.
+            The response shape is identical to a real execution.
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: OK - Invite cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CancelInviteResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
+          description: Conflict - Invite already cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/500"
   /iam/v1/roles:
     get:
       tags:
@@ -3673,167 +3834,6 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
-  /iam/v1/users/invite:
-    post:
-      tags:
-        - Users
-      summary: Invite user
-      description: Invites a new user to the organization with specified role and organization.
-      operationId: inviteUser
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/InviteUserRequest"
-      responses:
-        "201":
-          description: Created - User invitation created successfully.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/InviteResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
-  "/iam/v1/users/{id}/actions/resend":
-    post:
-      tags:
-        - Users
-      summary: Resend invite
-      description: |
-        Resets the invite expiry to 48 hours from now, invalidates the previous invite token (so
-        old email links stop working), and triggers a fresh invitation email. Works on invites in
-        any state including `Cancelled` — resending a cancelled invite reactivates it to `Pending`.
-
-        Returns `404` if no invite exists for the given ID (never created, or already accepted and removed).
-
-        Requires `usersManager` permission.
-      operationId: resendInvite
-      parameters:
-        - name: id
-          in: path
-          description: The unique ID of the invited user.
-          required: true
-          schema:
-            type: string
-        - name: Idempotency-Key
-          in: header
-          required: true
-          description: |
-            Client-generated idempotency key (UUID v4 or ULID recommended, max 255 characters).
-            Re-submitting the same key with the same request returns the cached response without
-            re-executing side effects. The server retains the key for at least 24 hours.
-          schema:
-            type: string
-            maxLength: 255
-        - name: dryRun
-          in: query
-          required: false
-          description: |
-            If `true`, validates and simulates the operation without committing changes.
-            The response shape is identical to a real execution.
-          schema:
-            type: boolean
-            default: false
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "200":
-          description: OK - Invite resent and expiry reset.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResendInviteResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-  "/iam/v1/users/{id}/actions/cancel":
-    post:
-      tags:
-        - Users
-      summary: Cancel invite
-      description: |
-        Marks the invite as `Cancelled` and invalidates the invite token so any outstanding email
-        links stop working. The invite document is retained (soft cancel) — the user row remains
-        visible in `GET /iam/v1/users` with `inviteStatus: Cancelled`. Use `DELETE /iam/v1/users/{id}`
-        to fully remove the record.
-
-        Returns `404` if no invite exists for the given ID, and `409` if the invite is already cancelled.
-
-        Requires `usersManager` permission.
-      operationId: cancelInvite
-      parameters:
-        - name: id
-          in: path
-          description: The unique ID of the invited user.
-          required: true
-          schema:
-            type: string
-        - name: Idempotency-Key
-          in: header
-          required: true
-          description: |
-            Client-generated idempotency key (UUID v4 or ULID recommended, max 255 characters).
-            Re-submitting the same key with the same request returns the cached response without
-            re-executing side effects. The server retains the key for at least 24 hours.
-          schema:
-            type: string
-            maxLength: 255
-        - name: dryRun
-          in: query
-          required: false
-          description: |
-            If `true`, validates and simulates the operation without committing changes.
-            The response shape is identical to a real execution.
-          schema:
-            type: boolean
-            default: false
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "200":
-          description: OK - Invite cancelled.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CancelInviteResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-        "409":
-          description: Conflict - Invite already cancelled.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "500":
-          $ref: "#/components/responses/500"
   /clouddiagrams/v1/scheme/find:
     post:
       tags:
@@ -10722,6 +10722,17 @@ components:
           type: number
           format: double
           description: The projected spend at the end of this period, based on a linear regression over the period's total spend series. 0 when insufficient history is available to compute a forecast.
+    CloudFlowRefineRequest:
+      type: object
+      required:
+        - question
+      properties:
+        question:
+          type: string
+          description: Natural language description of what to refine or modify in the CloudFlow.
+        conversationId:
+          type: string
+          description: ID of an existing conversation to continue. When omitted, a new conversation is started.
     AvaAskRequest:
       type: object
       properties:
@@ -10750,18 +10761,26 @@ components:
         - question
     AvaAskSyncResponse:
       type: object
+      description: >-
+        Ava's response. On success, `answer` is present. The endpoint streams keep-alive
+        whitespace while generating (to avoid proxy timeouts), so the HTTP status is committed to
+        200 before the answer is ready; if generation then fails, `answer` is omitted and `error`
+        carries a message instead. Consumers should check for `error` before reading `answer`.
       properties:
         answer:
           type: string
-          description: The Ava response text.
+          description: The Ava response text. Present on success.
         conversationId:
           type: string
           description: The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.
         answerId:
           type: string
           description: The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.
-      required:
-        - answer
+        error:
+          type: string
+          description: >-
+            Present instead of `answer` when generation fails after the response has begun
+            streaming (the HTTP status remains 200). A human-readable error message.
     AvaFeedbackRequest:
       type: object
       properties:

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -2446,6 +2446,34 @@ paths:
           $ref: "#/components/responses/403"
         "500":
           $ref: "#/components/responses/500"
+  /iam/v1/users/invite:
+    post:
+      tags:
+        - Users
+      summary: Invite user
+      description: Invites a new user to the organization with specified role and organization.
+      operationId: inviteUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InviteUserRequest"
+      responses:
+        "201":
+          description: Created - User invitation created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InviteResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "500":
+          $ref: "#/components/responses/500"
   /iam/v1/roles:
     get:
       tags:
@@ -2761,34 +2789,6 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
-  /iam/v1/users/invite:
-    post:
-      tags:
-        - Users
-      summary: Invite user
-      description: Invites a new user to the organization with specified role and organization.
-      operationId: inviteUser
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/InviteUserRequest"
-      responses:
-        "201":
-          description: Created - User invitation created successfully.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/InviteResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "403":
-          $ref: "#/components/responses/403"
-        "500":
-          $ref: "#/components/responses/500"
   /clouddiagrams/v1/scheme/find:
     post:
       tags:
@@ -4634,18 +4634,22 @@ components:
         - question
     AvaAskSyncResponse:
       type: object
+      description: >-
+        Ava's response. On success, `answer` is present. The endpoint streams keep-alive whitespace while generating (to avoid proxy timeouts), so the HTTP status is committed to 200 before the answer is ready; if generation then fails, `answer` is omitted and `error` carries a message instead. Consumers should check for `error` before reading `answer`.
       properties:
         answer:
           type: string
-          description: The Ava response text.
+          description: The Ava response text. Present on success.
         conversationId:
           type: string
           description: The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.
         answerId:
           type: string
           description: The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.
-      required:
-        - answer
+        error:
+          type: string
+          description: >-
+            Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.
     AwsAccountResponse:
       type: object
       properties:

--- a/docs/data-sources/ava.md
+++ b/docs/data-sources/ava.md
@@ -54,7 +54,6 @@ output "report_summary" {
 ### Read-Only
 
 - `answer` (String) The Ava response text. Present on success.
-- `error` (String) Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.
 - `id` (String) A deterministic hash of the question, used as the data source identifier.
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/data-sources/ava.md
+++ b/docs/data-sources/ava.md
@@ -53,7 +53,8 @@ output "report_summary" {
 
 ### Read-Only
 
-- `answer` (String) The Ava response text.
+- `answer` (String) The Ava response text. Present on success.
+- `error` (String) Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.
 - `id` (String) A deterministic hash of the question, used as the data source identifier.
 
 <a id="nestedatt--timeouts"></a>

--- a/internal/provider/ava_data_source.go
+++ b/internal/provider/ava_data_source.go
@@ -29,6 +29,7 @@ type avaDataSourceModel struct {
 	Id       types.String   `tfsdk:"id"`
 	Question types.String   `tfsdk:"question"`
 	Answer   types.String   `tfsdk:"answer"`
+	Error    types.String   `tfsdk:"error"`
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
@@ -58,8 +59,13 @@ func (d *avaDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			},
 			"answer": schema.StringAttribute{
 				Computed:            true,
-				Description:         "The Ava response text.",
-				MarkdownDescription: "The Ava response text.",
+				Description:         "The Ava response text. Present on success.",
+				MarkdownDescription: "The Ava response text. Present on success.",
+			},
+			"error": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Present instead of answer when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.",
+				MarkdownDescription: "Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.",
 			},
 			"timeouts": timeouts.Attributes(ctx),
 		},
@@ -104,6 +110,7 @@ func (d *avaDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	if data.Question.IsUnknown() {
 		data.Id = types.StringUnknown()
 		data.Answer = types.StringUnknown()
+		data.Error = types.StringUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
@@ -131,10 +138,18 @@ func (d *avaDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	// Set a deterministic ID based on the question hash
+	if apiResp.JSON200.Error != nil {
+		resp.Diagnostics.AddError(
+			"Ava Generation Failed",
+			fmt.Sprintf("Ava returned an error instead of an answer: %s", *apiResp.JSON200.Error),
+		)
+		return
+	}
+
 	hash := sha256.Sum256([]byte(question))
 	data.Id = types.StringValue(fmt.Sprintf("%x", hash))
-	data.Answer = types.StringValue(apiResp.JSON200.Answer)
+	data.Answer = types.StringPointerValue(apiResp.JSON200.Answer)
+	data.Error = types.StringNull()
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/ava_data_source.go
+++ b/internal/provider/ava_data_source.go
@@ -29,7 +29,6 @@ type avaDataSourceModel struct {
 	Id       types.String   `tfsdk:"id"`
 	Question types.String   `tfsdk:"question"`
 	Answer   types.String   `tfsdk:"answer"`
-	Error    types.String   `tfsdk:"error"`
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
@@ -62,11 +61,7 @@ func (d *avaDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				Description:         "The Ava response text. Present on success.",
 				MarkdownDescription: "The Ava response text. Present on success.",
 			},
-			"error": schema.StringAttribute{
-				Computed:            true,
-				Description:         "Present instead of answer when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.",
-				MarkdownDescription: "Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.",
-			},
+
 			"timeouts": timeouts.Attributes(ctx),
 		},
 	}
@@ -110,7 +105,6 @@ func (d *avaDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	if data.Question.IsUnknown() {
 		data.Id = types.StringUnknown()
 		data.Answer = types.StringUnknown()
-		data.Error = types.StringUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
@@ -149,7 +143,6 @@ func (d *avaDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	hash := sha256.Sum256([]byte(question))
 	data.Id = types.StringValue(fmt.Sprintf("%x", hash))
 	data.Answer = types.StringPointerValue(apiResp.JSON200.Answer)
-	data.Error = types.StringNull()
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/ava_data_source_internal_test.go
+++ b/internal/provider/ava_data_source_internal_test.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestAvaDataSource_Read_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		responseBody  string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:         "success - answer present",
+			responseBody: `{"answer": "You are using AWS and GCP."}`,
+			expectError:  false,
+		},
+		{
+			name:          "generation failure - error present",
+			responseBody:  `{"error": "generation failed: internal timeout"}`,
+			expectError:   true,
+			errorContains: "generation failed: internal timeout",
+		},
+		{
+			name:          "empty body - JSON parse error",
+			responseBody:  ``,
+			expectError:   true,
+			errorContains: "Unable to send question to Ava",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				if tt.responseBody != "" {
+					_, _ = w.Write([]byte(tt.responseBody))
+				}
+			}))
+			defer server.Close()
+
+			client, err := models.NewClientWithResponses(server.URL)
+			if err != nil {
+				t.Fatalf("Failed to create client: %v", err)
+			}
+
+			ds := &avaDataSource{client: client}
+			ctx := context.Background()
+
+			schemaResp := &datasource.SchemaResponse{}
+			ds.Schema(ctx, datasource.SchemaRequest{}, schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("Failed to get schema: %v", schemaResp.Diagnostics)
+			}
+
+			configValues := map[string]tftypes.Value{
+				"question": tftypes.NewValue(tftypes.String, "What cloud providers am I using?"),
+			}
+			for attrName, attr := range schemaResp.Schema.Attributes {
+				if attrName == "question" {
+					continue
+				}
+				configValues[attrName] = tftypes.NewValue(attr.GetType().TerraformType(ctx), nil)
+			}
+
+			attrTypes := make(map[string]tftypes.Type)
+			for name, attr := range schemaResp.Schema.Attributes {
+				attrTypes[name] = attr.GetType().TerraformType(ctx)
+			}
+			configType := tftypes.Object{
+				AttributeTypes: attrTypes,
+			}
+			configVal := tftypes.NewValue(configType, configValues)
+			config := tfsdk.Config{
+				Schema: schemaResp.Schema,
+				Raw:    configVal,
+			}
+
+			readReq := datasource.ReadRequest{
+				Config: config,
+			}
+			readResp := &datasource.ReadResponse{
+				State: tfsdk.State{
+					Schema: schemaResp.Schema,
+				},
+			}
+
+			ds.Read(ctx, readReq, readResp)
+
+			hasError := readResp.Diagnostics.HasError()
+			if hasError != tt.expectError {
+				t.Errorf("Read() hasError = %v, expectError %v; diagnostics: %v",
+					hasError, tt.expectError, readResp.Diagnostics)
+			}
+
+			if tt.expectError && tt.errorContains != "" {
+				found := false
+				for _, d := range readResp.Diagnostics {
+					if strings.Contains(d.Detail(), tt.errorContains) || strings.Contains(d.Summary(), tt.errorContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected error containing %q, got: %v", tt.errorContains, readResp.Diagnostics)
+				}
+			}
+		})
+	}
+}

--- a/internal/provider/ava_data_source_test.go
+++ b/internal/provider/ava_data_source_test.go
@@ -4,9 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccAvaDataSource_Basic(t *testing.T) {
@@ -22,13 +19,6 @@ func TestAccAvaDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.doit_ava.test", "id"),
 					resource.TestCheckResourceAttr("data.doit_ava.test", "question", "What cloud providers am I using?"),
 				),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"data.doit_ava.test",
-						tfjsonpath.New("error"),
-						knownvalue.Null(),
-					),
-				},
 			},
 			// Note: No drift check step. Ava responses are non-deterministic,
 			// so re-applying would always produce a diff on `answer`.

--- a/internal/provider/ava_data_source_test.go
+++ b/internal/provider/ava_data_source_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccAvaDataSource_Basic(t *testing.T) {
@@ -19,6 +22,13 @@ func TestAccAvaDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.doit_ava.test", "id"),
 					resource.TestCheckResourceAttr("data.doit_ava.test", "question", "What cloud providers am I using?"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.doit_ava.test",
+						tfjsonpath.New("error"),
+						knownvalue.Null(),
+					),
+				},
 			},
 			// Note: No drift check step. Ava responses are non-deterministic,
 			// so re-applying would always produce a diff on `answer`.

--- a/internal/provider/datasource_ava/ava_data_source_gen.go
+++ b/internal/provider/datasource_ava/ava_data_source_gen.go
@@ -14,8 +14,8 @@ func AvaDataSourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"answer": schema.StringAttribute{
 				Computed:            true,
-				Description:         "The Ava response text.",
-				MarkdownDescription: "The Ava response text.",
+				Description:         "The Ava response text. Present on success.",
+				MarkdownDescription: "The Ava response text. Present on success.",
 			},
 			"answer_id": schema.StringAttribute{
 				Computed:            true,
@@ -27,6 +27,11 @@ func AvaDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.",
 				MarkdownDescription: "The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.",
 			},
+			"error": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.",
+				MarkdownDescription: "Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.",
+			},
 		},
 		Description:         "Interact with Ava, DoiT's AI-powered cloud assistant.",
 		MarkdownDescription: "Interact with Ava, DoiT's AI-powered cloud assistant.",
@@ -37,4 +42,5 @@ type AvaModel struct {
 	Answer         types.String `tfsdk:"answer"`
 	AnswerId       types.String `tfsdk:"answer_id"`
 	ConversationId types.String `tfsdk:"conversation_id"`
+	Error          types.String `tfsdk:"error"`
 }

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -4073,16 +4073,19 @@ type AvaAskSyncRequest struct {
 	Question string `json:"question"`
 }
 
-// AvaAskSyncResponse defines model for AvaAskSyncResponse.
+// AvaAskSyncResponse Ava's response. On success, `answer` is present. The endpoint streams keep-alive whitespace while generating (to avoid proxy timeouts), so the HTTP status is committed to 200 before the answer is ready; if generation then fails, `answer` is omitted and `error` carries a message instead. Consumers should check for `error` before reading `answer`.
 type AvaAskSyncResponse struct {
-	// Answer The Ava response text.
-	Answer string `json:"answer"`
+	// Answer The Ava response text. Present on success.
+	Answer *string `json:"answer,omitempty"`
 
 	// AnswerId The answer ID within the conversation. Present only for non-ephemeral requests. Required for the feedback endpoint.
 	AnswerId *string `json:"answerId,omitempty"`
 
 	// ConversationId The conversation ID. Present only for non-ephemeral requests. Can be used with the delete conversation endpoint.
 	ConversationId *string `json:"conversationId,omitempty"`
+
+	// Error Present instead of `answer` when generation fails after the response has begun streaming (the HTTP status remains 200). A human-readable error message.
+	Error *string `json:"error,omitempty"`
 }
 
 // AwsAccountResponse defines model for AwsAccountResponse.


### PR DESCRIPTION
## What changed

Syncs the upstream API spec changes for the `AvaAskSyncResponse` schema and updates the `doit_ava` data source to handle the new `error` response field and the `answer` field becoming optional (`*string`).

### Background

The Ava sync endpoint streams keep-alive whitespace while generating a response (to avoid proxy timeouts), so the HTTP status is committed to 200 before the answer is ready. If generation then fails, `answer` is omitted and `error` carries a message instead.

### Changes

- **OpenAPI spec sync**: Updated `openapi_spec_full.yml`, `openapi_spec_processed.yml`, and regenerated models + datasource schema
- **`ava_data_source.go`**:
  - Fixed `Answer` mapping to use `types.StringPointerValue()` (now `*string` upstream)
  - Added error-first check: when `error` is present in the API response, surfaces it as a Terraform diagnostic error so `terraform apply` fails visibly
  - The `error` field is intentionally **not** exposed as a schema attribute — since the data source returns a diagnostic error on failure, state is never persisted in the error case, so the attribute would always be null
- **`ava_data_source_internal_test.go`** (new): Unit test with `httptest.Server` covering:
  - Success path (answer present)
  - Generation failure (error present, deterministic)
  - Empty body (JSON parse error)
- **`docs/data-sources/ava.md`**: Regenerated

### How validated

- `go build ./...` ✅
- `go vet ./internal/provider/...` ✅
- `go test ./internal/provider/ -run TestAvaDataSource_Read_ErrorHandling` ✅ (3/3 pass)
- All pre-commit hooks pass