### PR TITLE
feat(codegen): flatten inline allOf and handle $ref with siblings

### DIFF
--- a/tools/extract-inline-schemas/main.go
+++ b/tools/extract-inline-schemas/main.go
@@ -84,7 +84,13 @@ func main() {
 		extractor.insertExtractedSchemas(schemasNode)
 	}
 
-	// Phase 3.5: Flatten multi-element allOf compositions in components/schemas.
+	// Phase 3.5: Wrap $ref nodes with sibling keywords (e.g., nullable) into allOf.
+	// OAS 3.1 allows $ref with siblings, but codegen tools expect 3.0-style allOf.
+	// This must run before flattenAllOfSchemas so both named and inline patterns
+	// are normalized.
+	wrapRefSiblings(doc)
+
+	// Phase 3.6: Flatten multi-element allOf compositions in components/schemas.
 	// Schemas like {allOf: [$ref: Base, {properties: {extra}}]} are merged into
 	// a single {type: object, properties: {all Base props + extra}}. This allows
 	// downstream code generators (tfplugingen-openapi) that don't support allOf
@@ -537,6 +543,63 @@ func hasRef(node *yaml.Node) bool {
 		}
 	}
 	return false
+}
+
+// wrapRefSiblings recursively walks the YAML tree and wraps any $ref node
+// that has sibling keywords (e.g., description, nullable) in a single-member
+// allOf. This converts valid OAS 3.1 patterns into 3.0-compatible structures.
+//
+// Before:  {$ref: "#/.../Foo", description: "...", nullable: true}.
+// After:   {allOf: [{$ref: "#/.../Foo"}], description: "...", nullable: true}.
+func wrapRefSiblings(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		refIdx := -1
+		for i := 0; i < len(node.Content)-1; i += 2 {
+			if node.Content[i].Value == "$ref" {
+				refIdx = i
+				break
+			}
+		}
+		if refIdx >= 0 && len(node.Content) > 2 {
+			refKeyNode := node.Content[refIdx]
+			refValNode := node.Content[refIdx+1]
+
+			innerRef := &yaml.Node{
+				Kind:    yaml.MappingNode,
+				Content: []*yaml.Node{refKeyNode, refValNode},
+			}
+
+			var siblings []*yaml.Node
+			for i := 0; i < len(node.Content)-1; i += 2 {
+				if i != refIdx {
+					siblings = append(siblings, node.Content[i], node.Content[i+1])
+				}
+			}
+
+			node.Content = append(
+				[]*yaml.Node{
+					{Kind: yaml.ScalarNode, Value: "allOf", Tag: "!!str"},
+					{Kind: yaml.SequenceNode, Content: []*yaml.Node{innerRef}},
+				},
+				siblings...,
+			)
+		}
+		for i := 1; i < len(node.Content); i += 2 {
+			wrapRefSiblings(node.Content[i])
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			wrapRefSiblings(child)
+		}
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			wrapRefSiblings(child)
+		}
+	}
 }
 
 // flattenAllOfSchemas walks all named schemas in components/schemas and flattens
@@ -1000,24 +1063,42 @@ func resolveRefs(v any, schemas map[string]any) any {
 func resolveRefsWithVisited(v any, schemas map[string]any, visited map[string]bool) any {
 	switch val := v.(type) {
 	case map[string]any:
-		// Check if this is a $ref
-		if ref, ok := val["$ref"].(string); ok && len(val) == 1 {
+		// Check if this is a $ref (with or without sibling keywords).
+		// OAS 3.1 allows $ref with siblings; we resolve the $ref and
+		// merge the non-$ref siblings into the result so that equivalence
+		// checking works correctly after wrapRefSiblings transforms them.
+		if ref, ok := val["$ref"].(string); ok {
 			const prefix = "#/components/schemas/"
 			if strings.HasPrefix(ref, prefix) {
 				name := ref[len(prefix):]
 				if visited[name] {
-					// Circular reference — return as-is to avoid infinite loop
 					return val
 				}
 				if schema, ok := schemas[name]; ok {
 					newVisited := make(map[string]bool, len(visited)+1)
 					maps.Copy(newVisited, visited)
 					newVisited[name] = true
-					return resolveRefsWithVisited(schema, schemas, newVisited)
+					resolved := resolveRefsWithVisited(schema, schemas, newVisited)
+					if len(val) > 1 {
+						if resolvedMap, ok := resolved.(map[string]any); ok {
+							merged := make(map[string]any, len(resolvedMap)+len(val))
+							for k, v := range resolvedMap {
+								merged[k] = v
+							}
+							for k, v := range val {
+								if k != "$ref" {
+									merged[k] = resolveRefsWithVisited(v, schemas, newVisited)
+								}
+							}
+							return merged
+						}
+					}
+					return resolved
 				}
 			}
-			// Non-schema $ref (e.g., responses, parameters) — leave as-is
-			return val
+			if len(val) == 1 {
+				return val
+			}
 		}
 
 		result := make(map[string]any, len(val))
@@ -1051,16 +1132,33 @@ func stripDocFields(v any) any {
 			}
 			result[k] = stripDocFields(v)
 		}
-		// Unwrap single-element allOf/anyOf/oneOf when it's the only remaining key.
-		// This handles the pattern: {description: "...", allOf: [{$ref: ...}]}
-		// After stripping description: {allOf: [{resolved_schema}]}
-		// Which should be equivalent to just {resolved_schema}.
+		// Unwrap single-element allOf/anyOf/oneOf.
+		// Case 1: {allOf: [{resolved_schema}]} → {resolved_schema}
+		// Case 2: {allOf: [{resolved_schema}], nullable: true} → {resolved_schema..., nullable: true}
+		// Case 2 handles patterns from wrapRefSiblings where $ref+siblings
+		// becomes allOf+siblings, which must resolve equivalently.
 		for _, compKey := range []string{"allOf", "anyOf", "oneOf"} {
-			if items, ok := result[compKey].([]any); ok && len(items) == 1 && len(result) == 1 {
-				if inner, ok := items[0].(map[string]any); ok {
-					return inner
+			items, ok := result[compKey].([]any)
+			if !ok || len(items) != 1 {
+				continue
+			}
+			inner, ok := items[0].(map[string]any)
+			if !ok {
+				continue
+			}
+			if len(result) == 1 {
+				return inner
+			}
+			merged := make(map[string]any, len(inner)+len(result))
+			for k, v := range inner {
+				merged[k] = v
+			}
+			for k, v := range result {
+				if k != compKey {
+					merged[k] = v
 				}
 			}
+			return merged
 		}
 		// Merge multi-element allOf: when all elements are objects, merge their
 		// properties and required arrays into a single flat object.

--- a/tools/extract-inline-schemas/main.go
+++ b/tools/extract-inline-schemas/main.go
@@ -546,11 +546,15 @@ func hasRef(node *yaml.Node) bool {
 }
 
 // wrapRefSiblings recursively walks the YAML tree and wraps any $ref node
-// that has sibling keywords (e.g., description, nullable) in a single-member
-// allOf. This converts valid OAS 3.1 patterns into 3.0-compatible structures.
+// that has sibling keywords (e.g., nullable) in a single-member allOf.
+// This converts valid OAS 3.1 patterns into 3.0-compatible structures.
 //
-// Before:  {$ref: "#/.../Foo", description: "...", nullable: true}.
-// After:   {allOf: [{$ref: "#/.../Foo"}], description: "...", nullable: true}.
+// Non-schema Reference Objects (where the only siblings are summary and/or
+// description) are left untouched — those are valid OAS 3.1 reference
+// annotations, not schema compositions.
+//
+// Before:  {$ref: "#/.../Foo", nullable: true}.
+// After:   {allOf: [{$ref: "#/.../Foo"}], nullable: true}.
 func wrapRefSiblings(node *yaml.Node) {
 	if node == nil {
 		return
@@ -564,7 +568,7 @@ func wrapRefSiblings(node *yaml.Node) {
 				break
 			}
 		}
-		if refIdx >= 0 && len(node.Content) > 2 {
+		if refIdx >= 0 && len(node.Content) > 2 && hasSchemaKeywordSiblings(node, refIdx) {
 			refKeyNode := node.Content[refIdx]
 			refValNode := node.Content[refIdx+1]
 
@@ -600,6 +604,22 @@ func wrapRefSiblings(node *yaml.Node) {
 			wrapRefSiblings(child)
 		}
 	}
+}
+
+// hasSchemaKeywordSiblings returns true if a mapping node has sibling keys
+// beyond $ref that are schema keywords (not just summary/description which
+// are valid on non-schema Reference Objects in OAS 3.1).
+func hasSchemaKeywordSiblings(node *yaml.Node, refIdx int) bool {
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if i == refIdx {
+			continue
+		}
+		key := node.Content[i].Value
+		if key != "summary" && key != "description" {
+			return true
+		}
+	}
+	return false
 }
 
 // flattenAllOfSchemas walks all named schemas in components/schemas and flattens
@@ -1081,16 +1101,16 @@ func resolveRefsWithVisited(v any, schemas map[string]any, visited map[string]bo
 					resolved := resolveRefsWithVisited(schema, schemas, newVisited)
 					if len(val) > 1 {
 						if resolvedMap, ok := resolved.(map[string]any); ok {
-							merged := make(map[string]any, len(resolvedMap)+len(val))
-							for k, v := range resolvedMap {
-								merged[k] = v
-							}
+							siblings := make(map[string]any, len(val)-1)
 							for k, v := range val {
 								if k != "$ref" {
-									merged[k] = resolveRefsWithVisited(v, schemas, newVisited)
+									siblings[k] = resolveRefsWithVisited(v, schemas, newVisited)
 								}
 							}
-							return merged
+							merged, ok := mergeAllOfItems([]any{resolvedMap, siblings})
+							if ok {
+								return merged
+							}
 						}
 					}
 					return resolved
@@ -1149,16 +1169,15 @@ func stripDocFields(v any) any {
 			if len(result) == 1 {
 				return inner
 			}
-			merged := make(map[string]any, len(inner)+len(result))
-			for k, v := range inner {
-				merged[k] = v
-			}
+			siblings := make(map[string]any, len(result)-1)
 			for k, v := range result {
 				if k != compKey {
-					merged[k] = v
+					siblings[k] = v
 				}
 			}
-			return merged
+			if m, ok := mergeAllOfItems([]any{inner, siblings}); ok {
+				return m
+			}
 		}
 		// Merge multi-element allOf: when all elements are objects, merge their
 		// properties and required arrays into a single flat object.

--- a/tools/extract-inline-schemas/main_test.go
+++ b/tools/extract-inline-schemas/main_test.go
@@ -521,6 +521,42 @@ func TestStripDocFields(t *testing.T) {
 			t.Error("inner 'properties' should be present after merge")
 		}
 	})
+
+	t.Run("unwraps single-element allOf with overlapping properties using union", func(t *testing.T) {
+		input := map[string]any{
+			"properties": map[string]any{
+				"a": map[string]any{"type": "string"},
+			},
+			"required": []any{"a"},
+			"allOf": []any{
+				map[string]any{
+					"properties": map[string]any{
+						"b": map[string]any{"type": "integer"},
+					},
+					"required": []any{"b"},
+				},
+			},
+		}
+		got := stripDocFields(input).(map[string]any)
+		if _, ok := got["allOf"]; ok {
+			t.Error("single-element allOf should be unwrapped")
+		}
+		props := got["properties"].(map[string]any)
+		if _, ok := props["a"]; !ok {
+			t.Error("sibling property 'a' should be preserved")
+		}
+		if _, ok := props["b"]; !ok {
+			t.Error("inner property 'b' should be preserved")
+		}
+		req := got["required"].([]any)
+		seen := map[string]bool{}
+		for _, r := range req {
+			seen[r.(string)] = true
+		}
+		if !seen["a"] || !seen["b"] {
+			t.Errorf("required should contain both 'a' and 'b', got %v", req)
+		}
+	})
 }
 
 // --- mergeAllOfItems ---
@@ -607,6 +643,83 @@ func TestMergeAllOfItems(t *testing.T) {
 		req := merged["required"].([]any)
 		if len(req) != 3 {
 			t.Errorf("expected 3 unique required fields, got %d: %v", len(req), req)
+		}
+	})
+}
+
+// --- wrapRefSiblings ---
+
+func TestWrapRefSiblings(t *testing.T) {
+	t.Run("wraps $ref with schema keyword siblings", func(t *testing.T) {
+		node := mustParseYAML(t, `
+root:
+  $ref: "#/components/schemas/Foo"
+  nullable: true
+`)
+		root := getMappingValue(node, "root")
+		wrapRefSiblings(root)
+		if getMappingValue(root, "allOf") == nil {
+			t.Error("$ref with nullable should be wrapped in allOf")
+		}
+		if getMappingValue(root, "$ref") != nil {
+			t.Error("$ref should be moved inside allOf")
+		}
+	})
+
+	t.Run("skips $ref with only description sibling", func(t *testing.T) {
+		node := mustParseYAML(t, `
+root:
+  $ref: "#/components/responses/NotFound"
+  description: "Not found response"
+`)
+		root := getMappingValue(node, "root")
+		wrapRefSiblings(root)
+		if getMappingValue(root, "allOf") != nil {
+			t.Error("$ref with only description sibling should NOT be wrapped")
+		}
+		if getScalarValue(root, "$ref") != "#/components/responses/NotFound" {
+			t.Error("$ref should remain untouched")
+		}
+	})
+
+	t.Run("skips $ref with only summary sibling", func(t *testing.T) {
+		node := mustParseYAML(t, `
+root:
+  $ref: "#/components/schemas/Bar"
+  summary: "A bar"
+`)
+		root := getMappingValue(node, "root")
+		wrapRefSiblings(root)
+		if getMappingValue(root, "allOf") != nil {
+			t.Error("$ref with only summary sibling should NOT be wrapped")
+		}
+	})
+
+	t.Run("skips $ref with summary and description siblings only", func(t *testing.T) {
+		node := mustParseYAML(t, `
+root:
+  $ref: "#/components/parameters/PageToken"
+  summary: "Pagination token"
+  description: "The token returned from the previous page"
+`)
+		root := getMappingValue(node, "root")
+		wrapRefSiblings(root)
+		if getMappingValue(root, "allOf") != nil {
+			t.Error("$ref with only summary+description siblings should NOT be wrapped")
+		}
+	})
+
+	t.Run("wraps $ref with description and schema keyword siblings", func(t *testing.T) {
+		node := mustParseYAML(t, `
+root:
+  $ref: "#/components/schemas/Foo"
+  description: "A foo"
+  nullable: true
+`)
+		root := getMappingValue(node, "root")
+		wrapRefSiblings(root)
+		if getMappingValue(root, "allOf") == nil {
+			t.Error("$ref with description+nullable should be wrapped (nullable is a schema keyword)")
 		}
 	})
 }
@@ -969,6 +1082,46 @@ func TestResolveRefs(t *testing.T) {
 		got := resolveRefs(input, schemas).(map[string]any)
 		if got["$ref"] != "#/components/responses/NotFound" {
 			t.Error("non-schema ref should be left as-is")
+		}
+	})
+
+	t.Run("merges $ref with sibling properties using union", func(t *testing.T) {
+		schemas := map[string]any{
+			"Base": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{"type": "string"},
+					"b": map[string]any{"type": "string"},
+				},
+				"required": []any{"a"},
+			},
+		}
+		input := map[string]any{
+			"$ref": "#/components/schemas/Base",
+			"properties": map[string]any{
+				"c": map[string]any{"type": "integer"},
+			},
+			"required": []any{"b", "c"},
+		}
+		got := resolveRefs(input, schemas).(map[string]any)
+		props := got["properties"].(map[string]any)
+		for _, name := range []string{"a", "b", "c"} {
+			if _, ok := props[name]; !ok {
+				t.Errorf("expected property %q in merged result", name)
+			}
+		}
+		req := got["required"].([]any)
+		seen := map[string]bool{}
+		for _, r := range req {
+			seen[r.(string)] = true
+		}
+		for _, name := range []string{"a", "b", "c"} {
+			if !seen[name] {
+				t.Errorf("expected %q in required, got %v", name, req)
+			}
+		}
+		if len(req) != 3 {
+			t.Errorf("required should have 3 entries (deduped), got %d", len(req))
 		}
 	})
 }

--- a/tools/extract-inline-schemas/main_test.go
+++ b/tools/extract-inline-schemas/main_test.go
@@ -503,7 +503,7 @@ func TestStripDocFields(t *testing.T) {
 		}
 	})
 
-	t.Run("does not unwrap allOf with other sibling keys", func(t *testing.T) {
+	t.Run("unwraps single-element allOf with sibling keys by merging", func(t *testing.T) {
 		input := map[string]any{
 			"type": "object",
 			"allOf": []any{
@@ -511,8 +511,14 @@ func TestStripDocFields(t *testing.T) {
 			},
 		}
 		got := stripDocFields(input).(map[string]any)
-		if _, ok := got["allOf"]; !ok {
-			t.Error("allOf with sibling type should NOT be unwrapped")
+		if _, ok := got["allOf"]; ok {
+			t.Error("single-element allOf with siblings should be unwrapped (merged)")
+		}
+		if got["type"] != "object" {
+			t.Error("sibling key 'type' should be preserved after merge")
+		}
+		if _, ok := got["properties"]; !ok {
+			t.Error("inner 'properties' should be present after merge")
 		}
 	})
 }


### PR DESCRIPTION
Extend the schema extraction tool with:
- flattenInlineAllOf: recursively flatten multi-element allOf inside schema properties (e.g. CloudflowConnection.awsConfig extending a $ref with server-owned response fields)
- wrapRefSiblings: normalize OAS 3.1 $ref-with-siblings into 3.0-style allOf for codegen compatibility
- resolveRefsWithVisited: merge $ref sibling keywords during equivalence resolution
- stripDocFields: unwrap single-element allOf with siblings after doc-field stripping