### PR TITLE
fix(codegen): add missing flattenInlineAllOf function

### DIFF
--- a/tools/extract-inline-schemas/main.go
+++ b/tools/extract-inline-schemas/main.go
@@ -647,34 +647,7 @@ func flattenAllOfSchemas(schemasNode *yaml.Node) {
 			continue
 		}
 
-		// Preserve parent-level fields (description, example) from outside the allOf.
-		parentDesc := getScalarNode(schemaNode, "description")
-		parentExample := getMappingValue(schemaNode, "example")
-
-		// Replace the schema node content with the merged result.
-		schemaNode.Content = merged.Content
-
-		// Re-add parent description, overriding any inherited from sub-schemas.
-		if parentDesc != nil && parentDesc.Value != "" {
-			removeMappingKey(schemaNode, "description")
-			schemaNode.Content = append(
-				[]*yaml.Node{
-					{Kind: yaml.ScalarNode, Value: "description", Tag: "!!str"},
-					{Kind: yaml.ScalarNode, Value: parentDesc.Value, Tag: "!!str", Style: parentDesc.Style},
-				},
-				schemaNode.Content...,
-			)
-		}
-
-		// Re-add parent example, overriding any inherited from sub-schemas.
-		if parentExample != nil {
-			removeMappingKey(schemaNode, "example")
-			schemaNode.Content = append(schemaNode.Content,
-				&yaml.Node{Kind: yaml.ScalarNode, Value: "example", Tag: "!!str"},
-				deepCopyNode(parentExample),
-			)
-		}
-
+		applyMergedAllOf(schemaNode, merged)
 		fmt.Printf("Flattened allOf in schema %s\n", schemaName)
 	}
 
@@ -707,35 +680,40 @@ func flattenInlineAllOf(node *yaml.Node, schemasNode *yaml.Node, path string) {
 			propPath := path + "." + propName
 			merged := flattenAllOf(allOfNode, schemasNode, propPath)
 			if merged != nil {
-				parentDesc := getScalarNode(propVal, "description")
-				parentExample := getMappingValue(propVal, "example")
-
-				propVal.Content = merged.Content
-
-				if parentDesc != nil && parentDesc.Value != "" {
-					removeMappingKey(propVal, "description")
-					propVal.Content = append(
-						[]*yaml.Node{
-							{Kind: yaml.ScalarNode, Value: "description", Tag: "!!str"},
-							{Kind: yaml.ScalarNode, Value: parentDesc.Value, Tag: "!!str", Style: parentDesc.Style},
-						},
-						propVal.Content...,
-					)
-				}
-
-				if parentExample != nil {
-					removeMappingKey(propVal, "example")
-					propVal.Content = append(propVal.Content,
-						&yaml.Node{Kind: yaml.ScalarNode, Value: "example", Tag: "!!str"},
-						deepCopyNode(parentExample),
-					)
-				}
-
+				applyMergedAllOf(propVal, merged)
 				fmt.Printf("Flattened inline allOf in %s\n", propPath)
 			}
 		}
 
 		flattenInlineAllOf(propsNode.Content[i+1], schemasNode, path+"."+propName)
+	}
+}
+
+// applyMergedAllOf replaces a node's content with a merged allOf result,
+// preserving any parent-level description and example fields.
+func applyMergedAllOf(target *yaml.Node, merged *yaml.Node) {
+	parentDesc := getScalarNode(target, "description")
+	parentExample := getMappingValue(target, "example")
+
+	target.Content = merged.Content
+
+	if parentDesc != nil && parentDesc.Value != "" {
+		removeMappingKey(target, "description")
+		target.Content = append(
+			[]*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "description", Tag: "!!str"},
+				{Kind: yaml.ScalarNode, Value: parentDesc.Value, Tag: "!!str", Style: parentDesc.Style},
+			},
+			target.Content...,
+		)
+	}
+
+	if parentExample != nil {
+		removeMappingKey(target, "example")
+		target.Content = append(target.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "example", Tag: "!!str"},
+			deepCopyNode(parentExample),
+		)
 	}
 }
 

--- a/tools/extract-inline-schemas/main.go
+++ b/tools/extract-inline-schemas/main.go
@@ -677,6 +677,66 @@ func flattenAllOfSchemas(schemasNode *yaml.Node) {
 
 		fmt.Printf("Flattened allOf in schema %s\n", schemaName)
 	}
+
+	for i := 0; i < len(schemasNode.Content)-1; i += 2 {
+		schemaName := schemasNode.Content[i].Value
+		schemaNode := schemasNode.Content[i+1]
+		flattenInlineAllOf(schemaNode, schemasNode, schemaName)
+	}
+}
+
+// flattenInlineAllOf recursively walks a schema node's properties and
+// flattens any inline multi-element allOf found in property values.
+func flattenInlineAllOf(node *yaml.Node, schemasNode *yaml.Node, path string) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	propsNode := getMappingValue(node, "properties")
+	if propsNode == nil || propsNode.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(propsNode.Content)-1; i += 2 {
+		propName := propsNode.Content[i].Value
+		propVal := propsNode.Content[i+1]
+		if propVal.Kind != yaml.MappingNode {
+			continue
+		}
+
+		allOfNode := getMappingValue(propVal, "allOf")
+		if allOfNode != nil && allOfNode.Kind == yaml.SequenceNode && len(allOfNode.Content) >= 2 {
+			propPath := path + "." + propName
+			merged := flattenAllOf(allOfNode, schemasNode, propPath)
+			if merged != nil {
+				parentDesc := getScalarNode(propVal, "description")
+				parentExample := getMappingValue(propVal, "example")
+
+				propVal.Content = merged.Content
+
+				if parentDesc != nil && parentDesc.Value != "" {
+					removeMappingKey(propVal, "description")
+					propVal.Content = append(
+						[]*yaml.Node{
+							{Kind: yaml.ScalarNode, Value: "description", Tag: "!!str"},
+							{Kind: yaml.ScalarNode, Value: parentDesc.Value, Tag: "!!str", Style: parentDesc.Style},
+						},
+						propVal.Content...,
+					)
+				}
+
+				if parentExample != nil {
+					removeMappingKey(propVal, "example")
+					propVal.Content = append(propVal.Content,
+						&yaml.Node{Kind: yaml.ScalarNode, Value: "example", Tag: "!!str"},
+						deepCopyNode(parentExample),
+					)
+				}
+
+				fmt.Printf("Flattened inline allOf in %s\n", propPath)
+			}
+		}
+
+		flattenInlineAllOf(propsNode.Content[i+1], schemasNode, path+"."+propName)
+	}
 }
 
 // flattenAllOf merges all sub-schemas of an allOf sequence node into a single

--- a/tools/extract-inline-schemas/main_test.go
+++ b/tools/extract-inline-schemas/main_test.go
@@ -900,6 +900,139 @@ B:
 	})
 }
 
+func TestFlattenInlineAllOf(t *testing.T) {
+	t.Run("inline property allOf (CloudflowConnection pattern)", func(t *testing.T) {
+		schemasNode := mustParseYAML(t, `
+GCPConfigRequest:
+  type: object
+  properties:
+    projectId:
+      type: string
+    level:
+      type: string
+CloudflowConnection:
+  type: object
+  properties:
+    name:
+      type: string
+    gcpConfig:
+      allOf:
+        - $ref: "#/components/schemas/GCPConfigRequest"
+        - type: object
+          properties:
+            status:
+              type: string
+            deploymentCommand:
+              type: string
+`)
+		flattenAllOfSchemas(schemasNode)
+
+		conn := getMappingValue(schemasNode, "CloudflowConnection")
+		gcpConfig := getMappingValue(getMappingValue(conn, "properties"), "gcpConfig")
+		if gcpConfig == nil {
+			t.Fatal("gcpConfig not found")
+		}
+		if getMappingValue(gcpConfig, "allOf") != nil {
+			t.Error("allOf should have been flattened")
+		}
+		if getScalarValue(gcpConfig, "type") != "object" {
+			t.Error("flattened gcpConfig should have type: object")
+		}
+		props := getMappingValue(gcpConfig, "properties")
+		if props == nil {
+			t.Fatal("properties not found on flattened gcpConfig")
+		}
+		for _, name := range []string{"projectId", "level", "status", "deploymentCommand"} {
+			if getMappingValue(props, name) == nil {
+				t.Errorf("expected property %q in flattened gcpConfig", name)
+			}
+		}
+	})
+
+	t.Run("nested inline allOf", func(t *testing.T) {
+		schemasNode := mustParseYAML(t, `
+Inner:
+  type: object
+  properties:
+    x:
+      type: string
+Outer:
+  type: object
+  properties:
+    wrapper:
+      type: object
+      properties:
+        nested:
+          allOf:
+            - $ref: "#/components/schemas/Inner"
+            - type: object
+              properties:
+                y:
+                  type: integer
+`)
+		flattenAllOfSchemas(schemasNode)
+
+		outer := getMappingValue(schemasNode, "Outer")
+		wrapper := getMappingValue(getMappingValue(outer, "properties"), "wrapper")
+		nested := getMappingValue(getMappingValue(wrapper, "properties"), "nested")
+		if nested == nil {
+			t.Fatal("nested not found")
+		}
+		if getMappingValue(nested, "allOf") != nil {
+			t.Error("nested allOf should have been flattened")
+		}
+		props := getMappingValue(nested, "properties")
+		if getMappingValue(props, "x") == nil {
+			t.Error("expected property x from $ref")
+		}
+		if getMappingValue(props, "y") == nil {
+			t.Error("expected property y from inline extension")
+		}
+	})
+
+	t.Run("sibling key preservation", func(t *testing.T) {
+		schemasNode := mustParseYAML(t, `
+Base:
+  type: object
+  properties:
+    a:
+      type: string
+Parent:
+  type: object
+  properties:
+    child:
+      description: "Keep this description"
+      allOf:
+        - $ref: "#/components/schemas/Base"
+        - type: object
+          properties:
+            b:
+              type: integer
+`)
+		flattenAllOfSchemas(schemasNode)
+
+		parent := getMappingValue(schemasNode, "Parent")
+		child := getMappingValue(getMappingValue(parent, "properties"), "child")
+		if child == nil {
+			t.Fatal("child not found")
+		}
+		desc := getScalarValue(child, "description")
+		if desc != "Keep this description" {
+			t.Errorf("expected parent description to be preserved, got %q", desc)
+		}
+		if getMappingValue(child, "allOf") != nil {
+			t.Error("allOf should have been flattened")
+		}
+		props := getMappingValue(child, "properties")
+		if getMappingValue(props, "a") == nil {
+			t.Error("expected property a from $ref")
+		}
+		if getMappingValue(props, "b") == nil {
+			t.Error("expected property b from inline extension")
+		}
+	})
+}
+
 // --- validateEquivalence with flattened allOf ---
 
 func TestValidateEquivalence_FlattenedAllOf(t *testing.T) {


### PR DESCRIPTION
## What

Adds the `flattenInlineAllOf` function and its wiring into `flattenAllOfSchemas` that were accidentally excluded from PR #248.

## Why

During the cherry-pick that created the tool branch for #248, the `flattenInlineAllOf` changes were in uncommitted state (stashed) and were not included. This caused inline `allOf` patterns in property values (e.g. `CloudflowConnection.gcpConfig`, `CloudflowConnection.awsConfig`) to pass through unflattened, resulting in response-only fields being dropped from the generated Terraform schema.

## Changes

- **`flattenAllOfSchemas`**: Added second pass that walks each named schema's property tree
- **`flattenInlineAllOf`**: Recursive helper that flattens multi-element `allOf` found inside property values, using the same `flattenAllOf` merge logic
- **Tests**: 3 new test cases (inline property allOf, nested inline allOf, sibling key preservation)

## Verification

- All tool tests pass
- `make generate` succeeds with the CloudFlow spec — output now includes all response-only fields (`gcp_config.status`, `gcp_config.deployment_command`, `aws_config.context[].status`, top-level `status`, `created_at`, `updated_at`)