### PR TITLE
feat(linters): flag discarded diag.Diagnostics returns in diagsuppressed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -178,7 +178,7 @@ linters:
     custom:
       diagsuppressed:
         type: "module"
-        description: "Detects suppressed diag.Diagnostics return values."
+        description: "Detects suppressed diag.Diagnostics return values (blank identifier or discarded bare call)."
       structliteral:
         type: "module"
         description: "Detects direct struct literal construction of generated Terraform Value types."

--- a/tools/linters/diagsuppressed/analyzer.go
+++ b/tools/linters/diagsuppressed/analyzer.go
@@ -1,18 +1,30 @@
 // Package diagsuppressed detects suppressed diagnostics in Terraform provider code.
 //
-// When a function returns diag.Diagnostics as its last return value, assigning
-// it to the blank identifier (_) silently swallows errors. This analyzer flags
-// all such assignments.
+// It flags two ways a diag.Diagnostics return value is silently swallowed:
 //
-// Bad:
+// 1. Assignment to the blank identifier (_):
 //
-//	myList, _ = types.ListValue(types.StringType, []attr.Value{})
+//	Bad:
 //
-// Good:
+//	    myList, _ = types.ListValue(types.StringType, []attr.Value{})
 //
-//	var listDiags diag.Diagnostics
-//	myList, listDiags = types.ListValue(types.StringType, []attr.Value{})
-//	diags.Append(listDiags...)
+//	Good:
+//
+//	    var listDiags diag.Diagnostics
+//	    myList, listDiags = types.ListValue(types.StringType, []attr.Value{})
+//	    diags.Append(listDiags...)
+//
+// 2. A bare call statement whose diag.Diagnostics return value is discarded
+// entirely (not assigned to anything, not even _):
+//
+//	Bad:
+//
+//	    state.Tags.ElementsAs(ctx, &gotTags, false) // return value dropped
+//
+//	Good:
+//
+//	    diags := state.Tags.ElementsAs(ctx, &gotTags, false)
+//	    resp.Diagnostics.Append(diags...)
 package diagsuppressed
 
 import (
@@ -27,7 +39,7 @@ import (
 // Analyzer is the go/analysis Analyzer for diagsuppressed.
 var Analyzer = &analysis.Analyzer{
 	Name:     "diagsuppressed",
-	Doc:      "Detects suppressed diag.Diagnostics return values assigned to blank identifier (_).",
+	Doc:      "Detects suppressed diag.Diagnostics return values (blank identifier or discarded bare call).",
 	Run:      run,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 }
@@ -38,38 +50,84 @@ const diagType = "github.com/hashicorp/terraform-plugin-framework/diag.Diagnosti
 func run(pass *analysis.Pass) (any, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-	nodeFilter := []ast.Node{(*ast.AssignStmt)(nil)}
+	nodeFilter := []ast.Node{(*ast.AssignStmt)(nil), (*ast.ExprStmt)(nil)}
 	insp.Preorder(nodeFilter, func(n ast.Node) {
-		assign := n.(*ast.AssignStmt)
-
-		// We need at least 2 LHS values (e.g., val, diags := ...).
-		if len(assign.Lhs) < 2 {
-			return
-		}
-
-		// Check each LHS for blank identifiers.
-		for i, lhs := range assign.Lhs {
-			ident, ok := lhs.(*ast.Ident)
-			if !ok || ident.Name != "_" {
-				continue
-			}
-
-			// Get the type of this position by looking at the RHS.
-			// For multi-return calls, we need the type of the i-th return value.
-			typ := typeOfPosition(pass, assign, i)
-			if typ == nil {
-				continue
-			}
-
-			if isDiagnosticsType(typ) {
-				pass.Reportf(ident.Pos(),
-					"diag.Diagnostics return value must not be suppressed with blank identifier; "+
-						"assign to a variable and append to the function's diagnostics")
-			}
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			checkBlankAssign(pass, stmt)
+		case *ast.ExprStmt:
+			checkDiscardedCall(pass, stmt)
 		}
 	})
 
 	return nil, nil
+}
+
+// checkBlankAssign flags diag.Diagnostics return values assigned to the blank
+// identifier (e.g. val, _ := listValue()).
+func checkBlankAssign(pass *analysis.Pass, assign *ast.AssignStmt) {
+	// We need at least 2 LHS values (e.g., val, diags := ...).
+	if len(assign.Lhs) < 2 {
+		return
+	}
+
+	// Check each LHS for blank identifiers.
+	for i, lhs := range assign.Lhs {
+		ident, ok := lhs.(*ast.Ident)
+		if !ok || ident.Name != "_" {
+			continue
+		}
+
+		// Get the type of this position by looking at the RHS.
+		// For multi-return calls, we need the type of the i-th return value.
+		typ := typeOfPosition(pass, assign, i)
+		if typ == nil {
+			continue
+		}
+
+		if isDiagnosticsType(typ) {
+			pass.Reportf(ident.Pos(),
+				"diag.Diagnostics return value must not be suppressed with blank identifier; "+
+					"assign to a variable and append to the function's diagnostics")
+		}
+	}
+}
+
+// checkDiscardedCall flags a bare call statement whose diag.Diagnostics return
+// value is discarded entirely (not assigned to anything, not even _), e.g.
+// state.Tags.ElementsAs(ctx, &gotTags, false).
+func checkDiscardedCall(pass *analysis.Pass, stmt *ast.ExprStmt) {
+	call, ok := stmt.X.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+
+	typ := pass.TypesInfo.TypeOf(call)
+	if typ == nil {
+		return
+	}
+
+	if !returnsDiagnostics(typ) {
+		return
+	}
+
+	pass.Reportf(call.Pos(),
+		"diag.Diagnostics return value must not be discarded; "+
+			"assign to a variable and append to the function's diagnostics")
+}
+
+// returnsDiagnostics reports whether a call's result type is diag.Diagnostics
+// (single return) or a tuple containing diag.Diagnostics (multi-return).
+func returnsDiagnostics(typ types.Type) bool {
+	if tuple, ok := typ.(*types.Tuple); ok {
+		for i := 0; i < tuple.Len(); i++ {
+			if isDiagnosticsType(tuple.At(i).Type()) {
+				return true
+			}
+		}
+		return false
+	}
+	return isDiagnosticsType(typ)
 }
 
 // typeOfPosition returns the type of the i-th element in a multi-value assignment.

--- a/tools/linters/diagsuppressed/testdata/src/diagtest/diagtest.go
+++ b/tools/linters/diagsuppressed/testdata/src/diagtest/diagtest.go
@@ -21,6 +21,20 @@ func twoStrings() (string, string) {
 	return "", ""
 }
 
+// elementsAs returns diag.Diagnostics as a single value, mirroring
+// types.Set.ElementsAs / types.List.ElementsAs.
+func (ListValue) elementsAs(_ interface{}) diag.Diagnostics {
+	return nil
+}
+
+// decode returns a value plus diagnostics, mirroring a multi-return helper.
+func decode() (ListValue, diag.Diagnostics) {
+	return ListValue{}, nil
+}
+
+// noReturn mirrors a void method like diags.Append(...).
+func (ListValue) noReturn() {}
+
 // --- BAD: suppressed diagnostics ---
 
 func badSuppressedDiag() {
@@ -30,6 +44,17 @@ func badSuppressedDiag() {
 func badSuppressedDiagShortAssign() {
 	list, _ := listValue() // want "diag.Diagnostics return value must not be suppressed"
 	_ = list
+}
+
+// --- BAD: discarded bare call (return value dropped entirely) ---
+
+func badDiscardedSingleReturn() {
+	var list ListValue
+	list.elementsAs(nil) // want "diag.Diagnostics return value must not be discarded"
+}
+
+func badDiscardedMultiReturn() {
+	decode() // want "diag.Diagnostics return value must not be discarded"
 }
 
 // --- GOOD: diagnostics properly handled ---
@@ -46,6 +71,14 @@ func goodHandledDiagAppend() {
 	_ = allDiags
 }
 
+func goodCapturedDiscardedCall() {
+	var list ListValue
+	var allDiags diag.Diagnostics
+	diags := list.elementsAs(nil)
+	allDiags.Append(diags...)
+	_ = allDiags
+}
+
 // --- NOT flagged: non-diagnostic blank identifiers ---
 
 func okBlankNonDiag() {
@@ -54,4 +87,15 @@ func okBlankNonDiag() {
 
 func okBlankTwoStrings() {
 	_, _ = twoStrings() // Two strings, not diagnostics.
+}
+
+// --- NOT flagged: bare calls that do not return diagnostics ---
+
+func okBareVoidCall() {
+	var list ListValue
+	list.noReturn() // Returns nothing.
+}
+
+func okBareNonDiagCall() {
+	stringValue() // Single non-diagnostic return, discarded.
 }


### PR DESCRIPTION
## What

Extend the `diagsuppressed` custom linter to catch a **bare call statement whose `diag.Diagnostics` return value is discarded entirely** — not assigned to anything, not even the blank identifier:

```go
state.Tags.ElementsAs(ctx, &gotTags, false) // return value dropped on the floor
```

## Why

This is the exact pattern [Copilot flagged](https://github.com/doitintl/terraform-provider-doit/pull/246) in `support_request_tags_internal_test.go`, which our custom linters missed. It fell into a gap between the two diagnostics linters:

| Pattern | Caught by |
|---|---|
| `x, _ := fn()` (blank identifier) | `diagsuppressed` ✅ |
| `d := fn()` then `d` never propagated | `diagdrop` ✅ |
| `fn()` (return value **entirely discarded**, bare call) | **nobody** ❌ |

`diagsuppressed` only inspected `AssignStmt` for a blank identifier; `diagdrop` only tracked diagnostics *captured into a named variable* — and is disabled on test files anyway. A fully-dropped return on a bare call was invisible to both.

Since `diagsuppressed` already runs on `_test.go` files, extending it here closes the gap precisely where it was missed.

## Change

- Add `*ast.ExprStmt` to the node filter and a `checkDiscardedCall` handler alongside the existing blank-identifier check (unchanged in behavior).
- `returnsDiagnostics` helper handles both single-return calls (`ElementsAs`-style) and multi-return calls where any result is `diag.Diagnostics`.
- Void calls (e.g. `Append`) and non-diag calls are unaffected.
- Testdata fixtures for both new BAD cases and the GOOD / not-flagged cases.

## Validation

- `go test ./tools/linters/diagsuppressed/` ✅
- `make lint` (rebuilt `custom-gcl`, repo-wide) — 0 issues, no false positives ✅
- **Smoke test** with a rebuilt binary + cleaned analysis cache, reproducing the Copilot pattern in a `_test.go` file:
  - discarded return → **flagged** ✅
  - captured return → **0 findings** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)