### PR TITLE
chore(linters): add x/tools modernize suite

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     - methodreceiver
     - requestguard
     - clearableattr
+    - modernize
   exclusions:
     generated: lax
     presets:
@@ -100,6 +101,7 @@ linters:
           - methodreceiver
           - requestguard
           - clearableattr
+          - modernize
       # Test files — exclude custom linters (except paralleltest which only applies to tests)
       - path: _test\.go
         linters:
@@ -242,6 +244,9 @@ linters:
       clearableattr:
         type: "module"
         description: "Ensures Optional+Computed attributes without Default are explicitly classified as clearable or not."
+      modernize:
+        type: "module"
+        description: "x/tools modernize suite: suggests modern Go language/library features (any, min/max, slices/maps helpers, atomic types, etc.)."
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/internal/provider/support_request_tags_internal_test.go
+++ b/internal/provider/support_request_tags_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -112,10 +113,7 @@ func TestSupportRequestTagsTagValidators(t *testing.T) {
 		t.Fatal("expected tags attribute to declare validators")
 	}
 
-	longTag := ""
-	for range 81 {
-		longTag += "a"
-	}
+	longTag := strings.Repeat("a", 81)
 	manyTags := make([]string, 51)
 	for i := range manyTags {
 		manyTags[i] = fmt.Sprintf("tag-%d", i)

--- a/internal/provider/support_request_tags_resource_test.go
+++ b/internal/provider/support_request_tags_resource_test.go
@@ -2,6 +2,7 @@ package provider_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -159,13 +160,11 @@ func TestAccSupportRequestTags_Import(t *testing.T) {
 }
 
 func testAccSupportRequestTagsConfig(tags []string) string {
-	tagsList := ""
+	quoted := make([]string, len(tags))
 	for i, t := range tags {
-		if i > 0 {
-			tagsList += ", "
-		}
-		tagsList += fmt.Sprintf("%q", t)
+		quoted[i] = fmt.Sprintf("%q", t)
 	}
+	tagsList := strings.Join(quoted, ", ")
 
 	return fmt.Sprintf(`
 data "doit_support_requests" "all" {

--- a/internal/provider/timeout_test.go
+++ b/internal/provider/timeout_test.go
@@ -33,9 +33,9 @@ func TestDCIRetryClient_RequestTimeout(t *testing.T) {
 	serverDelay := 3 * time.Second
 	clientTimeout := 1 * time.Second
 
-	var requestCount int64
+	var requestCount atomic.Int64
 	server := newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt64(&requestCount, 1)
+		requestCount.Add(1)
 		time.Sleep(serverDelay)
 		w.WriteHeader(http.StatusOK)
 	})
@@ -62,7 +62,7 @@ func TestDCIRetryClient_RequestTimeout(t *testing.T) {
 		t.Fatal("expected timeout error, got nil")
 	}
 
-	count := atomic.LoadInt64(&requestCount)
+	count := requestCount.Load()
 
 	// Should have made multiple attempts (each timing out at clientTimeout)
 	if count < 2 {
@@ -165,9 +165,9 @@ func TestDCIRetryClient_RetryRespectsContextDeadline(t *testing.T) {
 	requestTimeout := 30 * time.Second // High per-request timeout
 	contextDeadline := 3 * time.Second // Short context deadline
 
-	var requestCount int64
+	var requestCount atomic.Int64
 	server := newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt64(&requestCount, 1)
+		requestCount.Add(1)
 		w.WriteHeader(http.StatusServiceUnavailable) // 503 triggers retry
 	})
 	defer server.Close()
@@ -191,7 +191,7 @@ func TestDCIRetryClient_RetryRespectsContextDeadline(t *testing.T) {
 		t.Fatal("expected context deadline error, got nil")
 	}
 
-	count := atomic.LoadInt64(&requestCount)
+	count := requestCount.Load()
 
 	// Should have retried until the context deadline, not a hardcoded max elapsed time
 	if elapsed > 2*contextDeadline {

--- a/tools/linters/plugin.go
+++ b/tools/linters/plugin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/doitintl/terraform-provider-doit/tools/linters/usestatefunknown"
 	"github.com/golangci/plugin-module-register/register"
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/modernize"
 )
 
 type analyzerPlugin struct {
@@ -127,5 +128,13 @@ func init() {
 
 	register.Plugin("clearableattr", func(_ any) (register.LinterPlugin, error) {
 		return &analyzerPlugin{analyzers: []*analysis.Analyzer{clearableattr.Analyzer}}, nil
+	})
+
+	// modernize wraps the full x/tools modernize suite. Its "newexpr"
+	// analyzer shares a Name with our custom newexpr linter but targets a
+	// disjoint pattern (pointer-wrapper functions vs. temp-var-then-address),
+	// and both run fine side by side under separate golangci plugins.
+	register.Plugin("modernize", func(_ any) (register.LinterPlugin, error) {
+		return &analyzerPlugin{analyzers: modernize.Suite}, nil
 	})
 }


### PR DESCRIPTION
## What

Adds the [`golang.org/x/tools` modernize suite](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) as a custom golangci-lint module plugin and enables it, following the `register-custom-linter` skill:

- **[tools/linters/plugin.go](../blob/chore/add-modernize-linter/tools/linters/plugin.go)** — registers `modernize.Suite` under a `modernize` plugin.
- **[.golangci.yml](../blob/chore/add-modernize-linter/.golangci.yml)** — enables `modernize`, declares it as a `type: "module"` custom linter, and excludes it from generated files (`_gen.go` rule + `generated: lax`), so it only runs on hand-written code.

## The `newexpr` question

modernize ships its own `newexpr` analyzer that shares the internal `Name` with our existing custom `newexpr` linter — but the two detect **disjoint** patterns:

| | custom `newexpr` | modernize `newexpr` |
|---|---|---|
| Targets | temp-var-then-address inside a function body | pointer-wrapper *helper functions* |
| Example | `s := x(); return &s` | `func p(x int) *int { return &x }` |

Verified empirically that both run side by side under their separate plugins (no dedup, no panic; findings attributed as `(modernize)` vs `(newexpr)`), so the full suite is registered **unfiltered** — we keep both checks.

## Fixes to existing code

modernize surfaced 4 findings in test code, all fixed here:

- `timeout_test.go` — `var int64` + `atomic.{Add,Load}Int64` → `atomic.Int64` (`atomictypes`)
- `support_request_tags_internal_test.go` — `+=` loop → `strings.Repeat` (`stringsbuilder`)
- `support_request_tags_resource_test.go` — `+=` loop → `strings.Join` (`stringsbuilder`)

## Verification

- `./custom-gcl run --enable-only=modernize,newexpr ./internal/provider/...` → **0 issues**
- Confirmed the exclusion works: standalone modernize finds 20+ issues in `models_gen.go`; `custom-gcl` reports 0 there.
- `go build`, `go vet`, and `TestDCIRetryClient_RequestTimeout` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)