### PR TITLE
chore(provider): adopt nullable-type code generation and adapt mapping helpers

### DIFF
--- a/.agent/skills/go-conventions/SKILL.md
+++ b/.agent/skills/go-conventions/SKILL.md
@@ -117,14 +117,18 @@ if rule := nullableToPointer(resp.Rule); rule != nil {
 
 ### Write path (TF plan → API request)
 
-Prefer `valueToNullable` when the value is known non-nil — it avoids unnecessary pointer indirection:
+Prefer `valueToNullable` when the value is known non-nil — it avoids unnecessary pointer indirection.
+For `Optional` or `Optional+Computed` fields, ALWAYS verify they are not `Unknown` and not `Null` before using them:
 
 ```go
-// PREFERRED — concrete value
+// PREFERRED — concrete value (safe for Required fields)
 req.Name = valueToNullable(plan.Name.ValueString())
 
-// OK — when you already have a *T from ValueXxxPointer()
-req.Description = pointerToNullable(plan.Description.ValueStringPointer())
+// For Optional/Computed fields: guard against Unknown and Null states!
+if !plan.Description.IsUnknown() && !plan.Description.IsNull() {
+    // Both valueToNullable and pointerToNullable are safe here
+    req.Description = pointerToNullable(plan.Description.ValueStringPointer())
+}
 ```
 
 ### Nullable struct fields (`.Set()`)

--- a/.agent/skills/go-conventions/SKILL.md
+++ b/.agent/skills/go-conventions/SKILL.md
@@ -93,6 +93,72 @@ params.Filter = new(data.Filter.ValueString())
 
 > **Linter:** `newexpr` — suggests `new(expr)` for temp-then-address patterns.
 
+## Nullable Type Helpers (`nullable.Nullable[T]`)
+
+Generated API models use `nullable.Nullable[T]` (from `github.com/oapi-codegen/nullable`) instead of `*T` for fields where explicit `null` clearing is or will be supported. Three generic helpers in `nullable_helpers.go` bridge between Terraform types and nullable fields:
+
+| Helper | Signature | Use Case |
+|--------|-----------|----------|
+| `nullableToPointer` | `nullable.Nullable[T] → *T` | **Read path** — convert nullable response fields to `*T` for `types.XxxPointerValue()` |
+| `valueToNullable` | `T → nullable.Nullable[T]` | **Write path** — wrap a concrete value for a nullable request field (preferred) |
+| `pointerToNullable` | `*T → nullable.Nullable[T]` | **Write path** — wrap a `ValueXxxPointer()` result for a nullable request field |
+
+### Read path (API response → TF state)
+
+```go
+// Scalar nullable field
+state.Field = types.StringPointerValue(nullableToPointer(resp.Field))
+
+// Complex nullable field that needs dereferencing
+if rule := nullableToPointer(resp.Rule); rule != nil {
+    formula = rule.Formula
+}
+```
+
+### Write path (TF plan → API request)
+
+Prefer `valueToNullable` when the value is known non-nil — it avoids unnecessary pointer indirection:
+
+```go
+// PREFERRED — concrete value
+req.Name = valueToNullable(plan.Name.ValueString())
+
+// OK — when you already have a *T from ValueXxxPointer()
+req.Description = pointerToNullable(plan.Description.ValueStringPointer())
+```
+
+### Nullable struct fields (`.Set()`)
+
+For nullable struct-typed fields, build the struct first, then call `.Set()`:
+
+```go
+// OLD — pointer assignment
+req.Rule = &models.AllocationRule{Formula: plan.Rule.Formula.ValueString()}
+
+// NEW — build then Set()
+var rule models.AllocationRule
+rule.Formula = plan.Rule.Formula.ValueString()
+req.Rule.Set(rule)
+```
+
+### Nullable slices in lists
+
+When a list contains nullable elements (`[]nullable.Nullable[T]`), use `.Set()` per element:
+
+```go
+rules := make([]nullable.Nullable[models.GroupAllocationRule], len(planRules))
+for i := range planRules {
+    var rule models.GroupAllocationRule
+    rule.Name = planRules[i].Name.ValueStringPointer()
+    rules[i].Set(rule)
+}
+req.Rules = &rules
+```
+
+### Why nullable types?
+
+Not all API fields are `*T` pointers now — only fields where the API supports or will support explicit `null` clearing use `nullable.Nullable[T]`. This distinction matters for nested objects where sending the zero value (`{}`) is interpreted as "set defaults" rather than "clear." The API is gradually adding `null` acceptance per endpoint.
+
 ## .gitignore Check
 
 Always check `.gitignore` before committing. Some files (like `OpenAPI/api_endpoint_analysis.md`) are local documentation:

--- a/.agent/skills/implement-datasource/SKILL.md
+++ b/.agent/skills/implement-datasource/SKILL.md
@@ -204,8 +204,9 @@ budgetVal, diags := datasource_budgets.NewBudgetsValue(
 ### Type Handling Tips
 
 1. **Pointer vs Non-Pointer**: Check `models_gen.go` — pointer (`*string`) → `types.StringPointerValue()`, non-pointer → `types.StringValue()`
-2. **Enum Types**: Convert to string first — `types.StringValue(string(s.Mode))`
-3. **Nested Lists**: Create helper functions to map nested structures
+2. **Nullable fields**: `nullable.Nullable[T]` → wrap with `nullableToPointer()` before passing to `types.XxxPointerValue()`. Example: `types.StringPointerValue(nullableToPointer(resp.Field))`
+3. **Enum Types**: Convert to string first — `types.StringValue(string(s.Mode))`
+4. **Nested Lists**: Create helper functions to map nested structures
 
 ### RowCount Determinism
 

--- a/.agent/skills/implement-resource/SKILL.md
+++ b/.agent/skills/implement-resource/SKILL.md
@@ -349,3 +349,15 @@ The Go models from OpenAPI may differ between Request and Response wrappers:
 - Request `Scopes`: `*[]ExternalConfigFilter`
 
 Check `models/models_gen.go` when compilation fails. You may need `&slice` for requests but use the slice directly from responses.
+
+### Nullable Fields
+
+Fields that support explicit `null` clearing use `nullable.Nullable[T]` instead of `*T`. Check `models_gen.go` for the actual field type — both variants coexist:
+
+| Field Type | Read (response → state) | Write (plan → request) |
+|------------|------------------------|----------------------|
+| `*T` | `types.StringPointerValue(resp.Field)` | `req.Field = new(plan.Field.ValueString())` |
+| `nullable.Nullable[T]` | `types.StringPointerValue(nullableToPointer(resp.Field))` | `req.Field = valueToNullable(plan.Field.ValueString())` |
+| `nullable.Nullable[StructT]` | `if s := nullableToPointer(resp.Field); s != nil { ... }` | `req.Field.Set(structVal)` |
+
+See the [go-conventions](../go-conventions/SKILL.md#nullable-type-helpers-nullablenullablet) skill for the full helper reference.

--- a/.agent/skills/implement-resource/references/overlay-pattern.md
+++ b/.agent/skills/implement-resource/references/overlay-pattern.md
@@ -41,6 +41,7 @@ func overlayMyResourceComputedFields(ctx context.Context, apiResp *models.MyReso
     var diags diag.Diagnostics
 
     // 1. Computed-only stable fields: ALWAYS set from API response.
+    //    Use nullableToPointer() when the response field is nullable.Nullable[T].
     plan.Id = types.StringPointerValue(apiResp.Id)
     plan.CreateTime = types.Int64PointerValue(apiResp.CreateTime)
 
@@ -51,8 +52,10 @@ func overlayMyResourceComputedFields(ctx context.Context, apiResp *models.MyReso
     }
 
     // 3. Optional+Computed scalars: resolve ONLY when unknown.
+    //    Response field may be *T or nullable.Nullable[T] — check models_gen.go.
     if plan.Formula.IsUnknown() {
-        plan.Formula = types.StringPointerValue(apiResp.Formula)
+        plan.Formula = types.StringPointerValue(apiResp.Formula)                   // *T field
+        // plan.Field = types.StringPointerValue(nullableToPointer(apiResp.Field)) // nullable field
     }
     // If plan.Formula is known, leave it untouched — user's value wins.
 

--- a/.agent/skills/implementation-conventions/SKILL.md
+++ b/.agent/skills/implementation-conventions/SKILL.md
@@ -115,9 +115,9 @@ In `toCreateRequest` / `toUpdateRequest` and similar request builder functions, 
 
 For non-pointer value accessors (`ValueString()`, `ValueBool()`, `ValueFloat64()`, `ValueInt64()`), always guard with `IsUnknown()` when the field is Optional+Computed without Default — these accessors return zero values for Unknown, not nil.
 
-Pointer accessors (`ValueStringPointer()`, etc.) return `nil` for Unknown, which is often acceptable. When wrapping with `pointerToNullable`, `nil` produces an unspecified (empty) nullable — the field is omitted from the JSON request, preserving the same semantics as a nil pointer.
-
 **Nullable request fields:** Generated request structs may use `nullable.Nullable[T]` instead of `*T` for fields that support explicit null clearing. Use `valueToNullable(val)` for concrete values and `pointerToNullable(ptr)` for pointer values. See the [go-conventions](../go-conventions/SKILL.md#nullable-type-helpers-nullablenullablet) skill for the full helper reference.
+
+> **Warning (Unknown State pointers):** Be extremely careful with `.ValueStringPointer()` (or equivalent accessor methods) on framework attribute values. If the framework attribute has an `Unknown` state, `.ValueStringPointer()` returns a pointer to a **zero value** (e.g. `*""` or `*0`), NOT `nil`. If you pass this zero value pointer to `pointerToNullable()`, it will mark the `Nullable` as explicitly specified rather than `null`/omitted. Always guard access with `!plan.Attribute.IsUnknown()` for `Optional+Computed` fields before using their pointer methods.
 
 > **Linter:** `requestguard` — flags both redundant guards (dead code) and missing guards (bug risk) in request builder functions.
 

--- a/.agent/skills/implementation-conventions/SKILL.md
+++ b/.agent/skills/implementation-conventions/SKILL.md
@@ -82,9 +82,16 @@ If create and update use different API request types, implement both `toCreateRe
 When a schema field has a `Default` (e.g., `stringdefault.StaticString("cost")`), `mapXxxToModel` must map `nil` API responses to the default value, not to `null`:
 
 ```go
-// CORRECT — preserves the schema default on nil response
+// CORRECT — preserves the schema default on nil response (pointer field)
 if apiResp.Metric != nil {
     state.Metric = types.StringValue(*apiResp.Metric)
+} else {
+    state.Metric = types.StringValue("cost") // schema default
+}
+
+// CORRECT — nullable field variant
+if metric := nullableToPointer(apiResp.Metric); metric != nil {
+    state.Metric = types.StringValue(*metric)
 } else {
     state.Metric = types.StringValue("cost") // schema default
 }
@@ -108,7 +115,9 @@ In `toCreateRequest` / `toUpdateRequest` and similar request builder functions, 
 
 For non-pointer value accessors (`ValueString()`, `ValueBool()`, `ValueFloat64()`, `ValueInt64()`), always guard with `IsUnknown()` when the field is Optional+Computed without Default — these accessors return zero values for Unknown, not nil.
 
-Pointer accessors (`ValueStringPointer()`, etc.) return `nil` for Unknown, which is often acceptable.
+Pointer accessors (`ValueStringPointer()`, etc.) return `nil` for Unknown, which is often acceptable. When wrapping with `pointerToNullable`, `nil` produces an unspecified (empty) nullable — the field is omitted from the JSON request, preserving the same semantics as a nil pointer.
+
+**Nullable request fields:** Generated request structs may use `nullable.Nullable[T]` instead of `*T` for fields that support explicit null clearing. Use `valueToNullable(val)` for concrete values and `pointerToNullable(ptr)` for pointer values. See the [go-conventions](../go-conventions/SKILL.md#nullable-type-helpers-nullablenullablet) skill for the full helper reference.
 
 > **Linter:** `requestguard` — flags both redundant guards (dead code) and missing guards (bug risk) in request builder functions.
 

--- a/.agent/skills/testing/SKILL.md
+++ b/.agent/skills/testing/SKILL.md
@@ -155,6 +155,24 @@ ruleVal := resource_allocation.NewRulesValueMust(attrTypes, map[string]attr.Valu
 })
 ```
 
+### Constructing API Response Objects with Nullable Fields
+
+When constructing `models.*` structs in unit tests, use `valueToNullable` for fields that are `nullable.Nullable[T]` in `models_gen.go`:
+
+```go
+// OLD — pointer field
+apiResp := &models.Allocation{
+    Rule: &models.AllocationRule{Formula: "A"},
+}
+
+// NEW — nullable field
+apiResp := &models.Allocation{
+    Rule: valueToNullable(models.AllocationRule{Formula: "A"}),
+}
+```
+
+Check `models_gen.go` for the actual field types — both `*T` and `nullable.Nullable[T]` coexist.
+
 ### Test Helper Pattern
 
 Create helpers for constructing properly initialized values:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
+	github.com/oapi-codegen/nullable v1.1.0
 	github.com/oapi-codegen/runtime v1.4.1
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -179,7 +179,7 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 	// UnallocatedCosts is only sent if not empty because it is invalid for "single" allocations.
 	if !plan.UnallocatedCosts.IsNull() && !plan.UnallocatedCosts.IsUnknown() {
 		if v := plan.UnallocatedCosts.ValueString(); v != "" {
-			req.UnallocatedCosts = pointerToNullable(&v)
+			req.UnallocatedCosts = valueToNullable(v)
 		}
 	}
 

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_allocation"
+	"github.com/oapi-codegen/nullable"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -116,12 +117,12 @@ func (plan *allocationResourceModel) toCreateRequest(ctx context.Context) (req m
 	}
 
 	req.Description = ""
-	if common.Description != nil {
-		req.Description = *common.Description
+	if desc := nullableToPointer(common.Description); desc != nil {
+		req.Description = *desc
 	}
 	req.Name = ""
-	if common.Name != nil {
-		req.Name = *common.Name
+	if name := nullableToPointer(common.Name); name != nil {
+		req.Name = *name
 	}
 	req.UnallocatedCosts = common.UnallocatedCosts
 	req.FolderId = common.FolderId
@@ -172,21 +173,20 @@ func convertComponentsToModels(ctx context.Context, components []resource_alloca
 
 // Helper to fill common fields into UpdateAllocationRequest model (which uses pointers).
 func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, req *models.UpdateAllocationRequest) (diags diag.Diagnostics) {
-	req.Description = plan.Description.ValueStringPointer()
-	req.Name = plan.Name.ValueStringPointer()
+	req.Description = pointerToNullable(plan.Description.ValueStringPointer())
+	req.Name = pointerToNullable(plan.Name.ValueStringPointer())
 	req.FolderId = plan.FolderId.ValueStringPointer()
 	// UnallocatedCosts is only sent if not empty because it is invalid for "single" allocations.
 	if !plan.UnallocatedCosts.IsNull() && !plan.UnallocatedCosts.IsUnknown() {
 		if v := plan.UnallocatedCosts.ValueString(); v != "" {
-			req.UnallocatedCosts = &v
+			req.UnallocatedCosts = pointerToNullable(&v)
 		}
 	}
 
 	// Populate single Rule if present
 	if !plan.Rule.IsNull() && !plan.Rule.IsUnknown() {
-		req.Rule = &models.AllocationRule{
-			Formula: plan.Rule.Formula.ValueString(),
-		}
+		var rule models.AllocationRule
+		rule.Formula = plan.Rule.Formula.ValueString()
 		if !plan.Rule.Components.IsNull() {
 			planComponents := []resource_allocation.ComponentsValue{}
 			d := plan.Rule.Components.ElementsAs(ctx, &planComponents, false)
@@ -194,11 +194,12 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 			if diags.HasError() {
 				return diags
 			}
-			req.Rule.Components, diags = convertComponentsToModels(ctx, planComponents)
+			rule.Components, diags = convertComponentsToModels(ctx, planComponents)
 			if diags.HasError() {
 				return diags
 			}
 		}
+		req.Rule.Set(rule)
 	}
 
 	// Populate Group Rules if present.
@@ -213,15 +214,14 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 			return diags
 		}
 		if len(planRules) > 0 {
-			rules := make([]*models.GroupAllocationRule, len(planRules))
+			rules := make([]nullable.Nullable[models.GroupAllocationRule], len(planRules))
 			for i := range planRules {
-				rules[i] = &models.GroupAllocationRule{
-					Name:        planRules[i].Name.ValueStringPointer(),
-					Formula:     planRules[i].Formula.ValueStringPointer(),
-					Action:      models.GroupAllocationRuleAction(planRules[i].Action.ValueString()),
-					Id:          planRules[i].Id.ValueStringPointer(),
-					Description: planRules[i].Description.ValueStringPointer(),
-				}
+				var rule models.GroupAllocationRule
+				rule.Name = planRules[i].Name.ValueStringPointer()
+				rule.Formula = planRules[i].Formula.ValueStringPointer()
+				rule.Action = models.GroupAllocationRuleAction(planRules[i].Action.ValueString())
+				rule.Id = planRules[i].Id.ValueStringPointer()
+				rule.Description = planRules[i].Description.ValueStringPointer()
 
 				// Don't send components if selecting existing allocation (action "select")
 				// But for "create" or "update" action, components are required/allowed.
@@ -237,8 +237,9 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 					if diags.HasError() {
 						return diags
 					}
-					rules[i].Components = &createComponents
+					rule.Components = &createComponents
 				}
+				rules[i].Set(rule)
 			}
 			req.Rules = &rules
 		}
@@ -296,11 +297,11 @@ func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponse
 	state.Id = types.StringPointerValue(resp.Id)
 	state.Type = types.StringPointerValue(resp.Type)
 	state.Description = types.StringPointerValue(resp.Description)
-	state.AnomalyDetection = types.BoolPointerValue(resp.AnomalyDetection)
+	state.AnomalyDetection = types.BoolPointerValue(nullableToPointer(resp.AnomalyDetection))
 	state.CreateTime = types.Int64PointerValue(resp.CreateTime)
 	state.UpdateTime = types.Int64PointerValue(resp.UpdateTime)
 	state.Name = types.StringPointerValue(resp.Name)
-	state.UnallocatedCosts = types.StringPointerValue(resp.UnallocatedCosts)
+	state.UnallocatedCosts = types.StringPointerValue(nullableToPointer(resp.UnallocatedCosts))
 	// Defend against API returning nil: fall back to "root" to match the
 	// schema default and prevent perpetual plan drift.
 	if resp.FolderId != nil {
@@ -315,11 +316,11 @@ func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponse
 		state.AllocationType = types.StringNull()
 	}
 
-	if resp.Rule != nil {
+	if rule := nullableToPointer(resp.Rule); rule != nil {
 		m := map[string]attr.Value{
-			"formula": types.StringValue(resp.Rule.Formula),
+			"formula": types.StringValue(rule.Formula),
 		}
-		if resp.Rule.Components != nil {
+		if rule.Components != nil {
 			// Preserve existing component values from state for alias-type normalization
 			// and deprecated field round-tripping.
 			// - includeNull, inverse, caseInsensitive: use API value (reliably echoed),
@@ -335,7 +336,7 @@ func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponse
 				}
 			}
 			var d diag.Diagnostics
-			m["components"], d = toAllocationRuleComponentsListValue(ctx, resp.Rule.Components, existingComponents)
+			m["components"], d = toAllocationRuleComponentsListValue(ctx, rule.Components, existingComponents)
 			diags.Append(d...)
 			if diags.HasError() {
 				return
@@ -373,7 +374,8 @@ func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponse
 
 		rules := make([]attr.Value, 0, len(*resp.Rules))
 		ruleIndex := 0
-		for _, rulePtr := range *resp.Rules {
+		for _, ruleNullable := range *resp.Rules {
+			rulePtr := nullableToPointer(ruleNullable)
 			if rulePtr == nil {
 				ruleIndex++
 				continue
@@ -410,10 +412,10 @@ func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponse
 				respHTTPFullAlloc, err := client.GetAllocationWithResponse(ctx, *rule.Id)
 				if err == nil && respHTTPFullAlloc.JSON200 != nil {
 					fullAlloc := respHTTPFullAlloc.JSON200
-					if fullAlloc.Rule != nil {
-						formula = fullAlloc.Rule.Formula
-						if fullAlloc.Rule.Components != nil {
-							components = fullAlloc.Rule.Components
+					if rulePtr := nullableToPointer(fullAlloc.Rule); rulePtr != nil {
+						formula = rulePtr.Formula
+						if rulePtr.Components != nil {
+							components = rulePtr.Components
 						}
 					}
 				} else {

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -468,7 +468,7 @@ func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponse
 		if diags.HasError() {
 			return
 		}
-	} else if resp.Rule != nil {
+	} else if nullableToPointer(resp.Rule) != nil {
 		// Single-rule allocation: the API returns rules=nil because this isn't a
 		// group allocation. Keep state.Rules null so it's omitted from subsequent
 		// update requests. Sending "rules": [] to the API causes a 500 error.

--- a/internal/provider/allocation_data_source.go
+++ b/internal/provider/allocation_data_source.go
@@ -139,10 +139,10 @@ func (ds *allocationDataSource) mapAllocationToModel(ctx context.Context, alloca
 	data.Name = types.StringPointerValue(allocation.Name)
 	data.Description = types.StringPointerValue(allocation.Description)
 	data.Type = types.StringPointerValue(allocation.Type)
-	data.AnomalyDetection = types.BoolPointerValue(allocation.AnomalyDetection)
+	data.AnomalyDetection = types.BoolPointerValue(nullableToPointer(allocation.AnomalyDetection))
 	data.CreateTime = types.Int64PointerValue(allocation.CreateTime)
 	data.UpdateTime = types.Int64PointerValue(allocation.UpdateTime)
-	data.UnallocatedCosts = types.StringPointerValue(allocation.UnallocatedCosts)
+	data.UnallocatedCosts = types.StringPointerValue(nullableToPointer(allocation.UnallocatedCosts))
 	data.FolderId = types.StringPointerValue(allocation.FolderId)
 
 	if allocation.AllocationType != nil {
@@ -152,11 +152,11 @@ func (ds *allocationDataSource) mapAllocationToModel(ctx context.Context, alloca
 	}
 
 	// Map single Rule
-	if allocation.Rule != nil {
+	if rule := nullableToPointer(allocation.Rule); rule != nil {
 		ruleMap := map[string]attr.Value{
-			"formula": types.StringValue(allocation.Rule.Formula),
+			"formula": types.StringValue(rule.Formula),
 		}
-		componentsList, componentDiags := ds.mapComponentsToList(ctx, allocation.Rule.Components)
+		componentsList, componentDiags := ds.mapComponentsToList(ctx, rule.Components)
 		diags.Append(componentDiags...)
 		if diags.HasError() {
 			return
@@ -175,8 +175,13 @@ func (ds *allocationDataSource) mapAllocationToModel(ctx context.Context, alloca
 
 	// Map Rules list (for group allocations)
 	if allocation.Rules != nil && len(*allocation.Rules) > 0 {
-		rules := make([]attr.Value, len(*allocation.Rules))
-		for i, rule := range *allocation.Rules {
+		rules := make([]attr.Value, 0, len(*allocation.Rules))
+		for _, ruleNullable := range *allocation.Rules {
+			rulePtr := nullableToPointer(ruleNullable)
+			if rulePtr == nil {
+				continue
+			}
+			rule := *rulePtr
 			ruleMap := map[string]attr.Value{
 				"action":      types.StringValue("select"), // Default action - not returned by API
 				"description": types.StringPointerValue(rule.Description),
@@ -201,11 +206,12 @@ func (ds *allocationDataSource) mapAllocationToModel(ctx context.Context, alloca
 			ruleMap["components"] = componentsList
 
 			var ruleDiags diag.Diagnostics
-			rules[i], ruleDiags = datasource_allocation.NewRulesValue(datasource_allocation.RulesValue{}.AttributeTypes(ctx), ruleMap)
+			ruleVal, ruleDiags := datasource_allocation.NewRulesValue(datasource_allocation.RulesValue{}.AttributeTypes(ctx), ruleMap)
 			diags.Append(ruleDiags...)
 			if diags.HasError() {
 				return
 			}
+			rules = append(rules, ruleVal)
 		}
 		var rulesListDiags diag.Diagnostics
 		data.Rules, rulesListDiags = types.ListValueFrom(ctx, datasource_allocation.RulesValue{}.Type(ctx), rules)

--- a/internal/provider/allocation_internal_test.go
+++ b/internal/provider/allocation_internal_test.go
@@ -138,7 +138,7 @@ func TestMapAllocationToModel_SingleRule_RulesNull(t *testing.T) {
 	allocType := models.AllocationAllocationType("single")
 	apiResp := &models.Allocation{
 		AllocationType: &allocType,
-		Rule: &models.AllocationRule{
+		Rule: pointerToNullable(&models.AllocationRule{
 			Formula: "A",
 			Components: []models.AllocationComponent{
 				{
@@ -148,8 +148,7 @@ func TestMapAllocationToModel_SingleRule_RulesNull(t *testing.T) {
 					Values: []string{"JP"},
 				},
 			},
-		},
-		Rules: nil, // single-rule allocation: no group rules
+		}),
 	}
 
 	state := &allocationResourceModel{}

--- a/internal/provider/allocation_internal_test.go
+++ b/internal/provider/allocation_internal_test.go
@@ -138,7 +138,7 @@ func TestMapAllocationToModel_SingleRule_RulesNull(t *testing.T) {
 	allocType := models.AllocationAllocationType("single")
 	apiResp := &models.Allocation{
 		AllocationType: &allocType,
-		Rule: pointerToNullable(&models.AllocationRule{
+		Rule: valueToNullable(models.AllocationRule{
 			Formula: "A",
 			Components: []models.AllocationComponent{
 				{

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -2464,3 +2464,58 @@ resource "doit_allocation" "folder_test" {
 }
 `, rName, testProject())
 }
+
+// TestAccAllocation_Computed_Required_Fields tests that using a computed value
+// (like an ID from another resource) for a required field (like name or description)
+// works correctly and does not trigger any Unknown pointer bugs during Create.
+func TestAccAllocation_Computed_Required_Fields(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "doit_allocation" "dependency" {
+    name = "%s-dep"
+    description = "Dependency allocation"
+    rule = {
+       formula = "A"
+       components = [
+         {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["US"]
+         }
+       ]
+    }
+}
+
+resource "doit_allocation" "dependent" {
+    // These required fields will be Unknown at plan time
+    name = doit_allocation.dependency.id
+    description = "Dependent on ${doit_allocation.dependency.id}"
+    rule = {
+       formula = "A"
+       components = [
+         {
+           key    = "country"
+           mode   = "is"
+           type   = "fixed"
+           values = ["JP"]
+         }
+       ]
+    }
+}
+`, rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("doit_allocation.dependent", tfjsonpath.New("name"), knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/annotation.go
+++ b/internal/provider/annotation.go
@@ -203,8 +203,8 @@ func (plan *annotationResourceModel) toUpdateRequest(ctx context.Context) (model
 	}
 
 	req := models.UpdateAnnotationRequest{
-		Content:   new(plan.Content.ValueString()),
-		Timestamp: &timestamp,
+		Content:   pointerToNullable(new(plan.Content.ValueString())),
+		Timestamp: pointerToNullable(&timestamp),
 	}
 
 	// Handle optional labels list
@@ -214,7 +214,7 @@ func (plan *annotationResourceModel) toUpdateRequest(ctx context.Context) (model
 		if diags.HasError() {
 			return req, diags
 		}
-		req.Labels = &labels
+		req.Labels = pointerToNullable(&labels)
 	}
 
 	// Handle optional reports list
@@ -224,7 +224,7 @@ func (plan *annotationResourceModel) toUpdateRequest(ctx context.Context) (model
 		if diags.HasError() {
 			return req, diags
 		}
-		req.Reports = &reports
+		req.Reports = pointerToNullable(&reports)
 	}
 
 	return req, diags

--- a/internal/provider/annotation.go
+++ b/internal/provider/annotation.go
@@ -203,8 +203,8 @@ func (plan *annotationResourceModel) toUpdateRequest(ctx context.Context) (model
 	}
 
 	req := models.UpdateAnnotationRequest{
-		Content:   pointerToNullable(new(plan.Content.ValueString())),
-		Timestamp: pointerToNullable(&timestamp),
+		Content:   valueToNullable(plan.Content.ValueString()),
+		Timestamp: valueToNullable(timestamp),
 	}
 
 	// Handle optional labels list
@@ -214,7 +214,7 @@ func (plan *annotationResourceModel) toUpdateRequest(ctx context.Context) (model
 		if diags.HasError() {
 			return req, diags
 		}
-		req.Labels = pointerToNullable(&labels)
+		req.Labels = valueToNullable(labels)
 	}
 
 	// Handle optional reports list
@@ -224,7 +224,7 @@ func (plan *annotationResourceModel) toUpdateRequest(ctx context.Context) (model
 		if diags.HasError() {
 			return req, diags
 		}
-		req.Reports = pointerToNullable(&reports)
+		req.Reports = valueToNullable(reports)
 	}
 
 	return req, diags

--- a/internal/provider/anomalies_data_source.go
+++ b/internal/provider/anomalies_data_source.go
@@ -182,26 +182,26 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if len(allAnomalies) > 0 {
 		anomalyVals := make([]datasource_anomalies.AnomaliesValue, 0, len(allAnomalies))
 		for _, anomaly := range allAnomalies {
-			// Handle EndTime *int -> Int64
+			// Handle EndTime nullable.Nullable[int] -> Int64
 			var endTimeVal types.Int64
-			if anomaly.EndTime != nil {
-				endTimeVal = types.Int64Value(int64(*anomaly.EndTime))
+			if endTime := nullableToPointer(anomaly.EndTime); endTime != nil {
+				endTimeVal = types.Int64Value(int64(*endTime))
 			} else {
 				endTimeVal = types.Int64Null()
 			}
 
 			// Handle Status enum
 			var statusVal types.String
-			if anomaly.Status != nil {
-				statusVal = types.StringValue(string(*anomaly.Status))
+			if status := nullableToPointer(anomaly.Status); status != nil {
+				statusVal = types.StringValue(string(*status))
 			} else {
 				statusVal = types.StringNull()
 			}
 
-			// Map AcknowledgedAt (*time.Time)
+			// Map AcknowledgedAt (nullable.Nullable[time.Time])
 			var acknowledgedAtVal types.String
-			if anomaly.AcknowledgedAt != nil {
-				acknowledgedAtVal = types.StringValue(anomaly.AcknowledgedAt.UTC().Format(time.RFC3339))
+			if acknowledgedAt := nullableToPointer(anomaly.AcknowledgedAt); acknowledgedAt != nil {
+				acknowledgedAtVal = types.StringValue(acknowledgedAt.UTC().Format(time.RFC3339))
 			} else {
 				acknowledgedAtVal = types.StringNull()
 			}
@@ -221,7 +221,7 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 					"id":              types.StringPointerValue(anomaly.Id),
 					"acknowledged":    types.BoolPointerValue(anomaly.Acknowledged),
 					"acknowledged_at": acknowledgedAtVal,
-					"acknowledged_by": types.StringPointerValue(anomaly.AcknowledgedBy),
+					"acknowledged_by": types.StringPointerValue(nullableToPointer(anomaly.AcknowledgedBy)),
 					"attribution":     types.StringValue(anomaly.Attribution),
 					"billing_account": types.StringValue(anomaly.BillingAccount),
 					"cost_of_anomaly": types.Float64Value(anomaly.CostOfAnomaly),

--- a/internal/provider/anomaly_data_source.go
+++ b/internal/provider/anomaly_data_source.go
@@ -129,26 +129,26 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 	data.SeverityLevel = types.StringValue(anomaly.SeverityLevel)
 	data.TimeFrame = types.StringValue(anomaly.TimeFrame)
 
-	// AcknowledgedAt is *time.Time
-	if anomaly.AcknowledgedAt != nil {
-		data.AcknowledgedAt = types.StringValue(anomaly.AcknowledgedAt.UTC().Format(time.RFC3339))
+	// AcknowledgedAt is nullable.Nullable[time.Time]
+	if acknowledgedAt := nullableToPointer(anomaly.AcknowledgedAt); acknowledgedAt != nil {
+		data.AcknowledgedAt = types.StringValue(acknowledgedAt.UTC().Format(time.RFC3339))
 	} else {
 		data.AcknowledgedAt = types.StringNull()
 	}
 
-	// AcknowledgedBy is *string
-	data.AcknowledgedBy = types.StringPointerValue(anomaly.AcknowledgedBy)
+	// AcknowledgedBy is nullable.Nullable[string]
+	data.AcknowledgedBy = types.StringPointerValue(nullableToPointer(anomaly.AcknowledgedBy))
 
-	// EndTime is *int in the API
-	if anomaly.EndTime != nil {
-		data.EndTime = types.Int64Value(int64(*anomaly.EndTime))
+	// EndTime is nullable.Nullable[int] in the API
+	if endTime := nullableToPointer(anomaly.EndTime); endTime != nil {
+		data.EndTime = types.Int64Value(int64(*endTime))
 	} else {
 		data.EndTime = types.Int64Null()
 	}
 
-	// Status is a pointer
-	if anomaly.Status != nil {
-		data.Status = types.StringValue(string(*anomaly.Status))
+	// Status is nullable.Nullable[models.AnomalyItemStatus]
+	if status := nullableToPointer(anomaly.Status); status != nil {
+		data.Status = types.StringValue(string(*status))
 	} else {
 		data.Status = types.StringNull()
 	}

--- a/internal/provider/anomaly_data_source.go
+++ b/internal/provider/anomaly_data_source.go
@@ -146,7 +146,7 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 		data.EndTime = types.Int64Null()
 	}
 
-	// Status is nullable.Nullable[models.AnomalyItemStatus]
+	// Status is nullable.Nullable[models.GetAnomaly200ResponseStatus]
 	if status := nullableToPointer(anomaly.Status); status != nil {
 		data.Status = types.StringValue(string(*status))
 	} else {

--- a/internal/provider/cloud_diagrams_cost_snapshot_data_source.go
+++ b/internal/provider/cloud_diagrams_cost_snapshot_data_source.go
@@ -155,8 +155,8 @@ func (d *cloudDiagramsCostSnapshotDataSource) Read(ctx context.Context, req data
 	data.Currency = types.StringValue(snapshot.Currency)
 	data.Total = types.NumberValue(big.NewFloat(float64(snapshot.Total)))
 
-	if snapshot.TrendingPct != nil {
-		data.TrendingPct = types.NumberValue(big.NewFloat(float64(*snapshot.TrendingPct)))
+	if trendingPct := nullableToPointer(snapshot.TrendingPct); trendingPct != nil {
+		data.TrendingPct = types.NumberValue(big.NewFloat(float64(*trendingPct)))
 	} else {
 		data.TrendingPct = types.NumberNull()
 	}

--- a/internal/provider/custom_theme.go
+++ b/internal/provider/custom_theme.go
@@ -129,7 +129,7 @@ func (plan *customThemeResourceModel) toUpdateRequest(ctx context.Context) (mode
 	}
 
 	req := models.UpdateCustomThemeRequest{
-		Name:         new(plan.Name.ValueString()),
+		Name:         pointerToNullable(new(plan.Name.ValueString())),
 		PrimaryColor: hexColorPtr(plan.PrimaryColor),
 		Colors:       colorsPtr,
 	}

--- a/internal/provider/custom_theme.go
+++ b/internal/provider/custom_theme.go
@@ -129,7 +129,7 @@ func (plan *customThemeResourceModel) toUpdateRequest(ctx context.Context) (mode
 	}
 
 	req := models.UpdateCustomThemeRequest{
-		Name:         pointerToNullable(new(plan.Name.ValueString())),
+		Name:         valueToNullable(plan.Name.ValueString()),
 		PrimaryColor: hexColorPtr(plan.PrimaryColor),
 		Colors:       colorsPtr,
 	}

--- a/internal/provider/datahub_dataset_resource.go
+++ b/internal/provider/datahub_dataset_resource.go
@@ -130,7 +130,7 @@ func (r *datahubDatasetResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	overlayDatahubDatasetComputedFields(createResp.JSON201.Name, createResp.JSON201.Description, createResp.JSON201.Records, createResp.JSON201.UpdatedBy, createResp.JSON201.LastUpdated, &plan)
+	overlayDatahubDatasetComputedFields(createResp.JSON201.Name, createResp.JSON201.Description, nullableToPointer(createResp.JSON201.Records), createResp.JSON201.UpdatedBy, createResp.JSON201.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -215,7 +215,7 @@ func (r *datahubDatasetResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	overlayDatahubDatasetComputedFields(updateResp.JSON200.Name, updateResp.JSON200.Description, updateResp.JSON200.Records, updateResp.JSON200.UpdatedBy, updateResp.JSON200.LastUpdated, &plan)
+	overlayDatahubDatasetComputedFields(updateResp.JSON200.Name, updateResp.JSON200.Description, nullableToPointer(updateResp.JSON200.Records), updateResp.JSON200.UpdatedBy, updateResp.JSON200.LastUpdated, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/label.go
+++ b/internal/provider/label.go
@@ -98,7 +98,7 @@ func (plan *labelResourceModel) toCreateRequest() models.CreateLabelRequest {
 // toUpdateRequest converts the TF model to an UpdateLabelRequest.
 func (plan *labelResourceModel) toUpdateRequest() models.UpdateLabelRequest {
 	return models.UpdateLabelRequest{
-		Color: new(models.UpdateLabelRequestColor(plan.Color.ValueString())),
-		Name:  new(plan.Name.ValueString()),
+		Color: pointerToNullable(new(models.UpdateLabelRequestColor(plan.Color.ValueString()))),
+		Name:  pointerToNullable(new(plan.Name.ValueString())),
 	}
 }

--- a/internal/provider/label.go
+++ b/internal/provider/label.go
@@ -98,7 +98,7 @@ func (plan *labelResourceModel) toCreateRequest() models.CreateLabelRequest {
 // toUpdateRequest converts the TF model to an UpdateLabelRequest.
 func (plan *labelResourceModel) toUpdateRequest() models.UpdateLabelRequest {
 	return models.UpdateLabelRequest{
-		Color: pointerToNullable(new(models.UpdateLabelRequestColor(plan.Color.ValueString()))),
-		Name:  pointerToNullable(new(plan.Name.ValueString())),
+		Color: valueToNullable(models.UpdateLabelRequestColor(plan.Color.ValueString())),
+		Name:  valueToNullable(plan.Name.ValueString()),
 	}
 }

--- a/internal/provider/models/models.yml
+++ b/internal/provider/models/models.yml
@@ -6,3 +6,4 @@ generate:
   client: true
 output-options:
   response-type-suffix: Resp
+  nullable-type: true

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oapi-codegen/nullable"
 	"github.com/oapi-codegen/runtime"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -3775,7 +3776,7 @@ type Allocation struct {
 	AllocationType *AllocationAllocationType `json:"allocationType,omitempty"`
 
 	// AnomalyDetection Whether anomaly detection is enabled for this allocation.
-	AnomalyDetection *bool `json:"anomalyDetection,omitempty"`
+	AnomalyDetection nullable.Nullable[bool] `json:"anomalyDetection,omitempty"`
 
 	// CreateTime The time when the allocation was created (in UNIX timestamp).
 	CreateTime *int64 `json:"createTime,omitempty"`
@@ -3793,14 +3794,14 @@ type Allocation struct {
 	Name *string `json:"name,omitempty"`
 
 	// Rule Single allocation rule. Components can reference other existing allocation rules by using the "allocation_rule" dimension type.
-	Rule  *AllocationRule         `json:"rule,omitempty"`
-	Rules *[]*GroupAllocationRule `json:"rules,omitempty"`
+	Rule  nullable.Nullable[AllocationRule]         `json:"rule,omitempty"`
+	Rules *[]nullable.Nullable[GroupAllocationRule] `json:"rules,omitempty"`
 
 	// Type Type of allocation (preset or custom).
 	Type *string `json:"type,omitempty"`
 
 	// UnallocatedCosts Custom label for values that do not fit into allocation (required for group type allocation).
-	UnallocatedCosts *string `json:"unallocatedCosts,omitempty"`
+	UnallocatedCosts nullable.Nullable[string] `json:"unallocatedCosts,omitempty"`
 
 	// UpdateTime Last time the allocation was modified (in UNIX timestamp).
 	UpdateTime *int64 `json:"updateTime,omitempty"`
@@ -3946,10 +3947,10 @@ type AnomalyItem struct {
 	Acknowledged *bool `json:"acknowledged,omitempty"`
 
 	// AcknowledgedAt When the anomaly was first acknowledged
-	AcknowledgedAt *time.Time `json:"acknowledgedAt,omitempty"`
+	AcknowledgedAt nullable.Nullable[time.Time] `json:"acknowledgedAt,omitempty"`
 
 	// AcknowledgedBy Email of the user who first acknowledged the anomaly
-	AcknowledgedBy *string `json:"acknowledgedBy,omitempty"`
+	AcknowledgedBy nullable.Nullable[string] `json:"acknowledgedBy,omitempty"`
 
 	// Attribution Attribution ID.
 	Attribution string `json:"attribution"`
@@ -3961,8 +3962,8 @@ type AnomalyItem struct {
 	CostOfAnomaly float64 `json:"costOfAnomaly"`
 
 	// EndTime End of the anomaly.
-	EndTime *int    `json:"endTime,omitempty"`
-	Id      *string `json:"id,omitempty"`
+	EndTime nullable.Nullable[int] `json:"endTime,omitempty"`
+	Id      *string                `json:"id,omitempty"`
 
 	// Notifications Chronologically ordered notification dispatch events.
 	Notifications NotificationEventArray `json:"notifications"`
@@ -3983,8 +3984,8 @@ type AnomalyItem struct {
 	SeverityLevel string `json:"severityLevel"`
 
 	// StartTime Usage start time of the anomaly.
-	StartTime int64              `json:"startTime"`
-	Status    *AnomalyItemStatus `json:"status,omitempty"`
+	StartTime int64                                `json:"startTime"`
+	Status    nullable.Nullable[AnomalyItemStatus] `json:"status,omitempty"`
 
 	// TimeFrame Timeframe: Daily or Hourly
 	TimeFrame string `json:"timeFrame"`
@@ -4559,7 +4560,7 @@ type CloudDiagramCostSnapshot struct {
 
 	// TrendingPct Period-over-period change as a fraction (e.g. 0.142 = +14.2%). `null` when no
 	// prior period of equal length is available for comparison.
-	TrendingPct *float32 `json:"trendingPct"`
+	TrendingPct nullable.Nullable[float32] `json:"trendingPct"`
 }
 
 // CloudDiagramCostTimeRange Resolved cost window for the snapshot.
@@ -5469,11 +5470,11 @@ type CreateAllocationRequest struct {
 	Name string `json:"name"`
 
 	// Rule Single allocation rule. Components can reference other existing allocation rules by using the "allocation_rule" dimension type.
-	Rule  *AllocationRule         `json:"rule,omitempty"`
-	Rules *[]*GroupAllocationRule `json:"rules,omitempty"`
+	Rule  nullable.Nullable[AllocationRule]         `json:"rule,omitempty"`
+	Rules *[]nullable.Nullable[GroupAllocationRule] `json:"rules,omitempty"`
 
 	// UnallocatedCosts Custom label for values that do not fit into allocation (required for group type allocation).
-	UnallocatedCosts *string `json:"unallocatedCosts,omitempty"`
+	UnallocatedCosts nullable.Nullable[string] `json:"unallocatedCosts,omitempty"`
 }
 
 // CreateAnnotationRequest Request body to create an annotation.
@@ -5518,7 +5519,7 @@ type CreateDatahubDataset201Response struct {
 	Name *string `json:"name,omitempty"`
 
 	// Records The number of records in the dataset.
-	Records *int64 `json:"records,omitempty"`
+	Records nullable.Nullable[int64] `json:"records,omitempty"`
 
 	// UpdatedBy The email of the user who last updated the dataset.
 	UpdatedBy *string `json:"updatedBy,omitempty"`
@@ -6112,10 +6113,10 @@ type GetAnomaly200Response struct {
 	Acknowledged *bool `json:"acknowledged,omitempty"`
 
 	// AcknowledgedAt When the anomaly was first acknowledged
-	AcknowledgedAt *time.Time `json:"acknowledgedAt,omitempty"`
+	AcknowledgedAt nullable.Nullable[time.Time] `json:"acknowledgedAt,omitempty"`
 
 	// AcknowledgedBy Email of the user who first acknowledged the anomaly
-	AcknowledgedBy *string `json:"acknowledgedBy,omitempty"`
+	AcknowledgedBy nullable.Nullable[string] `json:"acknowledgedBy,omitempty"`
 
 	// Attribution Attribution ID
 	Attribution string `json:"attribution"`
@@ -6127,7 +6128,7 @@ type GetAnomaly200Response struct {
 	CostOfAnomaly float64 `json:"costOfAnomaly"`
 
 	// EndTime End of the anomaly
-	EndTime *int `json:"endTime,omitempty"`
+	EndTime nullable.Nullable[int] `json:"endTime,omitempty"`
 
 	// Notifications Chronologically ordered notification dispatch events.
 	Notifications NotificationEventArray `json:"notifications"`
@@ -6148,8 +6149,8 @@ type GetAnomaly200Response struct {
 	SeverityLevel string `json:"severityLevel"`
 
 	// StartTime Usage start time of the anomaly
-	StartTime int64                        `json:"startTime"`
-	Status    *GetAnomaly200ResponseStatus `json:"status,omitempty"`
+	StartTime int64                                          `json:"startTime"`
+	Status    nullable.Nullable[GetAnomaly200ResponseStatus] `json:"status,omitempty"`
 
 	// TimeFrame Timeframe: Daily or Hourly
 	TimeFrame string `json:"timeFrame"`
@@ -6287,13 +6288,13 @@ type GetReportResponseType string
 type GetReportResponseResult struct {
 	// CacheHit If true, results were fetched from the cache.
 	CacheHit     *bool                                `json:"cacheHit,omitempty"`
-	ForecastRows *[][]*Value                          `json:"forecastRows,omitempty"`
+	ForecastRows *[][]nullable.Nullable[Value]        `json:"forecastRows,omitempty"`
 	MlFeatures   *[]GetReportResponseResultMlFeatures `json:"mlFeatures,omitempty"`
-	Rows         *[][]*Value                          `json:"rows,omitempty"`
+	Rows         *[][]nullable.Nullable[Value]        `json:"rows,omitempty"`
 	Schema       *[]SchemaField                       `json:"schema,omitempty"`
 
 	// SecondaryRows Secondary time range rows.
-	SecondaryRows *[][]*Value `json:"secondaryRows,omitempty"`
+	SecondaryRows *[][]nullable.Nullable[Value] `json:"secondaryRows,omitempty"`
 }
 
 // GetReportResponseResultMlFeatures defines model for GetReportResponseResult.MlFeatures.
@@ -6942,7 +6943,7 @@ type ResourcePermissionsResponse struct {
 	Permissions *[]ResourcePermission `json:"permissions,omitempty"`
 
 	// Public Type of permissions users in the entire organization have for this resource
-	Public *ResourcePermissionsResponsePublic `json:"public,omitempty"`
+	Public nullable.Nullable[ResourcePermissionsResponsePublic] `json:"public,omitempty"`
 
 	// UpdateTime The time when this resource was last updated, in milliseconds since the epoch.
 	UpdateTime *int64 `json:"updateTime,omitempty"`
@@ -7171,13 +7172,13 @@ type RunReportResult struct {
 type RunReportResultResult struct {
 	// CacheHit If true, results were fetched from the cache.
 	CacheHit     *bool                              `json:"cacheHit,omitempty"`
-	ForecastRows *[][]*Value                        `json:"forecastRows,omitempty"`
+	ForecastRows *[][]nullable.Nullable[Value]      `json:"forecastRows,omitempty"`
 	MlFeatures   *[]RunReportResultResultMlFeatures `json:"mlFeatures,omitempty"`
-	Rows         *[][]*Value                        `json:"rows,omitempty"`
+	Rows         *[][]nullable.Nullable[Value]      `json:"rows,omitempty"`
 	Schema       *[]SchemaField                     `json:"schema,omitempty"`
 
 	// SecondaryRows Secondary time range rows.
-	SecondaryRows *[][]*Value `json:"secondaryRows,omitempty"`
+	SecondaryRows *[][]nullable.Nullable[Value] `json:"secondaryRows,omitempty"`
 }
 
 // RunReportResultResultMlFeatures defines model for RunReportResultResult.MlFeatures.
@@ -7490,35 +7491,35 @@ type TimeSettingsSecondaryCustomTimeRange struct {
 // UpdateAllocationRequest Request body for updating an allocation.
 type UpdateAllocationRequest struct {
 	// Description Allocation description
-	Description *string `json:"description,omitempty"`
+	Description nullable.Nullable[string] `json:"description,omitempty"`
 
 	// FolderId Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
 	FolderId *string `json:"folderId,omitempty"`
 
 	// Name Allocation name
-	Name *string `json:"name,omitempty"`
+	Name nullable.Nullable[string] `json:"name,omitempty"`
 
 	// Rule Single allocation rule. Components can reference other existing allocation rules by using the "allocation_rule" dimension type.
-	Rule  *AllocationRule         `json:"rule,omitempty"`
-	Rules *[]*GroupAllocationRule `json:"rules,omitempty"`
+	Rule  nullable.Nullable[AllocationRule]         `json:"rule,omitempty"`
+	Rules *[]nullable.Nullable[GroupAllocationRule] `json:"rules,omitempty"`
 
 	// UnallocatedCosts Custom label for values that do not fit into allocation (required for group type allocation).
-	UnallocatedCosts *string `json:"unallocatedCosts,omitempty"`
+	UnallocatedCosts nullable.Nullable[string] `json:"unallocatedCosts,omitempty"`
 }
 
 // UpdateAnnotationRequest Request body for updating an annotation.
 type UpdateAnnotationRequest struct {
 	// Content The content of the annotation.
-	Content *string `json:"content,omitempty"`
+	Content nullable.Nullable[string] `json:"content,omitempty"`
 
 	// Labels List of label IDs to associate with the annotation. Labels must already exist.
-	Labels *[]string `json:"labels,omitempty"`
+	Labels nullable.Nullable[[]string] `json:"labels,omitempty"`
 
 	// Reports List of report IDs associated with the annotation.
-	Reports *[]string `json:"reports,omitempty"`
+	Reports nullable.Nullable[[]string] `json:"reports,omitempty"`
 
 	// Timestamp The date associated with the annotation.
-	Timestamp *time.Time `json:"timestamp,omitempty"`
+	Timestamp nullable.Nullable[time.Time] `json:"timestamp,omitempty"`
 }
 
 // UpdateAwsFeatureRequestBody defines model for UpdateAwsFeatureRequestBody.
@@ -7539,7 +7540,7 @@ type UpdateCustomThemeRequest struct {
 	Colors *ThemeColors `json:"colors,omitempty"`
 
 	// Name The display name of the custom theme.
-	Name *string `json:"name,omitempty"`
+	Name nullable.Nullable[string] `json:"name,omitempty"`
 
 	// PrimaryColor A color in hex notation. Accepts `#RGB`, `#RRGGBB`, or `#RRGGBBAA`.
 	PrimaryColor *HexColor `json:"primaryColor,omitempty"`
@@ -7557,7 +7558,7 @@ type UpdateDatahubDataset200Response struct {
 	Name *string `json:"name,omitempty"`
 
 	// Records The number of records in the dataset.
-	Records *int64 `json:"records,omitempty"`
+	Records nullable.Nullable[int64] `json:"records,omitempty"`
 
 	// UpdatedBy The email of the user who last updated the dataset.
 	UpdatedBy *string `json:"updatedBy,omitempty"`
@@ -7588,10 +7589,10 @@ type UpdateFolderRequest struct {
 // UpdateLabelRequest Request body for updating a label.
 type UpdateLabelRequest struct {
 	// Color The color of the label.
-	Color *UpdateLabelRequestColor `json:"color,omitempty"`
+	Color nullable.Nullable[UpdateLabelRequestColor] `json:"color,omitempty"`
 
 	// Name The name of the label.
-	Name *string `json:"name,omitempty"`
+	Name nullable.Nullable[string] `json:"name,omitempty"`
 }
 
 // UpdateLabelRequestColor The color of the label.
@@ -7602,7 +7603,7 @@ type UpdateResourcePermissionRequestBody struct {
 	Permissions *[]ResourcePermission `json:"permissions,omitempty"`
 
 	// Public The type of permissions granted to all users in the organization for this resource.
-	Public *UpdateResourcePermissionRequestBodyPublic `json:"public,omitempty"`
+	Public nullable.Nullable[UpdateResourcePermissionRequestBodyPublic] `json:"public,omitempty"`
 }
 
 // UpdateResourcePermissionRequestBodyPublic The type of permissions granted to all users in the organization for this resource.

--- a/internal/provider/nullable_helpers.go
+++ b/internal/provider/nullable_helpers.go
@@ -1,0 +1,22 @@
+package provider
+
+import "github.com/oapi-codegen/nullable"
+
+// nullableToPointer converts a nullable.Nullable[T] to a *T pointer.
+// If the nullable is null or unspecified, it returns nil.
+func nullableToPointer[T any](n nullable.Nullable[T]) *T {
+	if !n.IsSpecified() || n.IsNull() {
+		return nil
+	}
+	return new(n.MustGet())
+}
+
+// pointerToNullable converts a *T pointer to a nullable.Nullable[T].
+// If the pointer is nil, it returns an unspecified (empty) Nullable[T].
+func pointerToNullable[T any](p *T) nullable.Nullable[T] {
+	var n nullable.Nullable[T]
+	if p != nil {
+		n.Set(*p)
+	}
+	return n
+}

--- a/internal/provider/nullable_helpers.go
+++ b/internal/provider/nullable_helpers.go
@@ -20,3 +20,10 @@ func pointerToNullable[T any](p *T) nullable.Nullable[T] {
 	}
 	return n
 }
+
+// valueToNullable converts a value to a specified nullable.Nullable[T].
+func valueToNullable[T any](v T) nullable.Nullable[T] {
+	var n nullable.Nullable[T]
+	n.Set(v)
+	return n
+}

--- a/internal/provider/nullable_helpers_test.go
+++ b/internal/provider/nullable_helpers_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/oapi-codegen/nullable"
+)
+
+func TestNullableComparison_ExplicitNullIsNotNil(t *testing.T) {
+	// Assesses that nullable.Nullable[T] is a map type, so an explicit JSON null
+	// parses into an initialized, non-nil map.
+	var n nullable.Nullable[models.AllocationRule]
+	n.SetNull()
+
+	if n == nil {
+		t.Errorf("Expected n != nil when set to null, but got nil")
+	}
+
+	// This proves that a direct comparison like `resp.Rule != nil` will be TRUE
+	// even when Rule is explicitly null. We must use `nullableToPointer(resp.Rule) != nil`
+	// to properly detect explicitly specified, non-null values.
+}
+
+func TestUnknownPointerAccessor_ReturnsZeroValue(t *testing.T) {
+	// Assesses the framework behavior that pointer accessors return a pointer
+	// to the zero value when the state is Unknown, not nil.
+	unknownStr := types.StringUnknown()
+	p := unknownStr.ValueStringPointer()
+
+	if p == nil {
+		t.Fatalf("Expected pointer to not be nil for Unknown")
+	}
+
+	// Because `p` is not nil, `pointerToNullable(p)` will mark the nullable as specified:
+	n := pointerToNullable(p)
+	if !n.IsSpecified() {
+		t.Errorf("Expected nullable to be marked as specified for Unknown")
+	}
+	if n.MustGet() != "" {
+		t.Errorf("Expected nullable value to be empty string for Unknown, got %q", n.MustGet())
+	}
+	// This proves why `!IsUnknown()` checks are required for `Optional+Computed` fields
+	// before invoking their pointer accessors.
+}
+
+func TestMapAllocationToModel_GroupRule_RuleNull(t *testing.T) {
+	ctx := context.Background()
+
+	allocType := models.AllocationAllocationType("group")
+	var nullRule nullable.Nullable[models.AllocationRule]
+	nullRule.SetNull()
+
+	apiResp := &models.Allocation{
+		AllocationType: &allocType,
+		Rule:           nullRule,
+		Rules:          &[]nullable.Nullable[models.GroupAllocationRule]{}, // Empty group allocation
+	}
+
+	state := &allocationResourceModel{}
+	state.Id = types.StringValue("test-id")
+
+	// Call the mapping function
+	diags := mapAllocationToModel(ctx, nil, apiResp, state)
+	if diags.HasError() {
+		t.Fatalf("Unexpected diagnostics: %v", diags)
+	}
+
+	// state.Rules should be correctly mapped as an empty list, not Null.
+	// If `resp.Rule != nil` is used instead of `nullableToPointer(resp.Rule) != nil`,
+	// state.Rules will incorrectly be mapped as Null.
+	if state.Rules.IsNull() {
+		t.Errorf("state.Rules is Null, expected empty list")
+	}
+}

--- a/internal/provider/sharing_data_source.go
+++ b/internal/provider/sharing_data_source.go
@@ -160,8 +160,8 @@ func mapSharingResponseToDataSourceModel(ctx context.Context, apiResp *models.Re
 	data.Permissions = mapDSPermissionsToList(ctx, apiResp.Permissions, &diags)
 
 	// Map public — normalize empty string to null (allocations return "" for "no public access")
-	if apiResp.Public != nil && string(*apiResp.Public) != "" {
-		data.Public = types.StringValue(string(*apiResp.Public))
+	if publicVal := nullableToPointer(apiResp.Public); publicVal != nil && string(*publicVal) != "" {
+		data.Public = types.StringValue(string(*publicVal))
 	} else {
 		data.Public = types.StringNull()
 	}

--- a/internal/provider/sharing_resource.go
+++ b/internal/provider/sharing_resource.go
@@ -389,7 +389,7 @@ func (r *sharingResource) Delete(ctx context.Context, req resource.DeleteRequest
 		Permissions: &resetPerms,
 	}
 	if resType == "allocations" {
-		resetReq.Public = new(models.UpdateResourcePermissionRequestBodyPublic(""))
+		resetReq.Public = pointerToNullable(new(models.UpdateResourcePermissionRequestBodyPublic("")))
 	}
 
 	putResp, err := r.client.UpdateResourcePermissionWithResponse(
@@ -497,8 +497,8 @@ func mapSharingToModel(ctx context.Context, apiResp *models.ResourcePermissionsR
 	// Map public — normalize empty string to null.
 	// Allocations return public:"" to mean "no public access" while other resource
 	// types return null. We normalize both to null to prevent spurious drift.
-	if apiResp.Public != nil && string(*apiResp.Public) != "" {
-		state.Public = types.StringValue(string(*apiResp.Public))
+	if publicVal := nullableToPointer(apiResp.Public); publicVal != nil && string(*publicVal) != "" {
+		state.Public = types.StringValue(string(*publicVal))
 	} else {
 		state.Public = types.StringNull()
 	}
@@ -568,12 +568,12 @@ func buildSharingRequest(ctx context.Context, plan *sharingResourceModel, resour
 
 	// Map public from plan to API type.
 	if !plan.Public.IsNull() && !plan.Public.IsUnknown() {
-		reqBody.Public = new(models.UpdateResourcePermissionRequestBodyPublic(plan.Public.ValueString()))
+		reqBody.Public = pointerToNullable(new(models.UpdateResourcePermissionRequestBodyPublic(plan.Public.ValueString())))
 	} else if resourceType == "allocations" {
 		// Allocations require the public field to be present in the request body.
 		// The API returns 500 if public is omitted or null. An empty string signals
 		// "no public access" and is the only accepted sentinel for allocations.
-		reqBody.Public = new(models.UpdateResourcePermissionRequestBodyPublic(""))
+		reqBody.Public = pointerToNullable(new(models.UpdateResourcePermissionRequestBodyPublic("")))
 	}
 
 	return reqBody, diags

--- a/internal/provider/sharing_resource.go
+++ b/internal/provider/sharing_resource.go
@@ -389,7 +389,7 @@ func (r *sharingResource) Delete(ctx context.Context, req resource.DeleteRequest
 		Permissions: &resetPerms,
 	}
 	if resType == "allocations" {
-		resetReq.Public = pointerToNullable(new(models.UpdateResourcePermissionRequestBodyPublic("")))
+		resetReq.Public = valueToNullable(models.UpdateResourcePermissionRequestBodyPublic(""))
 	}
 
 	putResp, err := r.client.UpdateResourcePermissionWithResponse(
@@ -568,12 +568,12 @@ func buildSharingRequest(ctx context.Context, plan *sharingResourceModel, resour
 
 	// Map public from plan to API type.
 	if !plan.Public.IsNull() && !plan.Public.IsUnknown() {
-		reqBody.Public = pointerToNullable(new(models.UpdateResourcePermissionRequestBodyPublic(plan.Public.ValueString())))
+		reqBody.Public = valueToNullable(models.UpdateResourcePermissionRequestBodyPublic(plan.Public.ValueString()))
 	} else if resourceType == "allocations" {
 		// Allocations require the public field to be present in the request body.
 		// The API returns 500 if public is omitted or null. An empty string signals
 		// "no public access" and is the only accepted sentinel for allocations.
-		reqBody.Public = pointerToNullable(new(models.UpdateResourcePermissionRequestBodyPublic("")))
+		reqBody.Public = valueToNullable(models.UpdateResourcePermissionRequestBodyPublic(""))
 	}
 
 	return reqBody, diags


### PR DESCRIPTION
### Summary of Changes
Adopts nullable-type code generation in preparation for supporting explicit null attribute clearing in a future pull request.

- **Config**: Enabled `nullable-type: true` in `models.yml` configuration.
- **Helpers**: Implemented generic conversion helpers `nullableToPointer[T](n nullable.Nullable[T]) *T`, `pointerToNullable[T](p *T) nullable.Nullable[T]`, and `valueToNullable[T](v T) nullable.Nullable[T]` in `nullable_helpers.go` (complying with the Go 1.26+ `new(expr)` custom linter).
- **Mapping**: Refactored mapping code across all relevant resources and data sources (including allocation, annotation, anomalies, anomaly, custom theme, datahub dataset, label, and resource sharing) to support the new generated nullable structs without changing their runtime behaviors (retaining backward-compatibility). Used `valueToNullable` wherever possible to avoid unnecessary pointer taking or allocations.
- **Tests**: Reconciled the internal unit tests for allocations to align with the new nullable type structure and helpers.

### Developer/User Impact
- **Developer**: Fully unblocks utilizing explicit null states on API client and models.
- **User**: No functional or runtime changes have been introduced; behavior remains backward-compatible.

### Validation Performed
- Checked Go build successfully via `go build ./...`.
- Verified pre-commit hooks and `golangci-lint` pass.
- Verified unit tests pass via `go test ./internal/provider/...`.
- Acceptance tests verified as passing by user.

### AI Disclosure
This pull request includes commits generated with the assistance of AI (Antigravity).