### PR TITLE
chore(codegen): bump codegen-framework with ValueFromObject null/unknown guards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
-	github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260605110253-bd13bae94021 // indirect
+	github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260722140535-d4f68d4735b0 // indirect
 	github.com/doitintl/terraform-plugin-codegen-openapi v0.0.0-20260605111443-a72258dfe4c6 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/fatih/color v1.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260605110253-bd13bae94021 h1:bkUd/rkIHoWMoWd1k0mSEJ6u+Cm4paTpBpG83+wTkOc=
-github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260605110253-bd13bae94021/go.mod h1:IxLiAxGac8tdJjjcvD604g/FDxKyNC18DQ9KBxLh8Z4=
+github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260722140535-d4f68d4735b0 h1:3CExxL3BHZVGB+ZDbuclekfyJ+eWwgjLz3kezA6Cxb8=
+github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260722140535-d4f68d4735b0/go.mod h1:IxLiAxGac8tdJjjcvD604g/FDxKyNC18DQ9KBxLh8Z4=
 github.com/doitintl/terraform-plugin-codegen-openapi v0.0.0-20260605111443-a72258dfe4c6 h1:A196htHYMjXvDSRwbGibsygFz7HTEVKXhRcLWa7BkkY=
 github.com/doitintl/terraform-plugin-codegen-openapi v0.0.0-20260605111443-a72258dfe4c6/go.mod h1:X20JLZjGvx7MIS5S2CQ1maVFNUyPZ6/Q/tycb5QXC/0=
 github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/0PGwMEbC3d5AB7oi67+h4TsQqItC1GVYG58=

--- a/internal/provider/datasource_account_team/account_team_data_source_gen.go
+++ b/internal/provider/datasource_account_team/account_team_data_source_gen.go
@@ -78,6 +78,14 @@ func (t AccountManagersType) String() string {
 func (t AccountManagersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAccountManagersValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAccountManagersValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	calendlyLinkAttribute, ok := attributes["calendly_link"]

--- a/internal/provider/datasource_alert/alert_data_source_gen.go
+++ b/internal/provider/datasource_alert/alert_data_source_gen.go
@@ -212,6 +212,14 @@ func (t ConfigType) String() string {
 func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewConfigValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewConfigValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	attributionsAttribute, ok := attributes["attributions"]
@@ -1102,6 +1110,14 @@ func (t MetricType) String() string {
 func (t MetricType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewMetricValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	typeAttribute, ok := attributes["type"]
@@ -1480,6 +1496,14 @@ func (t ScopesType) String() string {
 
 func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewScopesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewScopesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_alerts/alerts_data_source_gen.go
+++ b/internal/provider/datasource_alerts/alerts_data_source_gen.go
@@ -282,6 +282,14 @@ func (t AlertsType) String() string {
 func (t AlertsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAlertsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAlertsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	configAttribute, ok := attributes["config"]
@@ -1045,6 +1053,14 @@ func (t ConfigType) String() string {
 
 func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewConfigValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewConfigValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1936,6 +1952,14 @@ func (t MetricType) String() string {
 func (t MetricType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewMetricValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	typeAttribute, ok := attributes["type"]
@@ -2314,6 +2338,14 @@ func (t ScopesType) String() string {
 
 func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewScopesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewScopesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_allocation/allocation_data_source_gen.go
+++ b/internal/provider/datasource_allocation/allocation_data_source_gen.go
@@ -278,6 +278,14 @@ func (t RuleType) String() string {
 func (t RuleType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewRuleValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRuleValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	componentsAttribute, ok := attributes["components"]
@@ -668,6 +676,14 @@ func (t ComponentsType) String() string {
 
 func (t ComponentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewComponentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewComponentsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1410,6 +1426,14 @@ func (t RulesType) String() string {
 
 func (t RulesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewRulesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRulesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_allocations/allocations_data_source_gen.go
+++ b/internal/provider/datasource_allocations/allocations_data_source_gen.go
@@ -173,6 +173,14 @@ func (t AllocationsType) String() string {
 func (t AllocationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAllocationsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAllocationsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	allocationTypeAttribute, ok := attributes["allocation_type"]

--- a/internal/provider/datasource_annotation/annotation_data_source_gen.go
+++ b/internal/provider/datasource_annotation/annotation_data_source_gen.go
@@ -112,6 +112,14 @@ func (t LabelsType) String() string {
 func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLabelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLabelsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]

--- a/internal/provider/datasource_annotations/annotations_data_source_gen.go
+++ b/internal/provider/datasource_annotations/annotations_data_source_gen.go
@@ -176,6 +176,14 @@ func (t AnnotationsType) String() string {
 func (t AnnotationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAnnotationsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAnnotationsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	contentAttribute, ok := attributes["content"]
@@ -875,6 +883,14 @@ func (t LabelsType) String() string {
 
 func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewLabelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLabelsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
+++ b/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
@@ -281,6 +281,14 @@ func (t AnomaliesType) String() string {
 func (t AnomaliesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAnomaliesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAnomaliesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	acknowledgedAttribute, ok := attributes["acknowledged"]
@@ -1576,6 +1584,14 @@ func (t NotificationsType) String() string {
 func (t NotificationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewNotificationsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNotificationsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	channelAttribute, ok := attributes["channel"]
@@ -1954,6 +1970,14 @@ func (t ResourceDataType) String() string {
 
 func (t ResourceDataType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewResourceDataValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewResourceDataValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -2511,6 +2535,14 @@ func (t LabelsType) String() string {
 func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLabelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLabelsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	costAttribute, ok := attributes["cost"]
@@ -2944,6 +2976,14 @@ func (t Top3skusType) String() string {
 
 func (t Top3skusType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTop3skusValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTop3skusValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
+++ b/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
@@ -242,6 +242,14 @@ func (t NotificationsType) String() string {
 func (t NotificationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewNotificationsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNotificationsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	channelAttribute, ok := attributes["channel"]
@@ -620,6 +628,14 @@ func (t ResourceDataType) String() string {
 
 func (t ResourceDataType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewResourceDataValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewResourceDataValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1177,6 +1193,14 @@ func (t LabelsType) String() string {
 func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLabelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLabelsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	costAttribute, ok := attributes["cost"]
@@ -1610,6 +1634,14 @@ func (t Top3skusType) String() string {
 
 func (t Top3skusType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTop3skusValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTop3skusValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_asset/asset_data_source_gen.go
+++ b/internal/provider/datasource_asset/asset_data_source_gen.go
@@ -254,6 +254,14 @@ func (t PropertiesType) String() string {
 func (t PropertiesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPropertiesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPropertiesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	customerDomainAttribute, ok := attributes["customer_domain"]
@@ -760,6 +768,14 @@ func (t SubscriptionType) String() string {
 
 func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSubscriptionValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSubscriptionValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1689,6 +1705,14 @@ func (t PlanType) String() string {
 func (t PlanType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPlanValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPlanValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	commitmentIntervalAttribute, ok := attributes["commitment_interval"]
@@ -2141,6 +2165,14 @@ func (t CommitmentIntervalType) String() string {
 func (t CommitmentIntervalType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCommitmentIntervalValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCommitmentIntervalValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	endTimeAttribute, ok := attributes["end_time"]
@@ -2520,6 +2552,14 @@ func (t RenewalSettingsType) String() string {
 func (t RenewalSettingsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewRenewalSettingsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRenewalSettingsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	renewalTypeAttribute, ok := attributes["renewal_type"]
@@ -2843,6 +2883,14 @@ func (t SeatsType) String() string {
 
 func (t SeatsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSeatsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSeatsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_assets/assets_data_source_gen.go
+++ b/internal/provider/datasource_assets/assets_data_source_gen.go
@@ -122,6 +122,14 @@ func (t AssetsType) String() string {
 func (t AssetsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAssetsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAssetsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	createTimeAttribute, ok := attributes["create_time"]

--- a/internal/provider/datasource_budget/budget_data_source_gen.go
+++ b/internal/provider/datasource_budget/budget_data_source_gen.go
@@ -298,6 +298,14 @@ func (t AlertsType) String() string {
 func (t AlertsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAlertsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAlertsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	forecastedDateAttribute, ok := attributes["forecasted_date"]
@@ -732,6 +740,14 @@ func (t CollaboratorsType) String() string {
 func (t CollaboratorsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCollaboratorsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCollaboratorsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	emailAttribute, ok := attributes["email"]
@@ -1110,6 +1126,14 @@ func (t RecipientsSlackChannelsType) String() string {
 
 func (t RecipientsSlackChannelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewRecipientsSlackChannelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRecipientsSlackChannelsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1709,6 +1733,14 @@ func (t ScopesType) String() string {
 
 func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewScopesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewScopesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_budgets/budgets_data_source_gen.go
+++ b/internal/provider/datasource_budgets/budgets_data_source_gen.go
@@ -220,6 +220,14 @@ func (t BudgetsType) String() string {
 func (t BudgetsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewBudgetsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewBudgetsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	alertThresholdsAttribute, ok := attributes["alert_thresholds"]
@@ -1438,6 +1446,14 @@ func (t AlertThresholdsType) String() string {
 func (t AlertThresholdsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAlertThresholdsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAlertThresholdsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	amountAttribute, ok := attributes["amount"]
@@ -1816,6 +1832,14 @@ func (t ScopesType) String() string {
 
 func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewScopesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewScopesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams/cloud_diagrams_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams/cloud_diagrams_data_source_gen.go
@@ -75,6 +75,14 @@ func (t CloudDiagramsType) String() string {
 func (t CloudDiagramsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCloudDiagramsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCloudDiagramsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	diagramUrlAttribute, ok := attributes["diagram_url"]

--- a/internal/provider/datasource_cloud_diagrams_activity_groups/cloud_diagrams_activity_groups_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_activity_groups/cloud_diagrams_activity_groups_data_source_gen.go
@@ -182,6 +182,14 @@ func (t CloudDiagramsActivityGroupsType) String() string {
 func (t CloudDiagramsActivityGroupsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCloudDiagramsActivityGroupsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCloudDiagramsActivityGroupsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -825,6 +833,14 @@ func (t ItemsType) String() string {
 
 func (t ItemsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewItemsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewItemsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams_cost_snapshot/cloud_diagrams_cost_snapshot_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_cost_snapshot/cloud_diagrams_cost_snapshot_data_source_gen.go
@@ -221,6 +221,14 @@ func (t ByServiceType) String() string {
 func (t ByServiceType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewByServiceValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewByServiceValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	amountAttribute, ok := attributes["amount"]
@@ -599,6 +607,14 @@ func (t TimeRangeType) String() string {
 
 func (t TimeRangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTimeRangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTimeRangeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1033,6 +1049,14 @@ func (t TopResourcesType) String() string {
 
 func (t TopResourcesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTopResourcesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTopResourcesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1522,6 +1546,14 @@ func (t TrendType) String() string {
 
 func (t TrendType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTrendValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTrendValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams_export/cloud_diagrams_export_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_export/cloud_diagrams_export_data_source_gen.go
@@ -842,6 +842,14 @@ func (t AttachmentsType) String() string {
 func (t AttachmentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAttachmentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAttachmentsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -1822,6 +1830,14 @@ func (t IssuesType) String() string {
 func (t IssuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewIssuesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewIssuesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -2310,6 +2326,14 @@ func (t CombinersType) String() string {
 
 func (t CombinersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewCombinersValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCombinersValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -2867,6 +2891,14 @@ func (t ItemsType) String() string {
 func (t ItemsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewItemsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewItemsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -3245,6 +3277,14 @@ func (t ElementsType) String() string {
 
 func (t ElementsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewElementsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewElementsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -4225,6 +4265,14 @@ func (t GroupsType) String() string {
 
 func (t GroupsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewGroupsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewGroupsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -5275,6 +5323,14 @@ func (t LinksType) String() string {
 
 func (t LinksType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewLinksValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLinksValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -6356,6 +6412,14 @@ func (t DestinationType) String() string {
 func (t DestinationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDestinationValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDestinationValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -6845,6 +6909,14 @@ func (t OriginType) String() string {
 func (t OriginType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewOriginValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewOriginValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -7333,6 +7405,14 @@ func (t MetadataType) String() string {
 
 func (t MetadataType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewMetadataValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetadataValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -7851,6 +7931,14 @@ func (t NodesType) String() string {
 
 func (t NodesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewNodesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNodesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -9022,6 +9110,14 @@ func (t InfraNodeType) String() string {
 func (t InfraNodeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewInfraNodeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewInfraNodeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -9455,6 +9551,14 @@ func (t NotesType) String() string {
 
 func (t NotesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewNotesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNotesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams_node_activities/cloud_diagrams_node_activities_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_node_activities/cloud_diagrams_node_activities_data_source_gen.go
@@ -129,6 +129,14 @@ func (t CloudDiagramsNodeActivitiesType) String() string {
 func (t CloudDiagramsNodeActivitiesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCloudDiagramsNodeActivitiesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCloudDiagramsNodeActivitiesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]

--- a/internal/provider/datasource_cloud_diagrams_relationships/cloud_diagrams_relationships_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_relationships/cloud_diagrams_relationships_data_source_gen.go
@@ -189,6 +189,14 @@ func (t AnchorType) String() string {
 func (t AnchorType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAnchorValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAnchorValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]
@@ -677,6 +685,14 @@ func (t RelationsType) String() string {
 
 func (t RelationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewRelationsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRelationsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams_schemes/cloud_diagrams_schemes_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_schemes/cloud_diagrams_schemes_data_source_gen.go
@@ -1071,6 +1071,14 @@ func (t SchemeType) String() string {
 func (t SchemeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewSchemeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSchemeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -1626,6 +1634,14 @@ func (t SchemeStatussheetType) String() string {
 
 func (t SchemeStatussheetType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSchemeStatussheetValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSchemeStatussheetValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -2225,6 +2241,14 @@ func (t StatussheetType) String() string {
 
 func (t StatussheetType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewStatussheetValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewStatussheetValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -3036,6 +3060,14 @@ func (t AttachmentType) String() string {
 
 func (t AttachmentType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewAttachmentValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAttachmentValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -4017,6 +4049,14 @@ func (t IssuesType) String() string {
 func (t IssuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewIssuesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewIssuesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -4505,6 +4545,14 @@ func (t CombinerType) String() string {
 
 func (t CombinerType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewCombinerValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCombinerValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -5062,6 +5110,14 @@ func (t ItemsType) String() string {
 func (t ItemsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewItemsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewItemsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -5440,6 +5496,14 @@ func (t ElementType) String() string {
 
 func (t ElementType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewElementValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewElementValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -6420,6 +6484,14 @@ func (t GroupType) String() string {
 
 func (t GroupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewGroupValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewGroupValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -7470,6 +7542,14 @@ func (t LinkType) String() string {
 
 func (t LinkType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewLinkValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLinkValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -8551,6 +8631,14 @@ func (t DestinationType) String() string {
 func (t DestinationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDestinationValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDestinationValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -9040,6 +9128,14 @@ func (t OriginType) String() string {
 func (t OriginType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewOriginValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewOriginValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -9528,6 +9624,14 @@ func (t NodeType) String() string {
 
 func (t NodeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewNodeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNodeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -10699,6 +10803,14 @@ func (t InfraNodeType) String() string {
 func (t InfraNodeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewInfraNodeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewInfraNodeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -11132,6 +11244,14 @@ func (t NoteType) String() string {
 
 func (t NoteType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewNoteValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNoteValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -11621,6 +11741,14 @@ func (t StatussheetStatussheetType) String() string {
 
 func (t StatussheetStatussheetType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewStatussheetStatussheetValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewStatussheetStatussheetValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -12128,6 +12256,14 @@ func (t ImportType) String() string {
 
 func (t ImportType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewImportValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewImportValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams_search/cloud_diagrams_search_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_search/cloud_diagrams_search_data_source_gen.go
@@ -269,6 +269,14 @@ func (t ComponentType) String() string {
 func (t ComponentType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewComponentValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewComponentValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -1161,6 +1169,14 @@ func (t PropsType) String() string {
 func (t PropsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPropsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPropsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	serviceTypeAttribute, ok := attributes["service_type"]
@@ -1484,6 +1500,14 @@ func (t PropType) String() string {
 
 func (t PropType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewPropValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPropValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -2376,6 +2400,14 @@ func (t SchemeType) String() string {
 
 func (t SchemeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSchemeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSchemeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams_snapshots/cloud_diagrams_snapshots_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_snapshots/cloud_diagrams_snapshots_data_source_gen.go
@@ -118,6 +118,14 @@ func (t CloudDiagramsSnapshotsType) String() string {
 func (t CloudDiagramsSnapshotsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCloudDiagramsSnapshotsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCloudDiagramsSnapshotsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]

--- a/internal/provider/datasource_cloud_diagrams_stats/cloud_diagrams_stats_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_stats/cloud_diagrams_stats_data_source_gen.go
@@ -181,6 +181,14 @@ func (t CloudDiagramsStatsType) String() string {
 func (t CloudDiagramsStatsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCloudDiagramsStatsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCloudDiagramsStatsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -975,6 +983,14 @@ func (t ChangesType) String() string {
 func (t ChangesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewChangesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewChangesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	countAttribute, ok := attributes["count"]
@@ -1408,6 +1424,14 @@ func (t ImportType) String() string {
 
 func (t ImportType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewImportValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewImportValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_diagrams_statussheet/cloud_diagrams_statussheet_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_statussheet/cloud_diagrams_statussheet_data_source_gen.go
@@ -808,6 +808,14 @@ func (t AttachmentType) String() string {
 func (t AttachmentType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAttachmentValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAttachmentValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -1788,6 +1796,14 @@ func (t IssuesType) String() string {
 func (t IssuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewIssuesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewIssuesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -2276,6 +2292,14 @@ func (t CombinerType) String() string {
 
 func (t CombinerType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewCombinerValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCombinerValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -2833,6 +2857,14 @@ func (t ItemsType) String() string {
 func (t ItemsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewItemsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewItemsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -3211,6 +3243,14 @@ func (t ElementType) String() string {
 
 func (t ElementType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewElementValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewElementValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -4191,6 +4231,14 @@ func (t GroupType) String() string {
 
 func (t GroupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewGroupValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewGroupValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -5241,6 +5289,14 @@ func (t LinkType) String() string {
 
 func (t LinkType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewLinkValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLinkValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -6322,6 +6378,14 @@ func (t DestinationType) String() string {
 func (t DestinationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDestinationValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDestinationValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -6811,6 +6875,14 @@ func (t OriginType) String() string {
 func (t OriginType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewOriginValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewOriginValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -7299,6 +7371,14 @@ func (t NodeType) String() string {
 
 func (t NodeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewNodeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNodeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -8470,6 +8550,14 @@ func (t InfraNodeType) String() string {
 func (t InfraNodeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewInfraNodeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewInfraNodeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	underscoreIdAttribute, ok := attributes["_id"]
@@ -8903,6 +8991,14 @@ func (t NoteType) String() string {
 
 func (t NoteType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewNoteValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewNoteValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_cloud_incidents/cloud_incidents_data_source_gen.go
+++ b/internal/provider/datasource_cloud_incidents/cloud_incidents_data_source_gen.go
@@ -136,6 +136,14 @@ func (t IncidentsType) String() string {
 func (t IncidentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewIncidentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewIncidentsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	createTimeAttribute, ok := attributes["create_time"]

--- a/internal/provider/datasource_cloudconnect_aws_account/cloudconnect_aws_account_data_source_gen.go
+++ b/internal/provider/datasource_cloudconnect_aws_account/cloudconnect_aws_account_data_source_gen.go
@@ -112,6 +112,14 @@ func (t SupportedFeaturesType) String() string {
 func (t SupportedFeaturesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewSupportedFeaturesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSupportedFeaturesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	hasRequiredPermissionsAttribute, ok := attributes["has_required_permissions"]

--- a/internal/provider/datasource_commitment/commitment_data_source_gen.go
+++ b/internal/provider/datasource_commitment/commitment_data_source_gen.go
@@ -172,6 +172,14 @@ func (t PeriodsType) String() string {
 func (t PeriodsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPeriodsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPeriodsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	commitmentValueAttribute, ok := attributes["commitment_value"]

--- a/internal/provider/datasource_commitments/commitments_data_source_gen.go
+++ b/internal/provider/datasource_commitments/commitments_data_source_gen.go
@@ -233,6 +233,14 @@ func (t CommitmentsType) String() string {
 func (t CommitmentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCommitmentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCommitmentsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	cloudProviderAttribute, ok := attributes["cloud_provider"]
@@ -1228,6 +1236,14 @@ func (t PeriodsType) String() string {
 
 func (t PeriodsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewPeriodsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPeriodsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_custom_theme/custom_theme_data_source_gen.go
+++ b/internal/provider/datasource_custom_theme/custom_theme_data_source_gen.go
@@ -103,6 +103,14 @@ func (t ColorsType) String() string {
 func (t ColorsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewColorsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewColorsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	darkAttribute, ok := attributes["dark"]

--- a/internal/provider/datasource_custom_themes/custom_themes_data_source_gen.go
+++ b/internal/provider/datasource_custom_themes/custom_themes_data_source_gen.go
@@ -116,6 +116,14 @@ func (t ThemesType) String() string {
 func (t ThemesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewThemesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewThemesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	colorsAttribute, ok := attributes["colors"]
@@ -732,6 +740,14 @@ func (t ColorsType) String() string {
 
 func (t ColorsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewColorsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewColorsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_datahub_datasets/datahub_datasets_data_source_gen.go
+++ b/internal/provider/datasource_datahub_datasets/datahub_datasets_data_source_gen.go
@@ -88,6 +88,14 @@ func (t DatasetsType) String() string {
 func (t DatasetsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDatasetsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDatasetsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	descriptionAttribute, ok := attributes["description"]

--- a/internal/provider/datasource_dimension/dimension_data_source_gen.go
+++ b/internal/provider/datasource_dimension/dimension_data_source_gen.go
@@ -104,6 +104,14 @@ func (t ValuesType) String() string {
 func (t ValuesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewValuesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewValuesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	cloudAttribute, ok := attributes["cloud"]

--- a/internal/provider/datasource_dimensions/dimensions_data_source_gen.go
+++ b/internal/provider/datasource_dimensions/dimensions_data_source_gen.go
@@ -135,6 +135,14 @@ func (t DimensionsType) String() string {
 func (t DimensionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDimensionsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDimensionsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]

--- a/internal/provider/datasource_folders/folders_data_source_gen.go
+++ b/internal/provider/datasource_folders/folders_data_source_gen.go
@@ -103,6 +103,14 @@ func (t FoldersType) String() string {
 func (t FoldersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewFoldersValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewFoldersValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	descriptionAttribute, ok := attributes["description"]

--- a/internal/provider/datasource_insight/insight_data_source_gen.go
+++ b/internal/provider/datasource_insight/insight_data_source_gen.go
@@ -229,6 +229,14 @@ func (t DismissalDetailsType) String() string {
 func (t DismissalDetailsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDismissalDetailsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDismissalDetailsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	commentAttribute, ok := attributes["comment"]
@@ -608,6 +616,14 @@ func (t LastStatusChangeType) String() string {
 func (t LastStatusChangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLastStatusChangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLastStatusChangeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	lastChangedAtAttribute, ok := attributes["last_changed_at"]
@@ -986,6 +1002,14 @@ func (t SummaryType) String() string {
 
 func (t SummaryType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSummaryValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSummaryValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_insight_resource_results/insight_resource_results_data_source_gen.go
+++ b/internal/provider/datasource_insight_resource_results/insight_resource_results_data_source_gen.go
@@ -257,6 +257,14 @@ func (t ResourceResultsType) String() string {
 func (t ResourceResultsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewResourceResultsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewResourceResultsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	accountAttribute, ok := attributes["account"]
@@ -1277,6 +1285,14 @@ func (t EnhancementType) String() string {
 func (t EnhancementType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewEnhancementValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewEnhancementValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	lastUpdatedAtAttribute, ok := attributes["last_updated_at"]
@@ -1817,6 +1833,14 @@ func (t PriorityType) String() string {
 func (t PriorityType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPriorityValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPriorityValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	priorityScoreAttribute, ok := attributes["priority_score"]
@@ -2195,6 +2219,14 @@ func (t ResultType) String() string {
 
 func (t ResultType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewResultValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewResultValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_insights/insights_data_source_gen.go
+++ b/internal/provider/datasource_insights/insights_data_source_gen.go
@@ -336,6 +336,14 @@ func (t PaginationType) String() string {
 func (t PaginationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPaginationValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPaginationValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	pageTokenAttribute, ok := attributes["page_token"]
@@ -714,6 +722,14 @@ func (t ResultsType) String() string {
 
 func (t ResultsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewResultsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewResultsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -2028,6 +2044,14 @@ func (t DismissalDetailsType) String() string {
 func (t DismissalDetailsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDismissalDetailsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDismissalDetailsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	commentAttribute, ok := attributes["comment"]
@@ -2407,6 +2431,14 @@ func (t LastStatusChangeType) String() string {
 func (t LastStatusChangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLastStatusChangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLastStatusChangeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	lastChangedAtAttribute, ok := attributes["last_changed_at"]
@@ -2785,6 +2817,14 @@ func (t SummaryType) String() string {
 
 func (t SummaryType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSummaryValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSummaryValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_invoice/invoice_data_source_gen.go
+++ b/internal/provider/datasource_invoice/invoice_data_source_gen.go
@@ -137,6 +137,14 @@ func (t LineItemsType) String() string {
 func (t LineItemsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLineItemsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLineItemsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	currencyAttribute, ok := attributes["currency"]

--- a/internal/provider/datasource_invoices/invoices_data_source_gen.go
+++ b/internal/provider/datasource_invoices/invoices_data_source_gen.go
@@ -151,6 +151,14 @@ func (t InvoicesType) String() string {
 func (t InvoicesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewInvoicesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewInvoicesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	balanceAmountAttribute, ok := attributes["balance_amount"]

--- a/internal/provider/datasource_label_assignments/label_assignments_data_source_gen.go
+++ b/internal/provider/datasource_label_assignments/label_assignments_data_source_gen.go
@@ -81,6 +81,14 @@ func (t AssignmentsType) String() string {
 func (t AssignmentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAssignmentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAssignmentsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	objectIdAttribute, ok := attributes["object_id"]

--- a/internal/provider/datasource_labels/labels_data_source_gen.go
+++ b/internal/provider/datasource_labels/labels_data_source_gen.go
@@ -151,6 +151,14 @@ func (t LabelsType) String() string {
 func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLabelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLabelsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	colorAttribute, ok := attributes["color"]

--- a/internal/provider/datasource_organizations/organizations_data_source_gen.go
+++ b/internal/provider/datasource_organizations/organizations_data_source_gen.go
@@ -79,6 +79,14 @@ func (t OrganizationsType) String() string {
 func (t OrganizationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewOrganizationsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewOrganizationsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]

--- a/internal/provider/datasource_platforms/platforms_data_source_gen.go
+++ b/internal/provider/datasource_platforms/platforms_data_source_gen.go
@@ -69,6 +69,14 @@ func (t PlatformsType) String() string {
 func (t PlatformsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPlatformsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPlatformsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	displayNameAttribute, ok := attributes["display_name"]

--- a/internal/provider/datasource_products/products_data_source_gen.go
+++ b/internal/provider/datasource_products/products_data_source_gen.go
@@ -77,6 +77,14 @@ func (t ProductsType) String() string {
 func (t ProductsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewProductsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewProductsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	displayNameAttribute, ok := attributes["display_name"]

--- a/internal/provider/datasource_report/report_data_source_gen.go
+++ b/internal/provider/datasource_report/report_data_source_gen.go
@@ -628,6 +628,14 @@ func (t ConfigType) String() string {
 func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewConfigValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewConfigValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	advancedAnalysisAttribute, ok := attributes["advanced_analysis"]
@@ -2293,6 +2301,14 @@ func (t AdvancedAnalysisType) String() string {
 func (t AdvancedAnalysisType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAdvancedAnalysisValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAdvancedAnalysisValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	forecastAttribute, ok := attributes["forecast"]
@@ -2782,6 +2798,14 @@ func (t CustomTimeRangeType) String() string {
 func (t CustomTimeRangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCustomTimeRangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCustomTimeRangeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	fromAttribute, ok := attributes["from"]
@@ -3161,6 +3185,14 @@ func (t DimensionsType) String() string {
 func (t DimensionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDimensionsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDimensionsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]
@@ -3539,6 +3571,14 @@ func (t DisplaySettingsType) String() string {
 
 func (t DisplaySettingsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewDisplaySettingsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDisplaySettingsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -4083,6 +4123,14 @@ func (t FiltersType) String() string {
 
 func (t FiltersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewFiltersValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewFiltersValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -4770,6 +4818,14 @@ func (t GroupType) String() string {
 func (t GroupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewGroupValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewGroupValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]
@@ -5221,6 +5277,14 @@ func (t LimitType) String() string {
 
 func (t LimitType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewLimitValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLimitValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -5674,6 +5738,14 @@ func (t MetricType) String() string {
 func (t MetricType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewMetricValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	typeAttribute, ok := attributes["type"]
@@ -6052,6 +6124,14 @@ func (t MetricFilterType) String() string {
 
 func (t MetricFilterType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewMetricFilterValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricFilterValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -6537,6 +6617,14 @@ func (t MetricsType) String() string {
 func (t MetricsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewMetricsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	typeAttribute, ok := attributes["type"]
@@ -6915,6 +7003,14 @@ func (t SecondaryTimeRangeType) String() string {
 
 func (t SecondaryTimeRangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSecondaryTimeRangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSecondaryTimeRangeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -7422,6 +7518,14 @@ func (t SplitsType) String() string {
 
 func (t SplitsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSplitsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSplitsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -8052,6 +8156,14 @@ func (t OriginType) String() string {
 func (t OriginType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewOriginValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewOriginValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]
@@ -8430,6 +8542,14 @@ func (t TargetsType) String() string {
 
 func (t TargetsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTargetsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTargetsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -8864,6 +8984,14 @@ func (t TimeRangeType) String() string {
 
 func (t TimeRangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTimeRangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTimeRangeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_reports/reports_data_source_gen.go
+++ b/internal/provider/datasource_reports/reports_data_source_gen.go
@@ -161,6 +161,14 @@ func (t ReportsType) String() string {
 func (t ReportsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewReportsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewReportsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	createTimeAttribute, ok := attributes["create_time"]
@@ -881,6 +889,14 @@ func (t LabelsType) String() string {
 
 func (t LabelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewLabelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLabelsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_roles/roles_data_source_gen.go
+++ b/internal/provider/datasource_roles/roles_data_source_gen.go
@@ -89,6 +89,14 @@ func (t RolesType) String() string {
 func (t RolesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewRolesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRolesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	customerAttribute, ok := attributes["customer"]

--- a/internal/provider/datasource_sharing/sharing_data_source_gen.go
+++ b/internal/provider/datasource_sharing/sharing_data_source_gen.go
@@ -131,6 +131,14 @@ func (t PermissionsType) String() string {
 func (t PermissionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPermissionsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPermissionsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	roleAttribute, ok := attributes["role"]

--- a/internal/provider/datasource_support_request_comments/support_request_comments_data_source_gen.go
+++ b/internal/provider/datasource_support_request_comments/support_request_comments_data_source_gen.go
@@ -112,6 +112,14 @@ func (t CommentsType) String() string {
 func (t CommentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCommentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCommentsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	attachmentsAttribute, ok := attributes["attachments"]
@@ -667,6 +675,14 @@ func (t AttachmentsType) String() string {
 
 func (t AttachmentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewAttachmentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAttachmentsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/datasource_support_requests/support_requests_data_source_gen.go
+++ b/internal/provider/datasource_support_requests/support_requests_data_source_gen.go
@@ -170,6 +170,14 @@ func (t TicketsType) String() string {
 func (t TicketsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewTicketsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTicketsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	createTimeAttribute, ok := attributes["create_time"]

--- a/internal/provider/datasource_users/users_data_source_gen.go
+++ b/internal/provider/datasource_users/users_data_source_gen.go
@@ -136,6 +136,14 @@ func (t UsersType) String() string {
 func (t UsersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewUsersValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewUsersValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	displayNameAttribute, ok := attributes["display_name"]

--- a/internal/provider/resource_alert/alert_resource_gen.go
+++ b/internal/provider/resource_alert/alert_resource_gen.go
@@ -315,6 +315,14 @@ func (t ConfigType) String() string {
 func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewConfigValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewConfigValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	attributionsAttribute, ok := attributes["attributions"]
@@ -1205,6 +1213,14 @@ func (t MetricType) String() string {
 func (t MetricType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewMetricValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	typeAttribute, ok := attributes["type"]
@@ -1583,6 +1599,14 @@ func (t ScopesType) String() string {
 
 func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewScopesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewScopesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_allocation/allocation_resource_gen.go
+++ b/internal/provider/resource_allocation/allocation_resource_gen.go
@@ -361,6 +361,14 @@ func (t RuleType) String() string {
 func (t RuleType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewRuleValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRuleValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	componentsAttribute, ok := attributes["components"]
@@ -751,6 +759,14 @@ func (t ComponentsType) String() string {
 
 func (t ComponentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewComponentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewComponentsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1493,6 +1509,14 @@ func (t RulesType) String() string {
 
 func (t RulesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewRulesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRulesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_asset/asset_resource_gen.go
+++ b/internal/provider/resource_asset/asset_resource_gen.go
@@ -255,6 +255,14 @@ func (t PropertiesType) String() string {
 func (t PropertiesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPropertiesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPropertiesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	customerDomainAttribute, ok := attributes["customer_domain"]
@@ -761,6 +769,14 @@ func (t SubscriptionType) String() string {
 
 func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSubscriptionValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSubscriptionValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1690,6 +1706,14 @@ func (t PlanType) String() string {
 func (t PlanType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPlanValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPlanValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	commitmentIntervalAttribute, ok := attributes["commitment_interval"]
@@ -2142,6 +2166,14 @@ func (t CommitmentIntervalType) String() string {
 func (t CommitmentIntervalType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCommitmentIntervalValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCommitmentIntervalValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	endTimeAttribute, ok := attributes["end_time"]
@@ -2521,6 +2553,14 @@ func (t RenewalSettingsType) String() string {
 func (t RenewalSettingsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewRenewalSettingsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRenewalSettingsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	renewalTypeAttribute, ok := attributes["renewal_type"]
@@ -2844,6 +2884,14 @@ func (t SeatsType) String() string {
 
 func (t SeatsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSeatsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSeatsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_budget/budget_resource_gen.go
+++ b/internal/provider/resource_budget/budget_resource_gen.go
@@ -417,6 +417,14 @@ func (t AlertsType) String() string {
 func (t AlertsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAlertsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAlertsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	forecastedDateAttribute, ok := attributes["forecasted_date"]
@@ -851,6 +859,14 @@ func (t CollaboratorsType) String() string {
 func (t CollaboratorsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCollaboratorsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCollaboratorsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	emailAttribute, ok := attributes["email"]
@@ -1229,6 +1245,14 @@ func (t RecipientsSlackChannelsType) String() string {
 
 func (t RecipientsSlackChannelsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewRecipientsSlackChannelsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRecipientsSlackChannelsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -1828,6 +1852,14 @@ func (t ScopesType) String() string {
 
 func (t ScopesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewScopesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewScopesValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_cloudconnect_aws_account/cloudconnect_aws_account_resource_gen.go
+++ b/internal/provider/resource_cloudconnect_aws_account/cloudconnect_aws_account_resource_gen.go
@@ -114,6 +114,14 @@ func (t SupportedFeaturesType) String() string {
 func (t SupportedFeaturesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewSupportedFeaturesValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSupportedFeaturesValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	hasRequiredPermissionsAttribute, ok := attributes["has_required_permissions"]

--- a/internal/provider/resource_custom_theme/custom_theme_resource_gen.go
+++ b/internal/provider/resource_custom_theme/custom_theme_resource_gen.go
@@ -119,6 +119,14 @@ func (t ColorsType) String() string {
 func (t ColorsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewColorsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewColorsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	darkAttribute, ok := attributes["dark"]

--- a/internal/provider/resource_insight/insight_resource_gen.go
+++ b/internal/provider/resource_insight/insight_resource_gen.go
@@ -271,6 +271,14 @@ func (t DismissalDetailsType) String() string {
 func (t DismissalDetailsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDismissalDetailsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDismissalDetailsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	commentAttribute, ok := attributes["comment"]
@@ -650,6 +658,14 @@ func (t LastStatusChangeType) String() string {
 func (t LastStatusChangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewLastStatusChangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLastStatusChangeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	lastChangedAtAttribute, ok := attributes["last_changed_at"]
@@ -1028,6 +1044,14 @@ func (t SummaryType) String() string {
 
 func (t SummaryType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSummaryValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSummaryValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_insight_resource_results/insight_resource_results_resource_gen.go
+++ b/internal/provider/resource_insight_resource_results/insight_resource_results_resource_gen.go
@@ -285,6 +285,14 @@ func (t ResourceResultsType) String() string {
 func (t ResourceResultsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewResourceResultsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewResourceResultsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	accountAttribute, ok := attributes["account"]
@@ -1305,6 +1313,14 @@ func (t EnhancementType) String() string {
 func (t EnhancementType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewEnhancementValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewEnhancementValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	lastUpdatedAtAttribute, ok := attributes["last_updated_at"]
@@ -1845,6 +1861,14 @@ func (t PriorityType) String() string {
 func (t PriorityType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPriorityValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPriorityValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	priorityScoreAttribute, ok := attributes["priority_score"]
@@ -2223,6 +2247,14 @@ func (t ResultType) String() string {
 
 func (t ResultType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewResultValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewResultValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_label_assignments/label_assignments_resource_gen.go
+++ b/internal/provider/resource_label_assignments/label_assignments_resource_gen.go
@@ -156,6 +156,14 @@ func (t AddType) String() string {
 func (t AddType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAddValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAddValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	objectIdAttribute, ok := attributes["object_id"]
@@ -535,6 +543,14 @@ func (t AssignmentsType) String() string {
 func (t AssignmentsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAssignmentsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAssignmentsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	objectIdAttribute, ok := attributes["object_id"]
@@ -913,6 +929,14 @@ func (t RemoveType) String() string {
 
 func (t RemoveType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewRemoveValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRemoveValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -1039,6 +1039,14 @@ func (t ConfigType) String() string {
 func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewConfigValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewConfigValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	advancedAnalysisAttribute, ok := attributes["advanced_analysis"]
@@ -2704,6 +2712,14 @@ func (t AdvancedAnalysisType) String() string {
 func (t AdvancedAnalysisType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewAdvancedAnalysisValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAdvancedAnalysisValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	forecastAttribute, ok := attributes["forecast"]
@@ -3193,6 +3209,14 @@ func (t CustomTimeRangeType) String() string {
 func (t CustomTimeRangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewCustomTimeRangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCustomTimeRangeValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	fromAttribute, ok := attributes["from"]
@@ -3572,6 +3596,14 @@ func (t DimensionsType) String() string {
 func (t DimensionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewDimensionsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDimensionsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]
@@ -3950,6 +3982,14 @@ func (t DisplaySettingsType) String() string {
 
 func (t DisplaySettingsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewDisplaySettingsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewDisplaySettingsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -4494,6 +4534,14 @@ func (t FiltersType) String() string {
 
 func (t FiltersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewFiltersValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewFiltersValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -5181,6 +5229,14 @@ func (t GroupType) String() string {
 func (t GroupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewGroupValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewGroupValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]
@@ -5632,6 +5688,14 @@ func (t LimitType) String() string {
 
 func (t LimitType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewLimitValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewLimitValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -6085,6 +6149,14 @@ func (t MetricType) String() string {
 func (t MetricType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewMetricValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	typeAttribute, ok := attributes["type"]
@@ -6463,6 +6535,14 @@ func (t MetricFilterType) String() string {
 
 func (t MetricFilterType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewMetricFilterValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricFilterValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -6948,6 +7028,14 @@ func (t MetricsType) String() string {
 func (t MetricsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewMetricsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewMetricsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	typeAttribute, ok := attributes["type"]
@@ -7326,6 +7414,14 @@ func (t SecondaryTimeRangeType) String() string {
 
 func (t SecondaryTimeRangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSecondaryTimeRangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSecondaryTimeRangeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -7833,6 +7929,14 @@ func (t SplitsType) String() string {
 
 func (t SplitsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewSplitsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewSplitsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -8463,6 +8567,14 @@ func (t OriginType) String() string {
 func (t OriginType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewOriginValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewOriginValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	idAttribute, ok := attributes["id"]
@@ -8841,6 +8953,14 @@ func (t TargetsType) String() string {
 
 func (t TargetsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTargetsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTargetsValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 
@@ -9275,6 +9395,14 @@ func (t TimeRangeType) String() string {
 
 func (t TimeRangeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewTimeRangeValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewTimeRangeValueUnknown(), diags
+	}
 
 	attributes := in.Attributes()
 

--- a/internal/provider/resource_sharing/sharing_resource_gen.go
+++ b/internal/provider/resource_sharing/sharing_resource_gen.go
@@ -150,6 +150,14 @@ func (t PermissionsType) String() string {
 func (t PermissionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewPermissionsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewPermissionsValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	roleAttribute, ok := attributes["role"]

--- a/internal/provider/resource_user/user_resource_gen.go
+++ b/internal/provider/resource_user/user_resource_gen.go
@@ -191,6 +191,14 @@ func (t UserType) String() string {
 func (t UserType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	if in.IsNull() {
+		return NewUserValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewUserValueUnknown(), diags
+	}
+
 	attributes := in.Attributes()
 
 	displayNameAttribute, ok := attributes["display_name"]


### PR DESCRIPTION
## Summary

- Bumps `terraform-plugin-codegen-framework` to [`d4f68d4`](https://github.com/doitintl/terraform-plugin-codegen-framework/commit/d4f68d4) (doitintl/terraform-plugin-codegen-framework#13)
- Regenerates all `_gen.go` files — every `ValueFromObject` method for nested object types now has null/unknown guards
- No hand-written provider code changes; this is purely generated output

## Context

The `ValueFromObject` template was the only `ValueFrom*` method missing null/unknown guards. When invoked on a null or unknown `ObjectValue` (e.g. during plan modification of a clearable nested block), it crashed with spurious "Attribute Missing" diagnostics.

This is a prerequisite for #255 (`forecast_settings`), which can now use the generated types directly instead of the 610-line `Safe*Type` wrapper workaround.

## Test plan

- [x] `go build ./...` — clean build
- [x] `go generate ./OpenAPI/2_tfplugingen-framework/...` — generates identical output
- [x] All existing acceptance tests unaffected (guards are dead code for non-clearable attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)