### PR TITLE
chore(codegen): bump codegen-framework with nested type normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
-	github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260722140535-d4f68d4735b0 // indirect
+	github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260723120000-eb6bfa74d554 // indirect
 	github.com/doitintl/terraform-plugin-codegen-openapi v0.0.0-20260605111443-a72258dfe4c6 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/fatih/color v1.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260722140535-d4f68d4735b0 h1:3CExxL3BHZVGB+ZDbuclekfyJ+eWwgjLz3kezA6Cxb8=
-github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260722140535-d4f68d4735b0/go.mod h1:IxLiAxGac8tdJjjcvD604g/FDxKyNC18DQ9KBxLh8Z4=
+github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260723120000-eb6bfa74d554 h1:XBXSaL+GjGmE/x4RsjRRfHEyJ44hCdBeQ0/Uzj3FJmk=
+github.com/doitintl/terraform-plugin-codegen-framework v0.0.0-20260723120000-eb6bfa74d554/go.mod h1:IxLiAxGac8tdJjjcvD604g/FDxKyNC18DQ9KBxLh8Z4=
 github.com/doitintl/terraform-plugin-codegen-openapi v0.0.0-20260605111443-a72258dfe4c6 h1:A196htHYMjXvDSRwbGibsygFz7HTEVKXhRcLWa7BkkY=
 github.com/doitintl/terraform-plugin-codegen-openapi v0.0.0-20260605111443-a72258dfe4c6/go.mod h1:X20JLZjGvx7MIS5S2CQ1maVFNUyPZ6/Q/tycb5QXC/0=
 github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/0PGwMEbC3d5AB7oi67+h4TsQqItC1GVYG58=

--- a/internal/provider/datasource_alert/alert_data_source_gen.go
+++ b/internal/provider/datasource_alert/alert_data_source_gen.go
@@ -322,12 +322,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	operatorAttribute, ok := attributes["operator"]

--- a/internal/provider/datasource_alerts/alerts_data_source_gen.go
+++ b/internal/provider/datasource_alerts/alerts_data_source_gen.go
@@ -302,12 +302,38 @@ func (t AlertsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	configVal, ok := configAttribute.(ConfigValue)
+	configValuable, ok := configAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`config expected to be ConfigValue, was: %T`, configAttribute))
+			fmt.Sprintf(`config expected to be basetypes.ObjectValuable, was: %T`, configAttribute))
+
+		return nil, diags
+	}
+
+	configObjVal, configObjValDiags := configValuable.ToObjectValue(ctx)
+	diags.Append(configObjValDiags...)
+
+	configTypable, ok := t.AttrTypes["config"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`config expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["config"]))
+
+		return nil, diags
+	}
+
+	configConverted, configConvertedDiags := configTypable.ValueFromObject(ctx, configObjVal)
+	diags.Append(configConvertedDiags...)
+
+	configVal, ok := configConverted.(ConfigValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`config expected to be ConfigValue, was: %T`, configConverted))
 	}
 
 	createTimeAttribute, ok := attributes["create_time"]
@@ -1164,12 +1190,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	operatorAttribute, ok := attributes["operator"]

--- a/internal/provider/datasource_asset/asset_data_source_gen.go
+++ b/internal/provider/datasource_asset/asset_data_source_gen.go
@@ -328,12 +328,38 @@ func (t PropertiesType) ValueFromObject(ctx context.Context, in basetypes.Object
 		return nil, diags
 	}
 
-	subscriptionVal, ok := subscriptionAttribute.(SubscriptionValue)
+	subscriptionValuable, ok := subscriptionAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`subscription expected to be SubscriptionValue, was: %T`, subscriptionAttribute))
+			fmt.Sprintf(`subscription expected to be basetypes.ObjectValuable, was: %T`, subscriptionAttribute))
+
+		return nil, diags
+	}
+
+	subscriptionObjVal, subscriptionObjValDiags := subscriptionValuable.ToObjectValue(ctx)
+	diags.Append(subscriptionObjValDiags...)
+
+	subscriptionTypable, ok := t.AttrTypes["subscription"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`subscription expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["subscription"]))
+
+		return nil, diags
+	}
+
+	subscriptionConverted, subscriptionConvertedDiags := subscriptionTypable.ValueFromObject(ctx, subscriptionObjVal)
+	diags.Append(subscriptionConvertedDiags...)
+
+	subscriptionVal, ok := subscriptionConverted.(SubscriptionValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`subscription expected to be SubscriptionValue, was: %T`, subscriptionConverted))
 	}
 
 	if diags.HasError() {
@@ -843,12 +869,38 @@ func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	planVal, ok := planAttribute.(PlanValue)
+	planValuable, ok := planAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`plan expected to be PlanValue, was: %T`, planAttribute))
+			fmt.Sprintf(`plan expected to be basetypes.ObjectValuable, was: %T`, planAttribute))
+
+		return nil, diags
+	}
+
+	planObjVal, planObjValDiags := planValuable.ToObjectValue(ctx)
+	diags.Append(planObjValDiags...)
+
+	planTypable, ok := t.AttrTypes["plan"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`plan expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["plan"]))
+
+		return nil, diags
+	}
+
+	planConverted, planConvertedDiags := planTypable.ValueFromObject(ctx, planObjVal)
+	diags.Append(planConvertedDiags...)
+
+	planVal, ok := planConverted.(PlanValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`plan expected to be PlanValue, was: %T`, planConverted))
 	}
 
 	purchaseOrderIdAttribute, ok := attributes["purchase_order_id"]
@@ -879,12 +931,38 @@ func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	renewalSettingsVal, ok := renewalSettingsAttribute.(RenewalSettingsValue)
+	renewalSettingsValuable, ok := renewalSettingsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`renewal_settings expected to be RenewalSettingsValue, was: %T`, renewalSettingsAttribute))
+			fmt.Sprintf(`renewal_settings expected to be basetypes.ObjectValuable, was: %T`, renewalSettingsAttribute))
+
+		return nil, diags
+	}
+
+	renewalSettingsObjVal, renewalSettingsObjValDiags := renewalSettingsValuable.ToObjectValue(ctx)
+	diags.Append(renewalSettingsObjValDiags...)
+
+	renewalSettingsTypable, ok := t.AttrTypes["renewal_settings"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`renewal_settings expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["renewal_settings"]))
+
+		return nil, diags
+	}
+
+	renewalSettingsConverted, renewalSettingsConvertedDiags := renewalSettingsTypable.ValueFromObject(ctx, renewalSettingsObjVal)
+	diags.Append(renewalSettingsConvertedDiags...)
+
+	renewalSettingsVal, ok := renewalSettingsConverted.(RenewalSettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`renewal_settings expected to be RenewalSettingsValue, was: %T`, renewalSettingsConverted))
 	}
 
 	resourceUiurlAttribute, ok := attributes["resource_uiurl"]
@@ -915,12 +993,38 @@ func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	seatsVal, ok := seatsAttribute.(SeatsValue)
+	seatsValuable, ok := seatsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`seats expected to be SeatsValue, was: %T`, seatsAttribute))
+			fmt.Sprintf(`seats expected to be basetypes.ObjectValuable, was: %T`, seatsAttribute))
+
+		return nil, diags
+	}
+
+	seatsObjVal, seatsObjValDiags := seatsValuable.ToObjectValue(ctx)
+	diags.Append(seatsObjValDiags...)
+
+	seatsTypable, ok := t.AttrTypes["seats"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`seats expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["seats"]))
+
+		return nil, diags
+	}
+
+	seatsConverted, seatsConvertedDiags := seatsTypable.ValueFromObject(ctx, seatsObjVal)
+	diags.Append(seatsConvertedDiags...)
+
+	seatsVal, ok := seatsConverted.(SeatsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`seats expected to be SeatsValue, was: %T`, seatsConverted))
 	}
 
 	skuIdAttribute, ok := attributes["sku_id"]
@@ -1725,12 +1829,38 @@ func (t PlanType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	commitmentIntervalVal, ok := commitmentIntervalAttribute.(CommitmentIntervalValue)
+	commitmentIntervalValuable, ok := commitmentIntervalAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`commitment_interval expected to be CommitmentIntervalValue, was: %T`, commitmentIntervalAttribute))
+			fmt.Sprintf(`commitment_interval expected to be basetypes.ObjectValuable, was: %T`, commitmentIntervalAttribute))
+
+		return nil, diags
+	}
+
+	commitmentIntervalObjVal, commitmentIntervalObjValDiags := commitmentIntervalValuable.ToObjectValue(ctx)
+	diags.Append(commitmentIntervalObjValDiags...)
+
+	commitmentIntervalTypable, ok := t.AttrTypes["commitment_interval"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`commitment_interval expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["commitment_interval"]))
+
+		return nil, diags
+	}
+
+	commitmentIntervalConverted, commitmentIntervalConvertedDiags := commitmentIntervalTypable.ValueFromObject(ctx, commitmentIntervalObjVal)
+	diags.Append(commitmentIntervalConvertedDiags...)
+
+	commitmentIntervalVal, ok := commitmentIntervalConverted.(CommitmentIntervalValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`commitment_interval expected to be CommitmentIntervalValue, was: %T`, commitmentIntervalConverted))
 	}
 
 	isCommitmentPlanAttribute, ok := attributes["is_commitment_plan"]

--- a/internal/provider/datasource_cloud_diagrams_export/cloud_diagrams_export_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_export/cloud_diagrams_export_data_source_gen.go
@@ -5452,12 +5452,38 @@ func (t LinksType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue
 		return nil, diags
 	}
 
-	destinationVal, ok := destinationAttribute.(DestinationValue)
+	destinationValuable, ok := destinationAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`destination expected to be DestinationValue, was: %T`, destinationAttribute))
+			fmt.Sprintf(`destination expected to be basetypes.ObjectValuable, was: %T`, destinationAttribute))
+
+		return nil, diags
+	}
+
+	destinationObjVal, destinationObjValDiags := destinationValuable.ToObjectValue(ctx)
+	diags.Append(destinationObjValDiags...)
+
+	destinationTypable, ok := t.AttrTypes["destination"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["destination"]))
+
+		return nil, diags
+	}
+
+	destinationConverted, destinationConvertedDiags := destinationTypable.ValueFromObject(ctx, destinationObjVal)
+	diags.Append(destinationConvertedDiags...)
+
+	destinationVal, ok := destinationConverted.(DestinationValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected to be DestinationValue, was: %T`, destinationConverted))
 	}
 
 	issuesAttribute, ok := attributes["issues"]
@@ -5506,12 +5532,38 @@ func (t LinksType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue
 		return nil, diags
 	}
 
-	originVal, ok := originAttribute.(OriginValue)
+	originValuable, ok := originAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originAttribute))
+			fmt.Sprintf(`origin expected to be basetypes.ObjectValuable, was: %T`, originAttribute))
+
+		return nil, diags
+	}
+
+	originObjVal, originObjValDiags := originValuable.ToObjectValue(ctx)
+	diags.Append(originObjValDiags...)
+
+	originTypable, ok := t.AttrTypes["origin"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["origin"]))
+
+		return nil, diags
+	}
+
+	originConverted, originConvertedDiags := originTypable.ValueFromObject(ctx, originObjVal)
+	diags.Append(originConvertedDiags...)
+
+	originVal, ok := originConverted.(OriginValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originConverted))
 	}
 
 	ownerSsIdAttribute, ok := attributes["owner_ss_id"]
@@ -8078,12 +8130,38 @@ func (t NodesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue
 		return nil, diags
 	}
 
-	infraNodeVal, ok := infraNodeAttribute.(InfraNodeValue)
+	infraNodeValuable, ok := infraNodeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`infra_node expected to be InfraNodeValue, was: %T`, infraNodeAttribute))
+			fmt.Sprintf(`infra_node expected to be basetypes.ObjectValuable, was: %T`, infraNodeAttribute))
+
+		return nil, diags
+	}
+
+	infraNodeObjVal, infraNodeObjValDiags := infraNodeValuable.ToObjectValue(ctx)
+	diags.Append(infraNodeObjValDiags...)
+
+	infraNodeTypable, ok := t.AttrTypes["infra_node"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`infra_node expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["infra_node"]))
+
+		return nil, diags
+	}
+
+	infraNodeConverted, infraNodeConvertedDiags := infraNodeTypable.ValueFromObject(ctx, infraNodeObjVal)
+	diags.Append(infraNodeConvertedDiags...)
+
+	infraNodeVal, ok := infraNodeConverted.(InfraNodeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`infra_node expected to be InfraNodeValue, was: %T`, infraNodeConverted))
 	}
 
 	instanceCountAttribute, ok := attributes["instance_count"]

--- a/internal/provider/datasource_cloud_diagrams_schemes/cloud_diagrams_schemes_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_schemes/cloud_diagrams_schemes_data_source_gen.go
@@ -2388,12 +2388,38 @@ func (t StatussheetType) ValueFromObject(ctx context.Context, in basetypes.Objec
 		return nil, diags
 	}
 
-	statussheetVal, ok := statussheetAttribute.(StatussheetStatussheetValue)
+	statussheetValuable, ok := statussheetAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`statussheet expected to be StatussheetStatussheetValue, was: %T`, statussheetAttribute))
+			fmt.Sprintf(`statussheet expected to be basetypes.ObjectValuable, was: %T`, statussheetAttribute))
+
+		return nil, diags
+	}
+
+	statussheetObjVal, statussheetObjValDiags := statussheetValuable.ToObjectValue(ctx)
+	diags.Append(statussheetObjValDiags...)
+
+	statussheetTypable, ok := t.AttrTypes["statussheet"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`statussheet expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["statussheet"]))
+
+		return nil, diags
+	}
+
+	statussheetConverted, statussheetConvertedDiags := statussheetTypable.ValueFromObject(ctx, statussheetObjVal)
+	diags.Append(statussheetConvertedDiags...)
+
+	statussheetVal, ok := statussheetConverted.(StatussheetStatussheetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`statussheet expected to be StatussheetStatussheetValue, was: %T`, statussheetConverted))
 	}
 
 	if diags.HasError() {
@@ -7671,12 +7697,38 @@ func (t LinkType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	destinationVal, ok := destinationAttribute.(DestinationValue)
+	destinationValuable, ok := destinationAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`destination expected to be DestinationValue, was: %T`, destinationAttribute))
+			fmt.Sprintf(`destination expected to be basetypes.ObjectValuable, was: %T`, destinationAttribute))
+
+		return nil, diags
+	}
+
+	destinationObjVal, destinationObjValDiags := destinationValuable.ToObjectValue(ctx)
+	diags.Append(destinationObjValDiags...)
+
+	destinationTypable, ok := t.AttrTypes["destination"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["destination"]))
+
+		return nil, diags
+	}
+
+	destinationConverted, destinationConvertedDiags := destinationTypable.ValueFromObject(ctx, destinationObjVal)
+	diags.Append(destinationConvertedDiags...)
+
+	destinationVal, ok := destinationConverted.(DestinationValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected to be DestinationValue, was: %T`, destinationConverted))
 	}
 
 	issuesAttribute, ok := attributes["issues"]
@@ -7725,12 +7777,38 @@ func (t LinkType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	originVal, ok := originAttribute.(OriginValue)
+	originValuable, ok := originAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originAttribute))
+			fmt.Sprintf(`origin expected to be basetypes.ObjectValuable, was: %T`, originAttribute))
+
+		return nil, diags
+	}
+
+	originObjVal, originObjValDiags := originValuable.ToObjectValue(ctx)
+	diags.Append(originObjValDiags...)
+
+	originTypable, ok := t.AttrTypes["origin"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["origin"]))
+
+		return nil, diags
+	}
+
+	originConverted, originConvertedDiags := originTypable.ValueFromObject(ctx, originObjVal)
+	diags.Append(originConvertedDiags...)
+
+	originVal, ok := originConverted.(OriginValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originConverted))
 	}
 
 	ownerSsIdAttribute, ok := attributes["owner_ss_id"]
@@ -9771,12 +9849,38 @@ func (t NodeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	infraNodeVal, ok := infraNodeAttribute.(InfraNodeValue)
+	infraNodeValuable, ok := infraNodeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`infra_node expected to be InfraNodeValue, was: %T`, infraNodeAttribute))
+			fmt.Sprintf(`infra_node expected to be basetypes.ObjectValuable, was: %T`, infraNodeAttribute))
+
+		return nil, diags
+	}
+
+	infraNodeObjVal, infraNodeObjValDiags := infraNodeValuable.ToObjectValue(ctx)
+	diags.Append(infraNodeObjValDiags...)
+
+	infraNodeTypable, ok := t.AttrTypes["infra_node"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`infra_node expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["infra_node"]))
+
+		return nil, diags
+	}
+
+	infraNodeConverted, infraNodeConvertedDiags := infraNodeTypable.ValueFromObject(ctx, infraNodeObjVal)
+	diags.Append(infraNodeConvertedDiags...)
+
+	infraNodeVal, ok := infraNodeConverted.(InfraNodeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`infra_node expected to be InfraNodeValue, was: %T`, infraNodeConverted))
 	}
 
 	instanceCountAttribute, ok := attributes["instance_count"]
@@ -11780,12 +11884,38 @@ func (t StatussheetStatussheetType) ValueFromObject(ctx context.Context, in base
 		return nil, diags
 	}
 
-	importVal, ok := importAttribute.(ImportValue)
+	importValuable, ok := importAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`import expected to be ImportValue, was: %T`, importAttribute))
+			fmt.Sprintf(`import expected to be basetypes.ObjectValuable, was: %T`, importAttribute))
+
+		return nil, diags
+	}
+
+	importObjVal, importObjValDiags := importValuable.ToObjectValue(ctx)
+	diags.Append(importObjValDiags...)
+
+	importTypable, ok := t.AttrTypes["import"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`import expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["import"]))
+
+		return nil, diags
+	}
+
+	importConverted, importConvertedDiags := importTypable.ValueFromObject(ctx, importObjVal)
+	diags.Append(importConvertedDiags...)
+
+	importVal, ok := importConverted.(ImportValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`import expected to be ImportValue, was: %T`, importConverted))
 	}
 
 	linksVersionAttribute, ok := attributes["links_version"]

--- a/internal/provider/datasource_cloud_diagrams_search/cloud_diagrams_search_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_search/cloud_diagrams_search_data_source_gen.go
@@ -415,12 +415,38 @@ func (t ComponentType) ValueFromObject(ctx context.Context, in basetypes.ObjectV
 		return nil, diags
 	}
 
-	propsVal, ok := propsAttribute.(PropsValue)
+	propsValuable, ok := propsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`props expected to be PropsValue, was: %T`, propsAttribute))
+			fmt.Sprintf(`props expected to be basetypes.ObjectValuable, was: %T`, propsAttribute))
+
+		return nil, diags
+	}
+
+	propsObjVal, propsObjValDiags := propsValuable.ToObjectValue(ctx)
+	diags.Append(propsObjValDiags...)
+
+	propsTypable, ok := t.AttrTypes["props"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`props expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["props"]))
+
+		return nil, diags
+	}
+
+	propsConverted, propsConvertedDiags := propsTypable.ValueFromObject(ctx, propsObjVal)
+	diags.Append(propsConvertedDiags...)
+
+	propsVal, ok := propsConverted.(PropsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`props expected to be PropsValue, was: %T`, propsConverted))
 	}
 
 	schemeIdAttribute, ok := attributes["scheme_id"]
@@ -1647,12 +1673,38 @@ func (t PropType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	propsVal, ok := propsAttribute.(PropsValue)
+	propsValuable, ok := propsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`props expected to be PropsValue, was: %T`, propsAttribute))
+			fmt.Sprintf(`props expected to be basetypes.ObjectValuable, was: %T`, propsAttribute))
+
+		return nil, diags
+	}
+
+	propsObjVal, propsObjValDiags := propsValuable.ToObjectValue(ctx)
+	diags.Append(propsObjValDiags...)
+
+	propsTypable, ok := t.AttrTypes["props"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`props expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["props"]))
+
+		return nil, diags
+	}
+
+	propsConverted, propsConvertedDiags := propsTypable.ValueFromObject(ctx, propsObjVal)
+	diags.Append(propsConvertedDiags...)
+
+	propsVal, ok := propsConverted.(PropsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`props expected to be PropsValue, was: %T`, propsConverted))
 	}
 
 	schemeIdAttribute, ok := attributes["scheme_id"]

--- a/internal/provider/datasource_cloud_diagrams_stats/cloud_diagrams_stats_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_stats/cloud_diagrams_stats_data_source_gen.go
@@ -291,12 +291,38 @@ func (t CloudDiagramsStatsType) ValueFromObject(ctx context.Context, in basetype
 		return nil, diags
 	}
 
-	importVal, ok := importAttribute.(ImportValue)
+	importValuable, ok := importAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`import expected to be ImportValue, was: %T`, importAttribute))
+			fmt.Sprintf(`import expected to be basetypes.ObjectValuable, was: %T`, importAttribute))
+
+		return nil, diags
+	}
+
+	importObjVal, importObjValDiags := importValuable.ToObjectValue(ctx)
+	diags.Append(importObjValDiags...)
+
+	importTypable, ok := t.AttrTypes["import"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`import expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["import"]))
+
+		return nil, diags
+	}
+
+	importConverted, importConvertedDiags := importTypable.ValueFromObject(ctx, importObjVal)
+	diags.Append(importConvertedDiags...)
+
+	importVal, ok := importConverted.(ImportValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`import expected to be ImportValue, was: %T`, importConverted))
 	}
 
 	nameAttribute, ok := attributes["name"]

--- a/internal/provider/datasource_cloud_diagrams_statussheet/cloud_diagrams_statussheet_data_source_gen.go
+++ b/internal/provider/datasource_cloud_diagrams_statussheet/cloud_diagrams_statussheet_data_source_gen.go
@@ -5418,12 +5418,38 @@ func (t LinkType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	destinationVal, ok := destinationAttribute.(DestinationValue)
+	destinationValuable, ok := destinationAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`destination expected to be DestinationValue, was: %T`, destinationAttribute))
+			fmt.Sprintf(`destination expected to be basetypes.ObjectValuable, was: %T`, destinationAttribute))
+
+		return nil, diags
+	}
+
+	destinationObjVal, destinationObjValDiags := destinationValuable.ToObjectValue(ctx)
+	diags.Append(destinationObjValDiags...)
+
+	destinationTypable, ok := t.AttrTypes["destination"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["destination"]))
+
+		return nil, diags
+	}
+
+	destinationConverted, destinationConvertedDiags := destinationTypable.ValueFromObject(ctx, destinationObjVal)
+	diags.Append(destinationConvertedDiags...)
+
+	destinationVal, ok := destinationConverted.(DestinationValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected to be DestinationValue, was: %T`, destinationConverted))
 	}
 
 	issuesAttribute, ok := attributes["issues"]
@@ -5472,12 +5498,38 @@ func (t LinkType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	originVal, ok := originAttribute.(OriginValue)
+	originValuable, ok := originAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originAttribute))
+			fmt.Sprintf(`origin expected to be basetypes.ObjectValuable, was: %T`, originAttribute))
+
+		return nil, diags
+	}
+
+	originObjVal, originObjValDiags := originValuable.ToObjectValue(ctx)
+	diags.Append(originObjValDiags...)
+
+	originTypable, ok := t.AttrTypes["origin"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["origin"]))
+
+		return nil, diags
+	}
+
+	originConverted, originConvertedDiags := originTypable.ValueFromObject(ctx, originObjVal)
+	diags.Append(originConvertedDiags...)
+
+	originVal, ok := originConverted.(OriginValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originConverted))
 	}
 
 	ownerSsIdAttribute, ok := attributes["owner_ss_id"]
@@ -7518,12 +7570,38 @@ func (t NodeType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	infraNodeVal, ok := infraNodeAttribute.(InfraNodeValue)
+	infraNodeValuable, ok := infraNodeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`infra_node expected to be InfraNodeValue, was: %T`, infraNodeAttribute))
+			fmt.Sprintf(`infra_node expected to be basetypes.ObjectValuable, was: %T`, infraNodeAttribute))
+
+		return nil, diags
+	}
+
+	infraNodeObjVal, infraNodeObjValDiags := infraNodeValuable.ToObjectValue(ctx)
+	diags.Append(infraNodeObjValDiags...)
+
+	infraNodeTypable, ok := t.AttrTypes["infra_node"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`infra_node expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["infra_node"]))
+
+		return nil, diags
+	}
+
+	infraNodeConverted, infraNodeConvertedDiags := infraNodeTypable.ValueFromObject(ctx, infraNodeObjVal)
+	diags.Append(infraNodeConvertedDiags...)
+
+	infraNodeVal, ok := infraNodeConverted.(InfraNodeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`infra_node expected to be InfraNodeValue, was: %T`, infraNodeConverted))
 	}
 
 	instanceCountAttribute, ok := attributes["instance_count"]

--- a/internal/provider/datasource_custom_themes/custom_themes_data_source_gen.go
+++ b/internal/provider/datasource_custom_themes/custom_themes_data_source_gen.go
@@ -136,12 +136,38 @@ func (t ThemesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	colorsVal, ok := colorsAttribute.(ColorsValue)
+	colorsValuable, ok := colorsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`colors expected to be ColorsValue, was: %T`, colorsAttribute))
+			fmt.Sprintf(`colors expected to be basetypes.ObjectValuable, was: %T`, colorsAttribute))
+
+		return nil, diags
+	}
+
+	colorsObjVal, colorsObjValDiags := colorsValuable.ToObjectValue(ctx)
+	diags.Append(colorsObjValDiags...)
+
+	colorsTypable, ok := t.AttrTypes["colors"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`colors expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["colors"]))
+
+		return nil, diags
+	}
+
+	colorsConverted, colorsConvertedDiags := colorsTypable.ValueFromObject(ctx, colorsObjVal)
+	diags.Append(colorsConvertedDiags...)
+
+	colorsVal, ok := colorsConverted.(ColorsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`colors expected to be ColorsValue, was: %T`, colorsConverted))
 	}
 
 	createTimeAttribute, ok := attributes["create_time"]

--- a/internal/provider/datasource_insight_resource_results/insight_resource_results_data_source_gen.go
+++ b/internal/provider/datasource_insight_resource_results/insight_resource_results_data_source_gen.go
@@ -313,12 +313,38 @@ func (t ResourceResultsType) ValueFromObject(ctx context.Context, in basetypes.O
 		return nil, diags
 	}
 
-	enhancementVal, ok := enhancementAttribute.(EnhancementValue)
+	enhancementValuable, ok := enhancementAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`enhancement expected to be EnhancementValue, was: %T`, enhancementAttribute))
+			fmt.Sprintf(`enhancement expected to be basetypes.ObjectValuable, was: %T`, enhancementAttribute))
+
+		return nil, diags
+	}
+
+	enhancementObjVal, enhancementObjValDiags := enhancementValuable.ToObjectValue(ctx)
+	diags.Append(enhancementObjValDiags...)
+
+	enhancementTypable, ok := t.AttrTypes["enhancement"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`enhancement expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["enhancement"]))
+
+		return nil, diags
+	}
+
+	enhancementConverted, enhancementConvertedDiags := enhancementTypable.ValueFromObject(ctx, enhancementObjVal)
+	diags.Append(enhancementConvertedDiags...)
+
+	enhancementVal, ok := enhancementConverted.(EnhancementValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`enhancement expected to be EnhancementValue, was: %T`, enhancementConverted))
 	}
 
 	externalIdAttribute, ok := attributes["external_id"]
@@ -457,12 +483,38 @@ func (t ResourceResultsType) ValueFromObject(ctx context.Context, in basetypes.O
 		return nil, diags
 	}
 
-	resultVal, ok := resultAttribute.(ResultValue)
+	resultValuable, ok := resultAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`result expected to be ResultValue, was: %T`, resultAttribute))
+			fmt.Sprintf(`result expected to be basetypes.ObjectValuable, was: %T`, resultAttribute))
+
+		return nil, diags
+	}
+
+	resultObjVal, resultObjValDiags := resultValuable.ToObjectValue(ctx)
+	diags.Append(resultObjValDiags...)
+
+	resultTypable, ok := t.AttrTypes["result"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`result expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["result"]))
+
+		return nil, diags
+	}
+
+	resultConverted, resultConvertedDiags := resultTypable.ValueFromObject(ctx, resultObjVal)
+	diags.Append(resultConvertedDiags...)
+
+	resultVal, ok := resultConverted.(ResultValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`result expected to be ResultValue, was: %T`, resultConverted))
 	}
 
 	resultTypeAttribute, ok := attributes["result_type"]
@@ -1341,12 +1393,38 @@ func (t EnhancementType) ValueFromObject(ctx context.Context, in basetypes.Objec
 		return nil, diags
 	}
 
-	priorityVal, ok := priorityAttribute.(PriorityValue)
+	priorityValuable, ok := priorityAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`priority expected to be PriorityValue, was: %T`, priorityAttribute))
+			fmt.Sprintf(`priority expected to be basetypes.ObjectValuable, was: %T`, priorityAttribute))
+
+		return nil, diags
+	}
+
+	priorityObjVal, priorityObjValDiags := priorityValuable.ToObjectValue(ctx)
+	diags.Append(priorityObjValDiags...)
+
+	priorityTypable, ok := t.AttrTypes["priority"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`priority expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["priority"]))
+
+		return nil, diags
+	}
+
+	priorityConverted, priorityConvertedDiags := priorityTypable.ValueFromObject(ctx, priorityObjVal)
+	diags.Append(priorityConvertedDiags...)
+
+	priorityVal, ok := priorityConverted.(PriorityValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`priority expected to be PriorityValue, was: %T`, priorityConverted))
 	}
 
 	tagsAttribute, ok := attributes["tags"]

--- a/internal/provider/datasource_insights/insights_data_source_gen.go
+++ b/internal/provider/datasource_insights/insights_data_source_gen.go
@@ -815,12 +815,38 @@ func (t ResultsType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 		return nil, diags
 	}
 
-	dismissalDetailsVal, ok := dismissalDetailsAttribute.(DismissalDetailsValue)
+	dismissalDetailsValuable, ok := dismissalDetailsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`dismissal_details expected to be DismissalDetailsValue, was: %T`, dismissalDetailsAttribute))
+			fmt.Sprintf(`dismissal_details expected to be basetypes.ObjectValuable, was: %T`, dismissalDetailsAttribute))
+
+		return nil, diags
+	}
+
+	dismissalDetailsObjVal, dismissalDetailsObjValDiags := dismissalDetailsValuable.ToObjectValue(ctx)
+	diags.Append(dismissalDetailsObjValDiags...)
+
+	dismissalDetailsTypable, ok := t.AttrTypes["dismissal_details"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dismissal_details expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["dismissal_details"]))
+
+		return nil, diags
+	}
+
+	dismissalDetailsConverted, dismissalDetailsConvertedDiags := dismissalDetailsTypable.ValueFromObject(ctx, dismissalDetailsObjVal)
+	diags.Append(dismissalDetailsConvertedDiags...)
+
+	dismissalDetailsVal, ok := dismissalDetailsConverted.(DismissalDetailsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dismissal_details expected to be DismissalDetailsValue, was: %T`, dismissalDetailsConverted))
 	}
 
 	displayStatusAttribute, ok := attributes["display_status"]
@@ -887,12 +913,38 @@ func (t ResultsType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 		return nil, diags
 	}
 
-	lastStatusChangeVal, ok := lastStatusChangeAttribute.(LastStatusChangeValue)
+	lastStatusChangeValuable, ok := lastStatusChangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`last_status_change expected to be LastStatusChangeValue, was: %T`, lastStatusChangeAttribute))
+			fmt.Sprintf(`last_status_change expected to be basetypes.ObjectValuable, was: %T`, lastStatusChangeAttribute))
+
+		return nil, diags
+	}
+
+	lastStatusChangeObjVal, lastStatusChangeObjValDiags := lastStatusChangeValuable.ToObjectValue(ctx)
+	diags.Append(lastStatusChangeObjValDiags...)
+
+	lastStatusChangeTypable, ok := t.AttrTypes["last_status_change"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`last_status_change expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["last_status_change"]))
+
+		return nil, diags
+	}
+
+	lastStatusChangeConverted, lastStatusChangeConvertedDiags := lastStatusChangeTypable.ValueFromObject(ctx, lastStatusChangeObjVal)
+	diags.Append(lastStatusChangeConvertedDiags...)
+
+	lastStatusChangeVal, ok := lastStatusChangeConverted.(LastStatusChangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`last_status_change expected to be LastStatusChangeValue, was: %T`, lastStatusChangeConverted))
 	}
 
 	lastUpdatedAttribute, ok := attributes["last_updated"]
@@ -977,12 +1029,38 @@ func (t ResultsType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 		return nil, diags
 	}
 
-	summaryVal, ok := summaryAttribute.(SummaryValue)
+	summaryValuable, ok := summaryAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`summary expected to be SummaryValue, was: %T`, summaryAttribute))
+			fmt.Sprintf(`summary expected to be basetypes.ObjectValuable, was: %T`, summaryAttribute))
+
+		return nil, diags
+	}
+
+	summaryObjVal, summaryObjValDiags := summaryValuable.ToObjectValue(ctx)
+	diags.Append(summaryObjValDiags...)
+
+	summaryTypable, ok := t.AttrTypes["summary"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`summary expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["summary"]))
+
+		return nil, diags
+	}
+
+	summaryConverted, summaryConvertedDiags := summaryTypable.ValueFromObject(ctx, summaryObjVal)
+	diags.Append(summaryConvertedDiags...)
+
+	summaryVal, ok := summaryConverted.(SummaryValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`summary expected to be SummaryValue, was: %T`, summaryConverted))
 	}
 
 	tagsAttribute, ok := attributes["tags"]

--- a/internal/provider/datasource_report/report_data_source_gen.go
+++ b/internal/provider/datasource_report/report_data_source_gen.go
@@ -648,12 +648,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	advancedAnalysisVal, ok := advancedAnalysisAttribute.(AdvancedAnalysisValue)
+	advancedAnalysisValuable, ok := advancedAnalysisAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`advanced_analysis expected to be AdvancedAnalysisValue, was: %T`, advancedAnalysisAttribute))
+			fmt.Sprintf(`advanced_analysis expected to be basetypes.ObjectValuable, was: %T`, advancedAnalysisAttribute))
+
+		return nil, diags
+	}
+
+	advancedAnalysisObjVal, advancedAnalysisObjValDiags := advancedAnalysisValuable.ToObjectValue(ctx)
+	diags.Append(advancedAnalysisObjValDiags...)
+
+	advancedAnalysisTypable, ok := t.AttrTypes["advanced_analysis"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`advanced_analysis expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["advanced_analysis"]))
+
+		return nil, diags
+	}
+
+	advancedAnalysisConverted, advancedAnalysisConvertedDiags := advancedAnalysisTypable.ValueFromObject(ctx, advancedAnalysisObjVal)
+	diags.Append(advancedAnalysisConvertedDiags...)
+
+	advancedAnalysisVal, ok := advancedAnalysisConverted.(AdvancedAnalysisValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`advanced_analysis expected to be AdvancedAnalysisValue, was: %T`, advancedAnalysisConverted))
 	}
 
 	aggregationAttribute, ok := attributes["aggregation"]
@@ -702,12 +728,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	customTimeRangeVal, ok := customTimeRangeAttribute.(CustomTimeRangeValue)
+	customTimeRangeValuable, ok := customTimeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeAttribute))
+			fmt.Sprintf(`custom_time_range expected to be basetypes.ObjectValuable, was: %T`, customTimeRangeAttribute))
+
+		return nil, diags
+	}
+
+	customTimeRangeObjVal, customTimeRangeObjValDiags := customTimeRangeValuable.ToObjectValue(ctx)
+	diags.Append(customTimeRangeObjValDiags...)
+
+	customTimeRangeTypable, ok := t.AttrTypes["custom_time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["custom_time_range"]))
+
+		return nil, diags
+	}
+
+	customTimeRangeConverted, customTimeRangeConvertedDiags := customTimeRangeTypable.ValueFromObject(ctx, customTimeRangeObjVal)
+	diags.Append(customTimeRangeConvertedDiags...)
+
+	customTimeRangeVal, ok := customTimeRangeConverted.(CustomTimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeConverted))
 	}
 
 	dataSourceAttribute, ok := attributes["data_source"]
@@ -756,12 +808,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	displaySettingsVal, ok := displaySettingsAttribute.(DisplaySettingsValue)
+	displaySettingsValuable, ok := displaySettingsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsAttribute))
+			fmt.Sprintf(`display_settings expected to be basetypes.ObjectValuable, was: %T`, displaySettingsAttribute))
+
+		return nil, diags
+	}
+
+	displaySettingsObjVal, displaySettingsObjValDiags := displaySettingsValuable.ToObjectValue(ctx)
+	diags.Append(displaySettingsObjValDiags...)
+
+	displaySettingsTypable, ok := t.AttrTypes["display_settings"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["display_settings"]))
+
+		return nil, diags
+	}
+
+	displaySettingsConverted, displaySettingsConvertedDiags := displaySettingsTypable.ValueFromObject(ctx, displaySettingsObjVal)
+	diags.Append(displaySettingsConvertedDiags...)
+
+	displaySettingsVal, ok := displaySettingsConverted.(DisplaySettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsConverted))
 	}
 
 	displayValuesAttribute, ok := attributes["display_values"]
@@ -882,12 +960,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	metricFilterAttribute, ok := attributes["metric_filter"]
@@ -900,12 +1004,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	metricFilterVal, ok := metricFilterAttribute.(MetricFilterValue)
+	metricFilterValuable, ok := metricFilterAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric_filter expected to be MetricFilterValue, was: %T`, metricFilterAttribute))
+			fmt.Sprintf(`metric_filter expected to be basetypes.ObjectValuable, was: %T`, metricFilterAttribute))
+
+		return nil, diags
+	}
+
+	metricFilterObjVal, metricFilterObjValDiags := metricFilterValuable.ToObjectValue(ctx)
+	diags.Append(metricFilterObjValDiags...)
+
+	metricFilterTypable, ok := t.AttrTypes["metric_filter"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric_filter expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric_filter"]))
+
+		return nil, diags
+	}
+
+	metricFilterConverted, metricFilterConvertedDiags := metricFilterTypable.ValueFromObject(ctx, metricFilterObjVal)
+	diags.Append(metricFilterConvertedDiags...)
+
+	metricFilterVal, ok := metricFilterConverted.(MetricFilterValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric_filter expected to be MetricFilterValue, was: %T`, metricFilterConverted))
 	}
 
 	metricsAttribute, ok := attributes["metrics"]
@@ -936,12 +1066,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	secondaryTimeRangeVal, ok := secondaryTimeRangeAttribute.(SecondaryTimeRangeValue)
+	secondaryTimeRangeValuable, ok := secondaryTimeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`secondary_time_range expected to be SecondaryTimeRangeValue, was: %T`, secondaryTimeRangeAttribute))
+			fmt.Sprintf(`secondary_time_range expected to be basetypes.ObjectValuable, was: %T`, secondaryTimeRangeAttribute))
+
+		return nil, diags
+	}
+
+	secondaryTimeRangeObjVal, secondaryTimeRangeObjValDiags := secondaryTimeRangeValuable.ToObjectValue(ctx)
+	diags.Append(secondaryTimeRangeObjValDiags...)
+
+	secondaryTimeRangeTypable, ok := t.AttrTypes["secondary_time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`secondary_time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["secondary_time_range"]))
+
+		return nil, diags
+	}
+
+	secondaryTimeRangeConverted, secondaryTimeRangeConvertedDiags := secondaryTimeRangeTypable.ValueFromObject(ctx, secondaryTimeRangeObjVal)
+	diags.Append(secondaryTimeRangeConvertedDiags...)
+
+	secondaryTimeRangeVal, ok := secondaryTimeRangeConverted.(SecondaryTimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`secondary_time_range expected to be SecondaryTimeRangeValue, was: %T`, secondaryTimeRangeConverted))
 	}
 
 	sortDimensionsAttribute, ok := attributes["sort_dimensions"]
@@ -1026,12 +1182,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	timeRangeVal, ok := timeRangeAttribute.(TimeRangeValue)
+	timeRangeValuable, ok := timeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`time_range expected to be TimeRangeValue, was: %T`, timeRangeAttribute))
+			fmt.Sprintf(`time_range expected to be basetypes.ObjectValuable, was: %T`, timeRangeAttribute))
+
+		return nil, diags
+	}
+
+	timeRangeObjVal, timeRangeObjValDiags := timeRangeValuable.ToObjectValue(ctx)
+	diags.Append(timeRangeObjValDiags...)
+
+	timeRangeTypable, ok := t.AttrTypes["time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["time_range"]))
+
+		return nil, diags
+	}
+
+	timeRangeConverted, timeRangeConvertedDiags := timeRangeTypable.ValueFromObject(ctx, timeRangeObjVal)
+	diags.Append(timeRangeConvertedDiags...)
+
+	timeRangeVal, ok := timeRangeConverted.(TimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`time_range expected to be TimeRangeValue, was: %T`, timeRangeConverted))
 	}
 
 	if diags.HasError() {
@@ -4856,12 +5038,38 @@ func (t GroupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue
 		return nil, diags
 	}
 
-	limitVal, ok := limitAttribute.(LimitValue)
+	limitValuable, ok := limitAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`limit expected to be LimitValue, was: %T`, limitAttribute))
+			fmt.Sprintf(`limit expected to be basetypes.ObjectValuable, was: %T`, limitAttribute))
+
+		return nil, diags
+	}
+
+	limitObjVal, limitObjValDiags := limitValuable.ToObjectValue(ctx)
+	diags.Append(limitObjValDiags...)
+
+	limitTypable, ok := t.AttrTypes["limit"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`limit expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["limit"]))
+
+		return nil, diags
+	}
+
+	limitConverted, limitConvertedDiags := limitTypable.ValueFromObject(ctx, limitObjVal)
+	diags.Append(limitConvertedDiags...)
+
+	limitVal, ok := limitConverted.(LimitValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`limit expected to be LimitValue, was: %T`, limitConverted))
 	}
 
 	typeAttribute, ok := attributes["type"]
@@ -5298,12 +5506,38 @@ func (t LimitType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	sortAttribute, ok := attributes["sort"]
@@ -6145,12 +6379,38 @@ func (t MetricFilterType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	operatorAttribute, ok := attributes["operator"]
@@ -7042,12 +7302,38 @@ func (t SecondaryTimeRangeType) ValueFromObject(ctx context.Context, in basetype
 		return nil, diags
 	}
 
-	customTimeRangeVal, ok := customTimeRangeAttribute.(CustomTimeRangeValue)
+	customTimeRangeValuable, ok := customTimeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeAttribute))
+			fmt.Sprintf(`custom_time_range expected to be basetypes.ObjectValuable, was: %T`, customTimeRangeAttribute))
+
+		return nil, diags
+	}
+
+	customTimeRangeObjVal, customTimeRangeObjValDiags := customTimeRangeValuable.ToObjectValue(ctx)
+	diags.Append(customTimeRangeObjValDiags...)
+
+	customTimeRangeTypable, ok := t.AttrTypes["custom_time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["custom_time_range"]))
+
+		return nil, diags
+	}
+
+	customTimeRangeConverted, customTimeRangeConvertedDiags := customTimeRangeTypable.ValueFromObject(ctx, customTimeRangeObjVal)
+	diags.Append(customTimeRangeConvertedDiags...)
+
+	customTimeRangeVal, ok := customTimeRangeConverted.(CustomTimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeConverted))
 	}
 
 	includeCurrentAttribute, ok := attributes["include_current"]
@@ -7593,12 +7879,38 @@ func (t SplitsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	originVal, ok := originAttribute.(OriginValue)
+	originValuable, ok := originAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originAttribute))
+			fmt.Sprintf(`origin expected to be basetypes.ObjectValuable, was: %T`, originAttribute))
+
+		return nil, diags
+	}
+
+	originObjVal, originObjValDiags := originValuable.ToObjectValue(ctx)
+	diags.Append(originObjValDiags...)
+
+	originTypable, ok := t.AttrTypes["origin"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["origin"]))
+
+		return nil, diags
+	}
+
+	originConverted, originConvertedDiags := originTypable.ValueFromObject(ctx, originObjVal)
+	diags.Append(originConvertedDiags...)
+
+	originVal, ok := originConverted.(OriginValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originConverted))
 	}
 
 	targetsAttribute, ok := attributes["targets"]

--- a/internal/provider/resource_alert/alert_resource_gen.go
+++ b/internal/provider/resource_alert/alert_resource_gen.go
@@ -425,12 +425,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	operatorAttribute, ok := attributes["operator"]

--- a/internal/provider/resource_asset/asset_resource_gen.go
+++ b/internal/provider/resource_asset/asset_resource_gen.go
@@ -329,12 +329,38 @@ func (t PropertiesType) ValueFromObject(ctx context.Context, in basetypes.Object
 		return nil, diags
 	}
 
-	subscriptionVal, ok := subscriptionAttribute.(SubscriptionValue)
+	subscriptionValuable, ok := subscriptionAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`subscription expected to be SubscriptionValue, was: %T`, subscriptionAttribute))
+			fmt.Sprintf(`subscription expected to be basetypes.ObjectValuable, was: %T`, subscriptionAttribute))
+
+		return nil, diags
+	}
+
+	subscriptionObjVal, subscriptionObjValDiags := subscriptionValuable.ToObjectValue(ctx)
+	diags.Append(subscriptionObjValDiags...)
+
+	subscriptionTypable, ok := t.AttrTypes["subscription"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`subscription expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["subscription"]))
+
+		return nil, diags
+	}
+
+	subscriptionConverted, subscriptionConvertedDiags := subscriptionTypable.ValueFromObject(ctx, subscriptionObjVal)
+	diags.Append(subscriptionConvertedDiags...)
+
+	subscriptionVal, ok := subscriptionConverted.(SubscriptionValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`subscription expected to be SubscriptionValue, was: %T`, subscriptionConverted))
 	}
 
 	if diags.HasError() {
@@ -844,12 +870,38 @@ func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	planVal, ok := planAttribute.(PlanValue)
+	planValuable, ok := planAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`plan expected to be PlanValue, was: %T`, planAttribute))
+			fmt.Sprintf(`plan expected to be basetypes.ObjectValuable, was: %T`, planAttribute))
+
+		return nil, diags
+	}
+
+	planObjVal, planObjValDiags := planValuable.ToObjectValue(ctx)
+	diags.Append(planObjValDiags...)
+
+	planTypable, ok := t.AttrTypes["plan"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`plan expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["plan"]))
+
+		return nil, diags
+	}
+
+	planConverted, planConvertedDiags := planTypable.ValueFromObject(ctx, planObjVal)
+	diags.Append(planConvertedDiags...)
+
+	planVal, ok := planConverted.(PlanValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`plan expected to be PlanValue, was: %T`, planConverted))
 	}
 
 	purchaseOrderIdAttribute, ok := attributes["purchase_order_id"]
@@ -880,12 +932,38 @@ func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	renewalSettingsVal, ok := renewalSettingsAttribute.(RenewalSettingsValue)
+	renewalSettingsValuable, ok := renewalSettingsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`renewal_settings expected to be RenewalSettingsValue, was: %T`, renewalSettingsAttribute))
+			fmt.Sprintf(`renewal_settings expected to be basetypes.ObjectValuable, was: %T`, renewalSettingsAttribute))
+
+		return nil, diags
+	}
+
+	renewalSettingsObjVal, renewalSettingsObjValDiags := renewalSettingsValuable.ToObjectValue(ctx)
+	diags.Append(renewalSettingsObjValDiags...)
+
+	renewalSettingsTypable, ok := t.AttrTypes["renewal_settings"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`renewal_settings expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["renewal_settings"]))
+
+		return nil, diags
+	}
+
+	renewalSettingsConverted, renewalSettingsConvertedDiags := renewalSettingsTypable.ValueFromObject(ctx, renewalSettingsObjVal)
+	diags.Append(renewalSettingsConvertedDiags...)
+
+	renewalSettingsVal, ok := renewalSettingsConverted.(RenewalSettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`renewal_settings expected to be RenewalSettingsValue, was: %T`, renewalSettingsConverted))
 	}
 
 	resourceUiurlAttribute, ok := attributes["resource_uiurl"]
@@ -916,12 +994,38 @@ func (t SubscriptionType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	seatsVal, ok := seatsAttribute.(SeatsValue)
+	seatsValuable, ok := seatsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`seats expected to be SeatsValue, was: %T`, seatsAttribute))
+			fmt.Sprintf(`seats expected to be basetypes.ObjectValuable, was: %T`, seatsAttribute))
+
+		return nil, diags
+	}
+
+	seatsObjVal, seatsObjValDiags := seatsValuable.ToObjectValue(ctx)
+	diags.Append(seatsObjValDiags...)
+
+	seatsTypable, ok := t.AttrTypes["seats"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`seats expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["seats"]))
+
+		return nil, diags
+	}
+
+	seatsConverted, seatsConvertedDiags := seatsTypable.ValueFromObject(ctx, seatsObjVal)
+	diags.Append(seatsConvertedDiags...)
+
+	seatsVal, ok := seatsConverted.(SeatsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`seats expected to be SeatsValue, was: %T`, seatsConverted))
 	}
 
 	skuIdAttribute, ok := attributes["sku_id"]
@@ -1726,12 +1830,38 @@ func (t PlanType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue)
 		return nil, diags
 	}
 
-	commitmentIntervalVal, ok := commitmentIntervalAttribute.(CommitmentIntervalValue)
+	commitmentIntervalValuable, ok := commitmentIntervalAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`commitment_interval expected to be CommitmentIntervalValue, was: %T`, commitmentIntervalAttribute))
+			fmt.Sprintf(`commitment_interval expected to be basetypes.ObjectValuable, was: %T`, commitmentIntervalAttribute))
+
+		return nil, diags
+	}
+
+	commitmentIntervalObjVal, commitmentIntervalObjValDiags := commitmentIntervalValuable.ToObjectValue(ctx)
+	diags.Append(commitmentIntervalObjValDiags...)
+
+	commitmentIntervalTypable, ok := t.AttrTypes["commitment_interval"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`commitment_interval expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["commitment_interval"]))
+
+		return nil, diags
+	}
+
+	commitmentIntervalConverted, commitmentIntervalConvertedDiags := commitmentIntervalTypable.ValueFromObject(ctx, commitmentIntervalObjVal)
+	diags.Append(commitmentIntervalConvertedDiags...)
+
+	commitmentIntervalVal, ok := commitmentIntervalConverted.(CommitmentIntervalValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`commitment_interval expected to be CommitmentIntervalValue, was: %T`, commitmentIntervalConverted))
 	}
 
 	isCommitmentPlanAttribute, ok := attributes["is_commitment_plan"]

--- a/internal/provider/resource_insight_resource_results/insight_resource_results_resource_gen.go
+++ b/internal/provider/resource_insight_resource_results/insight_resource_results_resource_gen.go
@@ -341,12 +341,38 @@ func (t ResourceResultsType) ValueFromObject(ctx context.Context, in basetypes.O
 		return nil, diags
 	}
 
-	enhancementVal, ok := enhancementAttribute.(EnhancementValue)
+	enhancementValuable, ok := enhancementAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`enhancement expected to be EnhancementValue, was: %T`, enhancementAttribute))
+			fmt.Sprintf(`enhancement expected to be basetypes.ObjectValuable, was: %T`, enhancementAttribute))
+
+		return nil, diags
+	}
+
+	enhancementObjVal, enhancementObjValDiags := enhancementValuable.ToObjectValue(ctx)
+	diags.Append(enhancementObjValDiags...)
+
+	enhancementTypable, ok := t.AttrTypes["enhancement"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`enhancement expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["enhancement"]))
+
+		return nil, diags
+	}
+
+	enhancementConverted, enhancementConvertedDiags := enhancementTypable.ValueFromObject(ctx, enhancementObjVal)
+	diags.Append(enhancementConvertedDiags...)
+
+	enhancementVal, ok := enhancementConverted.(EnhancementValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`enhancement expected to be EnhancementValue, was: %T`, enhancementConverted))
 	}
 
 	externalIdAttribute, ok := attributes["external_id"]
@@ -485,12 +511,38 @@ func (t ResourceResultsType) ValueFromObject(ctx context.Context, in basetypes.O
 		return nil, diags
 	}
 
-	resultVal, ok := resultAttribute.(ResultValue)
+	resultValuable, ok := resultAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`result expected to be ResultValue, was: %T`, resultAttribute))
+			fmt.Sprintf(`result expected to be basetypes.ObjectValuable, was: %T`, resultAttribute))
+
+		return nil, diags
+	}
+
+	resultObjVal, resultObjValDiags := resultValuable.ToObjectValue(ctx)
+	diags.Append(resultObjValDiags...)
+
+	resultTypable, ok := t.AttrTypes["result"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`result expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["result"]))
+
+		return nil, diags
+	}
+
+	resultConverted, resultConvertedDiags := resultTypable.ValueFromObject(ctx, resultObjVal)
+	diags.Append(resultConvertedDiags...)
+
+	resultVal, ok := resultConverted.(ResultValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`result expected to be ResultValue, was: %T`, resultConverted))
 	}
 
 	resultTypeAttribute, ok := attributes["result_type"]
@@ -1369,12 +1421,38 @@ func (t EnhancementType) ValueFromObject(ctx context.Context, in basetypes.Objec
 		return nil, diags
 	}
 
-	priorityVal, ok := priorityAttribute.(PriorityValue)
+	priorityValuable, ok := priorityAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`priority expected to be PriorityValue, was: %T`, priorityAttribute))
+			fmt.Sprintf(`priority expected to be basetypes.ObjectValuable, was: %T`, priorityAttribute))
+
+		return nil, diags
+	}
+
+	priorityObjVal, priorityObjValDiags := priorityValuable.ToObjectValue(ctx)
+	diags.Append(priorityObjValDiags...)
+
+	priorityTypable, ok := t.AttrTypes["priority"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`priority expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["priority"]))
+
+		return nil, diags
+	}
+
+	priorityConverted, priorityConvertedDiags := priorityTypable.ValueFromObject(ctx, priorityObjVal)
+	diags.Append(priorityConvertedDiags...)
+
+	priorityVal, ok := priorityConverted.(PriorityValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`priority expected to be PriorityValue, was: %T`, priorityConverted))
 	}
 
 	tagsAttribute, ok := attributes["tags"]

--- a/internal/provider/resource_report/report_resource_gen.go
+++ b/internal/provider/resource_report/report_resource_gen.go
@@ -1059,12 +1059,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	advancedAnalysisVal, ok := advancedAnalysisAttribute.(AdvancedAnalysisValue)
+	advancedAnalysisValuable, ok := advancedAnalysisAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`advanced_analysis expected to be AdvancedAnalysisValue, was: %T`, advancedAnalysisAttribute))
+			fmt.Sprintf(`advanced_analysis expected to be basetypes.ObjectValuable, was: %T`, advancedAnalysisAttribute))
+
+		return nil, diags
+	}
+
+	advancedAnalysisObjVal, advancedAnalysisObjValDiags := advancedAnalysisValuable.ToObjectValue(ctx)
+	diags.Append(advancedAnalysisObjValDiags...)
+
+	advancedAnalysisTypable, ok := t.AttrTypes["advanced_analysis"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`advanced_analysis expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["advanced_analysis"]))
+
+		return nil, diags
+	}
+
+	advancedAnalysisConverted, advancedAnalysisConvertedDiags := advancedAnalysisTypable.ValueFromObject(ctx, advancedAnalysisObjVal)
+	diags.Append(advancedAnalysisConvertedDiags...)
+
+	advancedAnalysisVal, ok := advancedAnalysisConverted.(AdvancedAnalysisValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`advanced_analysis expected to be AdvancedAnalysisValue, was: %T`, advancedAnalysisConverted))
 	}
 
 	aggregationAttribute, ok := attributes["aggregation"]
@@ -1113,12 +1139,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	customTimeRangeVal, ok := customTimeRangeAttribute.(CustomTimeRangeValue)
+	customTimeRangeValuable, ok := customTimeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeAttribute))
+			fmt.Sprintf(`custom_time_range expected to be basetypes.ObjectValuable, was: %T`, customTimeRangeAttribute))
+
+		return nil, diags
+	}
+
+	customTimeRangeObjVal, customTimeRangeObjValDiags := customTimeRangeValuable.ToObjectValue(ctx)
+	diags.Append(customTimeRangeObjValDiags...)
+
+	customTimeRangeTypable, ok := t.AttrTypes["custom_time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["custom_time_range"]))
+
+		return nil, diags
+	}
+
+	customTimeRangeConverted, customTimeRangeConvertedDiags := customTimeRangeTypable.ValueFromObject(ctx, customTimeRangeObjVal)
+	diags.Append(customTimeRangeConvertedDiags...)
+
+	customTimeRangeVal, ok := customTimeRangeConverted.(CustomTimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeConverted))
 	}
 
 	dataSourceAttribute, ok := attributes["data_source"]
@@ -1167,12 +1219,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	displaySettingsVal, ok := displaySettingsAttribute.(DisplaySettingsValue)
+	displaySettingsValuable, ok := displaySettingsAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsAttribute))
+			fmt.Sprintf(`display_settings expected to be basetypes.ObjectValuable, was: %T`, displaySettingsAttribute))
+
+		return nil, diags
+	}
+
+	displaySettingsObjVal, displaySettingsObjValDiags := displaySettingsValuable.ToObjectValue(ctx)
+	diags.Append(displaySettingsObjValDiags...)
+
+	displaySettingsTypable, ok := t.AttrTypes["display_settings"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["display_settings"]))
+
+		return nil, diags
+	}
+
+	displaySettingsConverted, displaySettingsConvertedDiags := displaySettingsTypable.ValueFromObject(ctx, displaySettingsObjVal)
+	diags.Append(displaySettingsConvertedDiags...)
+
+	displaySettingsVal, ok := displaySettingsConverted.(DisplaySettingsValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`display_settings expected to be DisplaySettingsValue, was: %T`, displaySettingsConverted))
 	}
 
 	displayValuesAttribute, ok := attributes["display_values"]
@@ -1293,12 +1371,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	metricFilterAttribute, ok := attributes["metric_filter"]
@@ -1311,12 +1415,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	metricFilterVal, ok := metricFilterAttribute.(MetricFilterValue)
+	metricFilterValuable, ok := metricFilterAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric_filter expected to be MetricFilterValue, was: %T`, metricFilterAttribute))
+			fmt.Sprintf(`metric_filter expected to be basetypes.ObjectValuable, was: %T`, metricFilterAttribute))
+
+		return nil, diags
+	}
+
+	metricFilterObjVal, metricFilterObjValDiags := metricFilterValuable.ToObjectValue(ctx)
+	diags.Append(metricFilterObjValDiags...)
+
+	metricFilterTypable, ok := t.AttrTypes["metric_filter"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric_filter expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric_filter"]))
+
+		return nil, diags
+	}
+
+	metricFilterConverted, metricFilterConvertedDiags := metricFilterTypable.ValueFromObject(ctx, metricFilterObjVal)
+	diags.Append(metricFilterConvertedDiags...)
+
+	metricFilterVal, ok := metricFilterConverted.(MetricFilterValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric_filter expected to be MetricFilterValue, was: %T`, metricFilterConverted))
 	}
 
 	metricsAttribute, ok := attributes["metrics"]
@@ -1347,12 +1477,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	secondaryTimeRangeVal, ok := secondaryTimeRangeAttribute.(SecondaryTimeRangeValue)
+	secondaryTimeRangeValuable, ok := secondaryTimeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`secondary_time_range expected to be SecondaryTimeRangeValue, was: %T`, secondaryTimeRangeAttribute))
+			fmt.Sprintf(`secondary_time_range expected to be basetypes.ObjectValuable, was: %T`, secondaryTimeRangeAttribute))
+
+		return nil, diags
+	}
+
+	secondaryTimeRangeObjVal, secondaryTimeRangeObjValDiags := secondaryTimeRangeValuable.ToObjectValue(ctx)
+	diags.Append(secondaryTimeRangeObjValDiags...)
+
+	secondaryTimeRangeTypable, ok := t.AttrTypes["secondary_time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`secondary_time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["secondary_time_range"]))
+
+		return nil, diags
+	}
+
+	secondaryTimeRangeConverted, secondaryTimeRangeConvertedDiags := secondaryTimeRangeTypable.ValueFromObject(ctx, secondaryTimeRangeObjVal)
+	diags.Append(secondaryTimeRangeConvertedDiags...)
+
+	secondaryTimeRangeVal, ok := secondaryTimeRangeConverted.(SecondaryTimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`secondary_time_range expected to be SecondaryTimeRangeValue, was: %T`, secondaryTimeRangeConverted))
 	}
 
 	sortDimensionsAttribute, ok := attributes["sort_dimensions"]
@@ -1437,12 +1593,38 @@ func (t ConfigType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	timeRangeVal, ok := timeRangeAttribute.(TimeRangeValue)
+	timeRangeValuable, ok := timeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`time_range expected to be TimeRangeValue, was: %T`, timeRangeAttribute))
+			fmt.Sprintf(`time_range expected to be basetypes.ObjectValuable, was: %T`, timeRangeAttribute))
+
+		return nil, diags
+	}
+
+	timeRangeObjVal, timeRangeObjValDiags := timeRangeValuable.ToObjectValue(ctx)
+	diags.Append(timeRangeObjValDiags...)
+
+	timeRangeTypable, ok := t.AttrTypes["time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["time_range"]))
+
+		return nil, diags
+	}
+
+	timeRangeConverted, timeRangeConvertedDiags := timeRangeTypable.ValueFromObject(ctx, timeRangeObjVal)
+	diags.Append(timeRangeConvertedDiags...)
+
+	timeRangeVal, ok := timeRangeConverted.(TimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`time_range expected to be TimeRangeValue, was: %T`, timeRangeConverted))
 	}
 
 	if diags.HasError() {
@@ -5267,12 +5449,38 @@ func (t GroupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue
 		return nil, diags
 	}
 
-	limitVal, ok := limitAttribute.(LimitValue)
+	limitValuable, ok := limitAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`limit expected to be LimitValue, was: %T`, limitAttribute))
+			fmt.Sprintf(`limit expected to be basetypes.ObjectValuable, was: %T`, limitAttribute))
+
+		return nil, diags
+	}
+
+	limitObjVal, limitObjValDiags := limitValuable.ToObjectValue(ctx)
+	diags.Append(limitObjValDiags...)
+
+	limitTypable, ok := t.AttrTypes["limit"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`limit expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["limit"]))
+
+		return nil, diags
+	}
+
+	limitConverted, limitConvertedDiags := limitTypable.ValueFromObject(ctx, limitObjVal)
+	diags.Append(limitConvertedDiags...)
+
+	limitVal, ok := limitConverted.(LimitValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`limit expected to be LimitValue, was: %T`, limitConverted))
 	}
 
 	typeAttribute, ok := attributes["type"]
@@ -5709,12 +5917,38 @@ func (t LimitType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	sortAttribute, ok := attributes["sort"]
@@ -6556,12 +6790,38 @@ func (t MetricFilterType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	metricVal, ok := metricAttribute.(MetricValue)
+	metricValuable, ok := metricAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricAttribute))
+			fmt.Sprintf(`metric expected to be basetypes.ObjectValuable, was: %T`, metricAttribute))
+
+		return nil, diags
+	}
+
+	metricObjVal, metricObjValDiags := metricValuable.ToObjectValue(ctx)
+	diags.Append(metricObjValDiags...)
+
+	metricTypable, ok := t.AttrTypes["metric"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["metric"]))
+
+		return nil, diags
+	}
+
+	metricConverted, metricConvertedDiags := metricTypable.ValueFromObject(ctx, metricObjVal)
+	diags.Append(metricConvertedDiags...)
+
+	metricVal, ok := metricConverted.(MetricValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`metric expected to be MetricValue, was: %T`, metricConverted))
 	}
 
 	operatorAttribute, ok := attributes["operator"]
@@ -7453,12 +7713,38 @@ func (t SecondaryTimeRangeType) ValueFromObject(ctx context.Context, in basetype
 		return nil, diags
 	}
 
-	customTimeRangeVal, ok := customTimeRangeAttribute.(CustomTimeRangeValue)
+	customTimeRangeValuable, ok := customTimeRangeAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeAttribute))
+			fmt.Sprintf(`custom_time_range expected to be basetypes.ObjectValuable, was: %T`, customTimeRangeAttribute))
+
+		return nil, diags
+	}
+
+	customTimeRangeObjVal, customTimeRangeObjValDiags := customTimeRangeValuable.ToObjectValue(ctx)
+	diags.Append(customTimeRangeObjValDiags...)
+
+	customTimeRangeTypable, ok := t.AttrTypes["custom_time_range"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["custom_time_range"]))
+
+		return nil, diags
+	}
+
+	customTimeRangeConverted, customTimeRangeConvertedDiags := customTimeRangeTypable.ValueFromObject(ctx, customTimeRangeObjVal)
+	diags.Append(customTimeRangeConvertedDiags...)
+
+	customTimeRangeVal, ok := customTimeRangeConverted.(CustomTimeRangeValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`custom_time_range expected to be CustomTimeRangeValue, was: %T`, customTimeRangeConverted))
 	}
 
 	includeCurrentAttribute, ok := attributes["include_current"]
@@ -8004,12 +8290,38 @@ func (t SplitsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValu
 		return nil, diags
 	}
 
-	originVal, ok := originAttribute.(OriginValue)
+	originValuable, ok := originAttribute.(basetypes.ObjectValuable)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originAttribute))
+			fmt.Sprintf(`origin expected to be basetypes.ObjectValuable, was: %T`, originAttribute))
+
+		return nil, diags
+	}
+
+	originObjVal, originObjValDiags := originValuable.ToObjectValue(ctx)
+	diags.Append(originObjValDiags...)
+
+	originTypable, ok := t.AttrTypes["origin"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["origin"]))
+
+		return nil, diags
+	}
+
+	originConverted, originConvertedDiags := originTypable.ValueFromObject(ctx, originObjVal)
+	diags.Append(originConvertedDiags...)
+
+	originVal, ok := originConverted.(OriginValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`origin expected to be OriginValue, was: %T`, originConverted))
 	}
 
 	targetsAttribute, ok := attributes["targets"]


### PR DESCRIPTION
## Summary

- Bumps `terraform-plugin-codegen-framework` to [`eb6bfa7`](https://github.com/doitintl/terraform-plugin-codegen-framework/commit/eb6bfa7) (doitintl/terraform-plugin-codegen-framework#14)
- Regenerates all `_gen.go` files — `ValueFromObject` methods for nested object types now normalize through `ObjectValuable.ToObjectValue()` → `Type.ValueFromObject()` instead of direct type assertion
- No hand-written provider code changes; purely generated output

## Context

The Terraform framework strips custom type information from nested attributes when reassembling parent objects after plan modification. The generated `ValueFromObject` now handles this by normalizing through the `ObjectValuable` interface, preventing plan-time crashes when any `SingleNestedAttribute` within a parent object has a plan modifier.

Builds on PR #261 (null/unknown guards). Prerequisite for #255 (`forecast_settings`).

## Test plan

- [x] `go build ./...` — clean build
- [x] `go generate ./OpenAPI/2_tfplugingen-framework/...` — generates identical output
- [x] All existing acceptance tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)