### PR TITLE
test: absorb flaky acceptance tests with gotestsum reruns

### DIFF
--- a/.agent/skills/testing/SKILL.md
+++ b/.agent/skills/testing/SKILL.md
@@ -19,19 +19,51 @@ make testacc-run TEST=TestAccLabel
 
 Do NOT use `go test` directly.
 
+The targets run tests through [`gotestsum`](https://github.com/gotestyourself/gotestsum),
+which **automatically reruns failed tests** (up to 2 extra attempts) to absorb
+upstream API flakiness. See [Capturing Full Output](#capturing-full-output) for how
+to tell a flaky rerun apart from a real failure.
+
 ### Capturing Full Output
 
-Always capture the full output so you don't have to re-run:
+`gotestsum` prints a clean, de-interleaved failure summary at the end of the run
+(plain `go test -v` output from parallel tests is interleaved and hard to read).
+Still capture the full output so you don't have to re-run:
 
 ```bash
 make testacc-run TEST=TestAccReport 2>&1 | tee /tmp/test-output.txt
 ```
 
-Then search for failures:
+Read results from the summary at the bottom, not by grepping raw `FAIL` lines:
 
 ```bash
-grep -A 20 "FAIL\|Error\|inconsistent" /tmp/test-output.txt
+# gotestsum groups every failed test's output under this block:
+sed -n '/^=== Failed/,$p' /tmp/test-output.txt
+# one-line tally, e.g. "DONE 2 runs, 3 tests, 1 failure":
+grep '^DONE' /tmp/test-output.txt
 ```
+
+**The exit code is the source of truth** for flaky-vs-real:
+
+- **`make` succeeds (exit 0)** = every test ultimately passed. Some may have needed
+  a rerun (flaky), but none is a real failure.
+- A test shown with **`(re-run 1)` / `(re-run 2)`** exhausted its retries → **real failure**.
+- A test that failed once with **no `(re-run N)` entries** recovered on rerun → **flaky**.
+  Not blocking, but worth reporting (see [Known API Issues](#known-api-issues)).
+
+The targets also write a one-line-per-flaky report to `/tmp/testacc-reruns.txt` —
+the quickest way to see exactly which tests were rerun this run (absent or empty if
+none were):
+
+```bash
+cat /tmp/testacc-reruns.txt   # e.g. "doit.TestAccReport_Basic: 2 runs, 1 failures"
+```
+
+**Do NOT trust `test-results.xml` for pass/fail.** gotestsum writes one `<testcase>`
+per *attempt*, so a recovered flaky still carries a `<failure>` node even on a green
+run — a naive parse reports false failures. That file exists only to feed the CI
+JUnit check (which sets `check_retries: true` to compensate). Locally, rely on the
+exit code and the `=== Failed` block.
 
 ### Required Environment Variables
 

--- a/.agent/skills/testing/SKILL.md
+++ b/.agent/skills/testing/SKILL.md
@@ -28,42 +28,47 @@ to tell a flaky rerun apart from a real failure.
 
 `gotestsum` prints a clean, de-interleaved failure summary at the end of the run
 (plain `go test -v` output from parallel tests is interleaved and hard to read).
-Still capture the full output so you don't have to re-run:
+Still capture the full output so you don't have to re-run — use `set -o pipefail`
+so the pipe to `tee` doesn't swallow the test exit code:
 
 ```bash
+set -o pipefail
 make testacc-run TEST=TestAccReport 2>&1 | tee /tmp/test-output.txt
+echo "exit: $?"   # WITHOUT pipefail this prints tee's status (0), not the test result
 ```
 
-Read results from the summary at the bottom, not by grepping raw `FAIL` lines:
+**The exit code is the source of truth** for overall pass/fail:
+
+- **exit 0** = every test ultimately passed. Some may have needed a rerun (flaky),
+  but none is a real failure.
+- **non-zero** = at least one test failed on its *final* attempt.
+
+To tell a genuine failure from a test that merely flaked, read the rerun report —
+the targets write one line per reran test to `/tmp/testacc-reruns.txt`:
 
 ```bash
-# gotestsum groups every failed test's output under this block:
-sed -n '/^=== Failed/,$p' /tmp/test-output.txt
-# one-line tally, e.g. "DONE 2 runs, 3 tests, 1 failure":
-grep '^DONE' /tmp/test-output.txt
+cat /tmp/testacc-reruns.txt   # absent or empty if nothing was rerun
+# doit.TestAccX: 3 runs, 3 failures   <- failures == runs → never passed → REAL failure
+# doit.TestAccY: 3 runs, 1 failures   <- failures  < runs → recovered   → flaky (report, not blocking)
 ```
 
-**The exit code is the source of truth** for flaky-vs-real:
+Flaky (recovered) tests are not blocking, but are worth reporting (see
+[Known API Issues](#known-api-issues)).
 
-- **`make` succeeds (exit 0)** = every test ultimately passed. Some may have needed
-  a rerun (flaky), but none is a real failure.
-- A test shown with **`(re-run 1)` / `(re-run 2)`** exhausted its retries → **real failure**.
-- A test that failed once with **no `(re-run N)` entries** recovered on rerun → **flaky**.
-  Not blocking, but worth reporting (see [Known API Issues](#known-api-issues)).
-
-The targets also write a one-line-per-flaky report to `/tmp/testacc-reruns.txt` —
-the quickest way to see exactly which tests were rerun this run (absent or empty if
-none were):
+Do **not** infer real-vs-flaky from `(re-run N)` markers in the log: a test can fail
+`(re-run 1)` and still pass on `(re-run 2)`. The `=== Failed` block lists every
+failed *attempt*, including attempts of tests that later recovered — use it to read
+failure *output*, not to decide pass/fail:
 
 ```bash
-cat /tmp/testacc-reruns.txt   # e.g. "doit.TestAccReport_Basic: 2 runs, 1 failures"
+sed -n '/^=== Failed/,$p' /tmp/test-output.txt   # failure output (may include recovered flakies)
 ```
 
 **Do NOT trust `test-results.xml` for pass/fail.** gotestsum writes one `<testcase>`
 per *attempt*, so a recovered flaky still carries a `<failure>` node even on a green
 run — a naive parse reports false failures. That file exists only to feed the CI
 JUnit check (which sets `check_retries: true` to compensate). Locally, rely on the
-exit code and the `=== Failed` block.
+exit code and `/tmp/testacc-reruns.txt`.
 
 ### Required Environment Variables
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,9 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      checks: write # allow the JUnit reporter to publish a check run
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -79,6 +82,10 @@ jobs:
           terraform_wrapper: false
 
       - run: go mod download
+
+      # gotestsum reruns individual failed tests to absorb upstream API flakiness.
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Run Tests
         env:
@@ -104,4 +111,24 @@ jobs:
           TEST_AWS_ROLE_ARN: ${{ vars.TEST_AWS_ROLE_ARN }}
           TEST_AWS_S3_BUCKET: ${{ vars.TEST_AWS_S3_BUCKET }}
           TEST_AWS_S3_BUCKET_REGION: ${{ vars.TEST_AWS_S3_BUCKET_REGION }}
-        run: go test -v -timeout 120m ./...
+        run: |
+          gotestsum \
+            --format standard-verbose \
+            --rerun-fails=2 \
+            --rerun-fails-max-failures=5 \
+            --packages='./...' \
+            --junitfile test-results.xml \
+            -- -timeout 120m
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
+        if: always() # publish results even when tests fail
+        with:
+          report_paths: test-results.xml
+          check_name: Acceptance Tests
+          check_retries: true # gotestsum emits one <testcase> per attempt; treat a recovered flaky as passed
+          flaky_summary: true # table of tests that failed then passed on rerun
+          detailed_summary: true # full results table in the job summary
+          require_tests: true # fail the report if no tests matched (e.g. compile error, empty XML)
+          fail_on_parse_error: true # fail if test-results.xml is unparseable
+          truncate_stack_traces: false # keep full TF error output in annotations

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ custom-gcl
 
 # Compiled provider binary (build artifact)
 /terraform-provider-doit
+
+# gotestsum JUnit report output
+test-results.xml

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -53,14 +53,37 @@ fmt:
 test:
 	go test -v -cover -timeout=120s -parallel=10 ./...
 
+# gotestsum wraps `go test` and automatically reruns individual failed tests,
+# which tames acceptance-test flakiness caused by the upstream API. Pinned and
+# invoked via `go run` so no separate install is needed locally.
+GOTESTSUM := go run gotest.tools/gotestsum@v1.13.0
+
 # Run acceptance tests (loads environment from .envrc.local)
+# --rerun-fails retries each failed test up to N times; --rerun-fails-max-failures
+# is a circuit breaker that skips reruns entirely if the initial run has many
+# failures (i.e. a systemic break rather than flakiness).
 testacc:
-	@test -f .envrc.local && . ./.envrc.local; TF_ACC=1 go test -v -cover -timeout 120m ./...
+	@test -f .envrc.local && . ./.envrc.local; \
+	TF_ACC=1 $(GOTESTSUM) \
+		--format standard-verbose \
+		--rerun-fails=2 \
+		--rerun-fails-max-failures=5 \
+		--rerun-fails-report=/tmp/testacc-reruns.txt \
+		--packages='./...' \
+		--junitfile test-results.xml \
+		-- -cover -timeout 120m
 
 # Run a specific acceptance test
 # Usage: make testacc-run TEST=TestAccBudget
 testacc-run:
-	@test -f .envrc.local && . ./.envrc.local; TF_ACC=1 go test -v -timeout 120m ./internal/provider/... -run '$(TEST)'
+	@test -f .envrc.local && . ./.envrc.local; \
+	TF_ACC=1 $(GOTESTSUM) \
+		--format standard-verbose \
+		--rerun-fails=2 \
+		--rerun-fails-max-failures=5 \
+		--rerun-fails-report=/tmp/testacc-reruns.txt \
+		--packages='./internal/provider/...' \
+		-- -timeout 120m -run '$(TEST)'
 
 # Validate all examples against the provider schema
 validate-examples:


### PR DESCRIPTION
## Summary

Acceptance tests are flaky because the upstream DoiT API occasionally returns non-retryable errors (e.g. 500). Rather than retry those requests in the provider (undesirable), this runs the suite through [gotestsum](https://github.com/gotestyourself/gotestsum), which reruns only the individual failed tests.

## Changes

- **Makefile** — `testacc` / `testacc-run` run via pinned `gotestsum` (`v1.13.0`, invoked with `go run` so no local install is needed):
  - `--rerun-fails=2` — up to 2 extra attempts per failed test
  - `--rerun-fails-max-failures=5` — circuit breaker; skips reruns entirely if the initial run has >5 failures (systemic break, not flakiness)
  - `--rerun-fails-report=/tmp/testacc-reruns.txt` — one-line-per-flaky list
- **CI (`tests.yml`)** — install gotestsum, run through it, and publish results with `mikepenz/action-junit-report` (SHA-pinned). Key input `check_retries: true`: gotestsum writes one `<testcase>` per attempt, so a recovered flaky still carries a `<failure>` node even on a green run — `check_retries` suppresses that false positive, and `flaky_summary` surfaces reran tests instead. Adds `checks: write` to the test job for the reporter.
- **.gitignore** — ignore generated `test-results.xml`.
- **testing skill** — document flaky-vs-real interpretation (exit code is the source of truth; `(re-run N)` = real failure, initial-only failure = recovered flaky), the `/tmp/testacc-reruns.txt` report, and that `test-results.xml` must not be trusted locally for pass/fail.

## Testing

- Verified gotestsum behavior empirically: a run whose only failure is a recovered flaky exits `0` but still emits a `<failure>` in the XML (confirms why `check_retries` is required); `--rerun-fails-report` writes `pkg.TestName: N runs, M failures`.
- Validated the workflow YAML parses and all mikepenz inputs are valid; confirmed both Makefile targets expand correctly.
- The mikepenz action itself only runs in CI (not exercisable locally without Docker/`act`) — watch the first CI run to confirm the check renders and recovered flakies are suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)