### PR TITLE
resource/doit_allocation: make anomaly_detection writable (single allocations only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### ENHANCEMENTS
+
+- **resource/doit_allocation**: `anomaly_detection` is now writable on single allocations. Removing it from configuration disables it (the API clears the field with an explicit `false`); it is rejected at plan time when used with group allocations (`rules`)
+- **data-source/doit_allocations**: Added the `anomaly_detection` field to listed allocations
+
 ## v1.6.0 (2026-07-30)
 
 ### FEATURES

--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -585,7 +585,7 @@
 						"name": "anomaly_detection",
 						"bool": {
 							"computed_optional_required": "computed",
-							"description": "Whether anomaly detection is enabled for this allocation."
+							"description": "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations."
 						}
 					},
 					{
@@ -919,6 +919,13 @@
 										"string": {
 											"computed_optional_required": "computed",
 											"description": "Composition type of allocation (single or group)."
+										}
+									},
+									{
+										"name": "anomaly_detection",
+										"bool": {
+											"computed_optional_required": "computed",
+											"description": "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations."
 										}
 									},
 									{

--- a/OpenAPI/2_tfplugingen-framework/output_resources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_resources.json
@@ -332,6 +332,13 @@
 			"schema": {
 				"attributes": [
 					{
+						"name": "anomaly_detection",
+						"bool": {
+							"computed_optional_required": "computed_optional",
+							"description": "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations."
+						}
+					},
+					{
 						"name": "description",
 						"string": {
 							"computed_optional_required": "required",
@@ -654,13 +661,6 @@
 						"string": {
 							"computed_optional_required": "computed",
 							"description": "Composition type of allocation."
-						}
-					},
-					{
-						"name": "anomaly_detection",
-						"bool": {
-							"computed_optional_required": "computed",
-							"description": "Whether anomaly detection is enabled for this allocation."
 						}
 					},
 					{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -8471,6 +8471,9 @@ components:
         description:
           type: string
           description: Allocation description.
+        anomalyDetection:
+          type: boolean
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
         rule:
           $ref: "#/components/schemas/AllocationRule"
         rules:
@@ -8498,6 +8501,9 @@ components:
           type: string
           description: Allocation description
           nullable: true
+        anomalyDetection:
+          type: boolean
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
         rule:
           $ref: "#/components/schemas/AllocationRule"
         rules:
@@ -8554,6 +8560,9 @@ components:
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
           default: root
           example: root
+        anomalyDetection:
+          type: boolean
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
     AllocationRule:
       required:
         - components
@@ -10549,8 +10558,7 @@ components:
           format: int64
         anomalyDetection:
           type: boolean
-          description: Whether anomaly detection is enabled for this allocation.
-          nullable: true
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
         rule:
           $ref: "#/components/schemas/AllocationRule"
         rules:

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -4523,8 +4523,7 @@ components:
           format: int64
         anomalyDetection:
           type: boolean
-          description: Whether anomaly detection is enabled for this allocation.
-          nullable: true
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
         rule:
           $ref: "#/components/schemas/AllocationRule"
         rules:
@@ -4680,6 +4679,9 @@ components:
           description: Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
           default: root
           example: root
+        anomalyDetection:
+          type: boolean
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
     AllocationRule:
       required:
         - components
@@ -7154,6 +7156,9 @@ components:
         description:
           type: string
           description: Allocation description.
+        anomalyDetection:
+          type: boolean
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
         rule:
           $ref: "#/components/schemas/AllocationRule"
         rules:
@@ -10448,6 +10453,9 @@ components:
           type: string
           description: Allocation description
           nullable: true
+        anomalyDetection:
+          type: boolean
+          description: Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
         rule:
           $ref: "#/components/schemas/AllocationRule"
         rules:

--- a/docs/data-sources/allocation.md
+++ b/docs/data-sources/allocation.md
@@ -46,7 +46,7 @@ output "allocation_description" {
 ### Read-Only
 
 - `allocation_type` (String) Composition type of allocation.
-- `anomaly_detection` (Boolean) Whether anomaly detection is enabled for this allocation.
+- `anomaly_detection` (Boolean) Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
 - `create_time` (Number) The time when the allocation was created (in UNIX timestamp).
 - `description` (String) Allocation description.
 - `folder_id` (String) Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).

--- a/docs/data-sources/allocations.md
+++ b/docs/data-sources/allocations.md
@@ -66,6 +66,7 @@ Optional:
 Read-Only:
 
 - `allocation_type` (String) Composition type of allocation (single or group).
+- `anomaly_detection` (Boolean) Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
 - `create_time` (Number) The time when the allocation was created (in UNIX timestamp).
 - `description` (String) Allocation description.
 - `folder_id` (String) Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).

--- a/docs/resources/allocation.md
+++ b/docs/resources/allocation.md
@@ -13,10 +13,13 @@ Define how costs are distributed across your organization.
 ## Example Usage
 
 ```terraform
-# Create an allocation for the development environment based on a project label
+# Create an allocation for the development environment based on a project label.
+# anomaly_detection is only valid on single allocations (those using "rule");
+# setting it alongside "rules" is rejected at plan time.
 resource "doit_allocation" "allocation_dev" {
-  name        = "Dev"
-  description = "Development Environment"
+  name              = "Dev"
+  description       = "Development Environment"
+  anomaly_detection = true
   rule = {
     formula = "A"
     components = [{
@@ -247,6 +250,7 @@ resource "doit_allocation" "dynamic_countries" {
 
 ### Optional
 
+- `anomaly_detection` (Boolean) Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
 - `folder_id` (String) Identifier of the folder that contains the allocation. Set to "root" if the allocation is at the top level (not in a folder).
 - `rule` (Attributes) Single allocation rule. Components can reference other existing allocation rules by using the "allocation_rule" dimension type. (see [below for nested schema](#nestedatt--rule))
 - `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
@@ -256,7 +260,6 @@ resource "doit_allocation" "dynamic_countries" {
 ### Read-Only
 
 - `allocation_type` (String) Composition type of allocation.
-- `anomaly_detection` (Boolean) Whether anomaly detection is enabled for this allocation.
 - `create_time` (Number) The time when the allocation was created (in UNIX timestamp).
 - `id` (String) Allocation ID.
 - `type` (String) Type of allocation (preset or custom).

--- a/examples/resources/doit_allocation/resource.tf
+++ b/examples/resources/doit_allocation/resource.tf
@@ -1,7 +1,10 @@
-# Create an allocation for the development environment based on a project label
+# Create an allocation for the development environment based on a project label.
+# anomaly_detection is only valid on single allocations (those using "rule");
+# setting it alongside "rules" is rejected at plan time.
 resource "doit_allocation" "allocation_dev" {
-  name        = "Dev"
-  description = "Development Environment"
+  name              = "Dev"
+  description       = "Development Environment"
+  anomaly_detection = true
   rule = {
     formula = "A"
     components = [{

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -50,14 +50,23 @@ func (r *allocationResource) overlayAllocationComputedFields(ctx context.Context
 	// ── Computed-only fields: always from resolved ──
 	plan.Id = resolved.Id
 	plan.CreateTime = resolved.CreateTime
-	plan.UpdateTime = resolved.UpdateTime
-	plan.AnomalyDetection = resolved.AnomalyDetection
+	// Guarded: a modifier-triggered Update (e.g. clearing anomaly_detection) leaves
+	// UpdateTime Known (copied from prior state) rather than Unknown, but the API
+	// always returns a new timestamp — assigning unconditionally would then conflict
+	// with Terraform's planned (stale) value. On Create/normal Update it's Unknown, so
+	// the guard is a no-op there.
+	if plan.UpdateTime.IsUnknown() {
+		plan.UpdateTime = resolved.UpdateTime //nolint:overlaycheck // guarded to avoid inconsistent result on Update
+	}
 	plan.Type = resolved.Type
 	plan.AllocationType = resolved.AllocationType
 
 	// ── Optional+Computed scalar fields: only when Unknown ──
 	if plan.UnallocatedCosts.IsUnknown() {
 		plan.UnallocatedCosts = resolved.UnallocatedCosts
+	}
+	if plan.AnomalyDetection.IsUnknown() {
+		plan.AnomalyDetection = resolved.AnomalyDetection
 	}
 
 	// ── Rule (single nested object): use resolved when Unknown, overlay subfields when Known ──
@@ -128,6 +137,7 @@ func (plan *allocationResourceModel) toCreateRequest(ctx context.Context) (req m
 	req.FolderId = common.FolderId
 	req.Rule = common.Rule
 	req.Rules = common.Rules
+	req.AnomalyDetection = common.AnomalyDetection
 
 	return req, diags
 }
@@ -181,6 +191,17 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 		if v := plan.UnallocatedCosts.ValueString(); v != "" {
 			req.UnallocatedCosts = valueToNullable(v)
 		}
+	}
+
+	// AnomalyDetection is only valid for "single" allocations — the API returns a
+	// 400 ("group allocation can not have 'anomalyDetection' field") if it is
+	// present at all on a group allocation, so it must be omitted rather than sent
+	// as false. A ConfigValidator keeps it null whenever rules is set.
+	// ValueBoolPointer() is nil when Null/Unknown, which the *bool field omits from
+	// the request — never an explicit JSON null, since the API ignores that anyway
+	// (clearing goes through the plan modifier's explicit false instead).
+	if !plan.AnomalyDetection.IsUnknown() {
+		req.AnomalyDetection = plan.AnomalyDetection.ValueBoolPointer()
 	}
 
 	// Populate single Rule if present
@@ -309,7 +330,7 @@ func mapAllocationToModel(ctx context.Context, client *models.ClientWithResponse
 	state.Id = types.StringPointerValue(resp.Id)
 	state.Type = types.StringPointerValue(resp.Type)
 	state.Description = types.StringPointerValue(resp.Description)
-	state.AnomalyDetection = types.BoolPointerValue(nullableToPointer(resp.AnomalyDetection))
+	state.AnomalyDetection = types.BoolPointerValue(resp.AnomalyDetection)
 	state.CreateTime = types.Int64PointerValue(resp.CreateTime)
 	state.UpdateTime = types.Int64PointerValue(resp.UpdateTime)
 	state.Name = types.StringPointerValue(resp.Name)

--- a/internal/provider/allocation_data_source.go
+++ b/internal/provider/allocation_data_source.go
@@ -139,7 +139,7 @@ func (ds *allocationDataSource) mapAllocationToModel(ctx context.Context, alloca
 	data.Name = types.StringPointerValue(allocation.Name)
 	data.Description = types.StringPointerValue(allocation.Description)
 	data.Type = types.StringPointerValue(allocation.Type)
-	data.AnomalyDetection = types.BoolPointerValue(nullableToPointer(allocation.AnomalyDetection))
+	data.AnomalyDetection = types.BoolPointerValue(allocation.AnomalyDetection)
 	data.CreateTime = types.Int64PointerValue(allocation.CreateTime)
 	data.UpdateTime = types.Int64PointerValue(allocation.UpdateTime)
 	data.UnallocatedCosts = types.StringPointerValue(nullableToPointer(allocation.UnallocatedCosts))

--- a/internal/provider/allocation_data_source_test.go
+++ b/internal/provider/allocation_data_source_test.go
@@ -41,6 +41,10 @@ func TestAccAllocationDataSource(t *testing.T) {
 						"data.doit_allocation.test",
 						tfjsonpath.New("rule").AtMapKey("formula"),
 						knownvalue.StringExact("A")),
+					statecheck.ExpectKnownValue(
+						"data.doit_allocation.test",
+						tfjsonpath.New("anomaly_detection"),
+						knownvalue.Bool(true)),
 				},
 			},
 			// Drift verification: re-apply the same config should produce an empty plan
@@ -84,8 +88,9 @@ func TestAccAllocationDataSource_Group(t *testing.T) {
 func testAccAllocationDataSourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "doit_allocation" "test" {
-    name        = %q
-    description = "test allocation for data source"
+    name              = %q
+    description       = "test allocation for data source"
+    anomaly_detection = true
     rule = {
        formula = "A"
        components = [

--- a/internal/provider/allocation_resource.go
+++ b/internal/provider/allocation_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
@@ -118,10 +117,6 @@ func (r *allocationResource) Schema(ctx context.Context, _ resource.SchemaReques
 		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
 		s.Attributes["allocation_type"] = attr
 	}
-	if attr, ok := s.Attributes["anomaly_detection"].(schema.BoolAttribute); ok {
-		attr.PlanModifiers = append(attr.PlanModifiers, boolplanmodifier.UseStateForUnknown())
-		s.Attributes["anomaly_detection"] = attr
-	}
 	if attr, ok := s.Attributes["type"].(schema.StringAttribute); ok {
 		attr.PlanModifiers = append(attr.PlanModifiers, stringplanmodifier.UseStateForUnknown())
 		s.Attributes["type"] = attr
@@ -148,6 +143,14 @@ func (r *allocationResource) Schema(ctx context.Context, _ resource.SchemaReques
 		s.Attributes["unallocated_costs"] = attr
 	}
 
+	// Category A: user-controlled toggle, cleared with an explicit false rather than
+	// null — the API returns 200 for a null anomalyDetection but leaves the stored
+	// value untouched, so planning null would drift permanently.
+	if attr, ok := s.Attributes["anomaly_detection"].(schema.BoolAttribute); ok {
+		attr.PlanModifiers = append(attr.PlanModifiers, useEmptyForUnknownBoolWhenConfigNull())
+		s.Attributes["anomaly_detection"] = attr
+	}
+
 	s.Attributes["timeouts"] = timeouts.Attributes(ctx, timeouts.Opts{
 		Create: true,
 		Read:   true,
@@ -171,6 +174,13 @@ func (r *allocationResource) ConfigValidators(_ context.Context) []resource.Conf
 		resourcevalidator.Conflicting(
 			path.MatchRoot("rule"),
 			path.MatchRoot("unallocated_costs"),
+		),
+		// The API rejects anomalyDetection on group allocations with a 400
+		// ("group allocation can not have 'anomalyDetection' field") on both
+		// create and update. Catch it at plan time instead.
+		resourcevalidator.Conflicting(
+			path.MatchRoot("anomaly_detection"),
+			path.MatchRoot("rules"),
 		),
 	}
 }

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -3460,15 +3460,9 @@ func TestAccAllocation_TypeSwitchForcesReplace(t *testing.T) {
 		})
 	})
 
-	// Regression test: prior state's anomaly_detection must not leak into the
-	// replacement's create request. Optional+Computed attributes not set in the
-	// new config carry forward the prior state value (via Terraform's standard
-	// proposed-new-state calculation, which the useEmptyForUnknownBoolWhenConfigNull
-	// modifier makes an explicit Known(false) rather than Unknown), so if the
-	// request builder didn't gate on the allocation shape, this would send
-	// "anomalyDetection" to the group create endpoint, which rejects it with a 400
-	// ("group allocation can not have 'anomalyDetection' field") regardless of the
-	// field's value.
+	// Verifies that a prior true anomaly_detection value doesn't leak into the
+	// group create request on a rule->rules switch: the API rejects the field
+	// unconditionally on group allocations, regardless of its value.
 	t.Run("rule_with_anomaly_detection_to_rules", func(t *testing.T) {
 		rName := acctest.RandomWithPrefix("tf-acc-alloc-switch")
 		resource.ParallelTest(t, resource.TestCase{
@@ -3485,12 +3479,9 @@ func TestAccAllocation_TypeSwitchForcesReplace(t *testing.T) {
 					},
 				},
 				// Step 2: switch to group (rules), omitting anomaly_detection — forces
-				// replacement. Must succeed (no API 400) and must not carry the prior
-				// true value into the new group allocation. The pre-apply
-				// ExpectUnknownValue pins down *why* it's safe: a destroy-before-create
-				// plans the create half from scratch (no prior state carried in), so
-				// this Optional+Computed attribute is Unknown, not a copied-forward
-				// Known(false/true) — the request builder's IsUnknown() guard omits it.
+				// replacement. Must succeed (no API 400), and the pre-apply plan must
+				// show anomaly_detection as unknown rather than a value carried
+				// forward from the destroyed single allocation.
 				{
 					Config: testAccAllocationSwitchRules(rName),
 					ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -3513,6 +3504,59 @@ func TestAccAllocation_TypeSwitchForcesReplace(t *testing.T) {
 				// Step 3: drift check after replacement.
 				{
 					Config: testAccAllocationSwitchRules(rName),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+				},
+			},
+		})
+	})
+
+	// Same as above, but under lifecycle { create_before_destroy = true }, where
+	// the new instance is created while the old one still exists. Names differ
+	// (-single/-group) so the test isn't confounded by a possible
+	// allocation-name-uniqueness constraint on the API side.
+	t.Run("rule_with_anomaly_detection_to_rules_create_before_destroy", func(t *testing.T) {
+		rName := acctest.RandomWithPrefix("tf-acc-alloc-switch")
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+			PreCheck:                 testAccPreCheckFunc(t),
+			TerraformVersionChecks:   testAccTFVersionChecks,
+			Steps: []resource.TestStep{
+				// Step 1: create as single (rule) with anomaly_detection explicitly true.
+				{
+					Config: testAccAllocationSwitchRuleWithAnomalyDetectionCBD(rName),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("doit_allocation.switch",
+							tfjsonpath.New("anomaly_detection"), knownvalue.Bool(true)),
+					},
+				},
+				// Step 2: switch to group (rules) with create_before_destroy — forces
+				// replacement, new instance created before the old one is destroyed.
+				// Must succeed (no API 400) and the pre-apply plan must show
+				// anomaly_detection as Unknown, not a copied-forward Known value.
+				{
+					Config: testAccAllocationSwitchRulesCBD(rName),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(
+								"doit_allocation.switch",
+								plancheck.ResourceActionCreateBeforeDestroy,
+							),
+							plancheck.ExpectUnknownValue(
+								"doit_allocation.switch",
+								tfjsonpath.New("anomaly_detection"),
+							),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("doit_allocation.switch",
+							tfjsonpath.New("rules"), knownvalue.ListSizeExact(1)),
+					},
+				},
+				// Step 3: drift check after replacement.
+				{
+					Config: testAccAllocationSwitchRulesCBD(rName),
 					ConfigPlanChecks: resource.ConfigPlanChecks{
 						PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 					},
@@ -3594,6 +3638,52 @@ resource "doit_allocation" "switch" {
   }
 }
 `, rName)
+}
+
+func testAccAllocationSwitchRuleWithAnomalyDetectionCBD(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "switch" {
+  name              = "%s-single"
+  description       = "type switch test (create_before_destroy)"
+  anomaly_detection = true
+  rule = {
+    formula = "A"
+    components = [{
+      key    = "country"
+      mode   = "is"
+      type   = "fixed"
+      values = ["JP"]
+    }]
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`, rName)
+}
+
+func testAccAllocationSwitchRulesCBD(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "switch" {
+  name              = "%s-group"
+  description       = "type switch test (create_before_destroy)"
+  unallocated_costs = "%s-other"
+  rules = [{
+    action  = "create"
+    name    = "%s-r1"
+    formula = "A"
+    components = [{
+      key    = "country"
+      mode   = "is"
+      type   = "fixed"
+      values = ["JP"]
+    }]
+  }]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`, rName, rName, rName)
 }
 
 func testAccAllocationSwitchRules(rName string) string {

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -3460,6 +3460,67 @@ func TestAccAllocation_TypeSwitchForcesReplace(t *testing.T) {
 		})
 	})
 
+	// Regression test: prior state's anomaly_detection must not leak into the
+	// replacement's create request. Optional+Computed attributes not set in the
+	// new config carry forward the prior state value (via Terraform's standard
+	// proposed-new-state calculation, which the useEmptyForUnknownBoolWhenConfigNull
+	// modifier makes an explicit Known(false) rather than Unknown), so if the
+	// request builder didn't gate on the allocation shape, this would send
+	// "anomalyDetection" to the group create endpoint, which rejects it with a 400
+	// ("group allocation can not have 'anomalyDetection' field") regardless of the
+	// field's value.
+	t.Run("rule_with_anomaly_detection_to_rules", func(t *testing.T) {
+		rName := acctest.RandomWithPrefix("tf-acc-alloc-switch")
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+			PreCheck:                 testAccPreCheckFunc(t),
+			TerraformVersionChecks:   testAccTFVersionChecks,
+			Steps: []resource.TestStep{
+				// Step 1: create as single (rule) with anomaly_detection explicitly true.
+				{
+					Config: testAccAllocationSwitchRuleWithAnomalyDetection(rName),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("doit_allocation.switch",
+							tfjsonpath.New("anomaly_detection"), knownvalue.Bool(true)),
+					},
+				},
+				// Step 2: switch to group (rules), omitting anomaly_detection — forces
+				// replacement. Must succeed (no API 400) and must not carry the prior
+				// true value into the new group allocation. The pre-apply
+				// ExpectUnknownValue pins down *why* it's safe: a destroy-before-create
+				// plans the create half from scratch (no prior state carried in), so
+				// this Optional+Computed attribute is Unknown, not a copied-forward
+				// Known(false/true) — the request builder's IsUnknown() guard omits it.
+				{
+					Config: testAccAllocationSwitchRules(rName),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(
+								"doit_allocation.switch",
+								plancheck.ResourceActionDestroyBeforeCreate,
+							),
+							plancheck.ExpectUnknownValue(
+								"doit_allocation.switch",
+								tfjsonpath.New("anomaly_detection"),
+							),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("doit_allocation.switch",
+							tfjsonpath.New("rules"), knownvalue.ListSizeExact(1)),
+					},
+				},
+				// Step 3: drift check after replacement.
+				{
+					Config: testAccAllocationSwitchRules(rName),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+					},
+				},
+			},
+		})
+	})
+
 	t.Run("rules_to_rule", func(t *testing.T) {
 		rName := acctest.RandomWithPrefix("tf-acc-alloc-switch")
 		resource.ParallelTest(t, resource.TestCase{
@@ -3503,6 +3564,25 @@ func testAccAllocationSwitchRule(rName string) string {
 resource "doit_allocation" "switch" {
   name        = "%s"
   description = "type switch test"
+  rule = {
+    formula = "A"
+    components = [{
+      key    = "country"
+      mode   = "is"
+      type   = "fixed"
+      values = ["JP"]
+    }]
+  }
+}
+`, rName)
+}
+
+func testAccAllocationSwitchRuleWithAnomalyDetection(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "switch" {
+  name              = "%s"
+  description       = "type switch test"
+  anomaly_detection = true
   rule = {
     formula = "A"
     components = [{

--- a/internal/provider/allocation_resource_test.go
+++ b/internal/provider/allocation_resource_test.go
@@ -3536,3 +3536,223 @@ resource "doit_allocation" "switch" {
 }
 `, rName, rName, rName)
 }
+
+// TestAccAllocation_AnomalyDetectionLifecycle covers the full Category A lifecycle for
+// anomaly_detection, which is cleared with an explicit false rather than null: the API
+// returns 200 for a null anomalyDetection but leaves the stored value untouched.
+// Step 6 (omitting the attribute) is the decisive assertion — it must land on false,
+// not null.
+func TestAccAllocation_AnomalyDetectionLifecycle(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	enabled, disabled := true, false
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			// Step 1: create with anomaly_detection = true.
+			{
+				Config: testAccAllocationAnomalyDetection(rName, &enabled),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"doit_allocation.anomaly",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.anomaly",
+						tfjsonpath.New("anomaly_detection"),
+						knownvalue.Bool(true)),
+				},
+			},
+			// Step 2: drift check.
+			{
+				Config: testAccAllocationAnomalyDetection(rName, &enabled),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Step 3: flip to an explicit false.
+			{
+				Config: testAccAllocationAnomalyDetection(rName, &disabled),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"doit_allocation.anomaly",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.anomaly",
+						tfjsonpath.New("anomaly_detection"),
+						knownvalue.Bool(false)),
+				},
+			},
+			// Step 4: drift check.
+			{
+				Config: testAccAllocationAnomalyDetection(rName, &disabled),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Step 5: back to true, so the clear in step 6 is a real transition.
+			{
+				Config: testAccAllocationAnomalyDetection(rName, &enabled),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"doit_allocation.anomaly",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.anomaly",
+						tfjsonpath.New("anomaly_detection"),
+						knownvalue.Bool(true)),
+				},
+			},
+			// Step 6: omit the attribute — the clearing modifier plans false and the
+			// API honors it. A null here would mean the modifier is wrong.
+			{
+				Config: testAccAllocationAnomalyDetection(rName, nil),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"doit_allocation.anomaly",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.anomaly",
+						tfjsonpath.New("anomaly_detection"),
+						knownvalue.Bool(false)),
+				},
+			},
+			// Step 7: drift check — the cleared value must be stable.
+			{
+				Config: testAccAllocationAnomalyDetection(rName, nil),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// Step 8: import.
+			{
+				ResourceName:      "doit_allocation.anomaly",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"update_time", // Computed field that changes on each modification
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_AnomalyDetection_OmittedOnCreate verifies the Optional+Computed
+// resolution on the Create path: the API stores false for a fresh allocation that never
+// mentions the field, and that must not drift.
+func TestAccAllocation_AnomalyDetection_OmittedOnCreate(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		CheckDestroy:             testAccCheckAllocationDestroy(t),
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllocationAnomalyDetection(rName, nil),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_allocation.anomaly",
+						tfjsonpath.New("anomaly_detection"),
+						knownvalue.Bool(false)),
+				},
+			},
+			{
+				Config: testAccAllocationAnomalyDetection(rName, nil),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+// TestAccAllocation_AnomalyDetection_ConflictsWithRules verifies the field is rejected
+// at plan time on group allocations. Without the validator the request reaches the API
+// and fails with a 400 ("group allocation can not have 'anomalyDetection' field").
+func TestAccAllocation_AnomalyDetection_ConflictsWithRules(t *testing.T) {
+	rName := acctest.RandomWithPrefix(testAllocPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAllocationGroupWithAnomalyDetection(rName),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
+			},
+		},
+	})
+}
+
+// testAccAllocationAnomalyDetection builds a single-allocation config, emitting the
+// anomaly_detection line only when ad is non-nil.
+func testAccAllocationAnomalyDetection(rName string, ad *bool) string {
+	adLine := ""
+	if ad != nil {
+		adLine = fmt.Sprintf("  anomaly_detection = %t\n", *ad)
+	}
+	return fmt.Sprintf(`
+resource "doit_allocation" "anomaly" {
+  name        = "%s"
+  description = "anomaly detection lifecycle test"
+%s  rule = {
+    formula = "A"
+    components = [{
+      key    = "country"
+      mode   = "is"
+      type   = "fixed"
+      values = ["JP"]
+    }]
+  }
+}
+`, rName, adLine)
+}
+
+func testAccAllocationGroupWithAnomalyDetection(rName string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "anomaly_group" {
+  name              = "%s"
+  description       = "anomaly detection is invalid on group allocations"
+  anomaly_detection = true
+  unallocated_costs = "%s-other"
+  rules = [{
+    action  = "create"
+    name    = "%s-r1"
+    formula = "A"
+    components = [{
+      key    = "country"
+      mode   = "is"
+      type   = "fixed"
+      values = ["JP"]
+    }]
+  }]
+}
+`, rName, rName, rName)
+}

--- a/internal/provider/allocations_data_source.go
+++ b/internal/provider/allocations_data_source.go
@@ -183,16 +183,17 @@ func (d *allocationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 			allocVal, diags := datasource_allocations.NewAllocationsValue(
 				datasource_allocations.AllocationsValue{}.AttributeTypes(ctx),
 				map[string]attr.Value{
-					"id":              types.StringPointerValue(alloc.Id),
-					"name":            types.StringPointerValue(alloc.Name),
-					"description":     types.StringPointerValue(alloc.Description),
-					"folder_id":       types.StringPointerValue(alloc.FolderId),
-					"owner":           types.StringPointerValue(alloc.Owner),
-					"type":            types.StringPointerValue(alloc.Type),
-					"allocation_type": allocTypeVal,
-					"create_time":     types.Int64PointerValue(alloc.CreateTime),
-					"update_time":     types.Int64PointerValue(alloc.UpdateTime),
-					"url_ui":          types.StringPointerValue(alloc.UrlUI),
+					"id":                types.StringPointerValue(alloc.Id),
+					"name":              types.StringPointerValue(alloc.Name),
+					"description":       types.StringPointerValue(alloc.Description),
+					"folder_id":         types.StringPointerValue(alloc.FolderId),
+					"owner":             types.StringPointerValue(alloc.Owner),
+					"type":              types.StringPointerValue(alloc.Type),
+					"allocation_type":   allocTypeVal,
+					"anomaly_detection": types.BoolPointerValue(alloc.AnomalyDetection),
+					"create_time":       types.Int64PointerValue(alloc.CreateTime),
+					"update_time":       types.Int64PointerValue(alloc.UpdateTime),
+					"url_ui":            types.StringPointerValue(alloc.UrlUI),
 				},
 			)
 			resp.Diagnostics.Append(diags...)

--- a/internal/provider/allocations_data_source_test.go
+++ b/internal/provider/allocations_data_source_test.go
@@ -28,6 +28,10 @@ func TestAccAllocationsDataSource_MaxResultsOnly(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.doit_allocations.limited", "allocations.#", "2"),
 					resource.TestCheckResourceAttrSet("data.doit_allocations.limited", "page_token"),
+					// anomaly_detection is a newly mapped list-item attribute. The
+					// generated NewAllocationsValue constructor errors at runtime if
+					// the mapping omits it, so assert it is populated.
+					resource.TestCheckResourceAttrSet("data.doit_allocations.limited", "allocations.0.anomaly_detection"),
 				),
 			},
 			{

--- a/internal/provider/datasource_allocation/allocation_data_source_gen.go
+++ b/internal/provider/datasource_allocation/allocation_data_source_gen.go
@@ -25,8 +25,8 @@ func AllocationDataSourceSchema(ctx context.Context) schema.Schema {
 			},
 			"anomaly_detection": schema.BoolAttribute{
 				Computed:            true,
-				Description:         "Whether anomaly detection is enabled for this allocation.",
-				MarkdownDescription: "Whether anomaly detection is enabled for this allocation.",
+				Description:         "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.",
+				MarkdownDescription: "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.",
 			},
 			"create_time": schema.Int64Attribute{
 				Computed:            true,

--- a/internal/provider/datasource_allocations/allocations_data_source_gen.go
+++ b/internal/provider/datasource_allocations/allocations_data_source_gen.go
@@ -28,6 +28,11 @@ func AllocationsDataSourceSchema(ctx context.Context) schema.Schema {
 							Description:         "Composition type of allocation (single or group).",
 							MarkdownDescription: "Composition type of allocation (single or group).",
 						},
+						"anomaly_detection": schema.BoolAttribute{
+							Computed:            true,
+							Description:         "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.",
+							MarkdownDescription: "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.",
+						},
 						"create_time": schema.Int64Attribute{
 							Computed:            true,
 							Description:         "The time when the allocation was created (in UNIX timestamp).",
@@ -201,6 +206,24 @@ func (t AllocationsType) ValueFromObject(ctx context.Context, in basetypes.Objec
 			fmt.Sprintf(`allocation_type expected to be basetypes.StringValue, was: %T`, allocationTypeAttribute))
 	}
 
+	anomalyDetectionAttribute, ok := attributes["anomaly_detection"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`anomaly_detection is missing from object`)
+
+		return nil, diags
+	}
+
+	anomalyDetectionVal, ok := anomalyDetectionAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`anomaly_detection expected to be basetypes.BoolValue, was: %T`, anomalyDetectionAttribute))
+	}
+
 	createTimeAttribute, ok := attributes["create_time"]
 
 	if !ok {
@@ -368,17 +391,18 @@ func (t AllocationsType) ValueFromObject(ctx context.Context, in basetypes.Objec
 	}
 
 	return AllocationsValue{
-		AllocationType:  allocationTypeVal,
-		CreateTime:      createTimeVal,
-		Description:     descriptionVal,
-		FolderId:        folderIdVal,
-		Id:              idVal,
-		Name:            nameVal,
-		Owner:           ownerVal,
-		AllocationsType: typeVal,
-		UpdateTime:      updateTimeVal,
-		UrlUi:           urlUiVal,
-		state:           attr.ValueStateKnown,
+		AllocationType:   allocationTypeVal,
+		AnomalyDetection: anomalyDetectionVal,
+		CreateTime:       createTimeVal,
+		Description:      descriptionVal,
+		FolderId:         folderIdVal,
+		Id:               idVal,
+		Name:             nameVal,
+		Owner:            ownerVal,
+		AllocationsType:  typeVal,
+		UpdateTime:       updateTimeVal,
+		UrlUi:            urlUiVal,
+		state:            attr.ValueStateKnown,
 	}, diags
 }
 
@@ -463,6 +487,24 @@ func NewAllocationsValue(attributeTypes map[string]attr.Type, attributes map[str
 			fmt.Sprintf(`allocation_type expected to be basetypes.StringValue, was: %T`, allocationTypeAttribute))
 	}
 
+	anomalyDetectionAttribute, ok := attributes["anomaly_detection"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`anomaly_detection is missing from object`)
+
+		return NewAllocationsValueUnknown(), diags
+	}
+
+	anomalyDetectionVal, ok := anomalyDetectionAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`anomaly_detection expected to be basetypes.BoolValue, was: %T`, anomalyDetectionAttribute))
+	}
+
 	createTimeAttribute, ok := attributes["create_time"]
 
 	if !ok {
@@ -630,17 +672,18 @@ func NewAllocationsValue(attributeTypes map[string]attr.Type, attributes map[str
 	}
 
 	return AllocationsValue{
-		AllocationType:  allocationTypeVal,
-		CreateTime:      createTimeVal,
-		Description:     descriptionVal,
-		FolderId:        folderIdVal,
-		Id:              idVal,
-		Name:            nameVal,
-		Owner:           ownerVal,
-		AllocationsType: typeVal,
-		UpdateTime:      updateTimeVal,
-		UrlUi:           urlUiVal,
-		state:           attr.ValueStateKnown,
+		AllocationType:   allocationTypeVal,
+		AnomalyDetection: anomalyDetectionVal,
+		CreateTime:       createTimeVal,
+		Description:      descriptionVal,
+		FolderId:         folderIdVal,
+		Id:               idVal,
+		Name:             nameVal,
+		Owner:            ownerVal,
+		AllocationsType:  typeVal,
+		UpdateTime:       updateTimeVal,
+		UrlUi:            urlUiVal,
+		state:            attr.ValueStateKnown,
 	}, diags
 }
 
@@ -712,26 +755,28 @@ func (t AllocationsType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = AllocationsValue{}
 
 type AllocationsValue struct {
-	AllocationType  basetypes.StringValue `tfsdk:"allocation_type"`
-	CreateTime      basetypes.Int64Value  `tfsdk:"create_time"`
-	Description     basetypes.StringValue `tfsdk:"description"`
-	FolderId        basetypes.StringValue `tfsdk:"folder_id"`
-	Id              basetypes.StringValue `tfsdk:"id"`
-	Name            basetypes.StringValue `tfsdk:"name"`
-	Owner           basetypes.StringValue `tfsdk:"owner"`
-	AllocationsType basetypes.StringValue `tfsdk:"type"`
-	UpdateTime      basetypes.Int64Value  `tfsdk:"update_time"`
-	UrlUi           basetypes.StringValue `tfsdk:"url_ui"`
-	state           attr.ValueState
+	AllocationType   basetypes.StringValue `tfsdk:"allocation_type"`
+	AnomalyDetection basetypes.BoolValue   `tfsdk:"anomaly_detection"`
+	CreateTime       basetypes.Int64Value  `tfsdk:"create_time"`
+	Description      basetypes.StringValue `tfsdk:"description"`
+	FolderId         basetypes.StringValue `tfsdk:"folder_id"`
+	Id               basetypes.StringValue `tfsdk:"id"`
+	Name             basetypes.StringValue `tfsdk:"name"`
+	Owner            basetypes.StringValue `tfsdk:"owner"`
+	AllocationsType  basetypes.StringValue `tfsdk:"type"`
+	UpdateTime       basetypes.Int64Value  `tfsdk:"update_time"`
+	UrlUi            basetypes.StringValue `tfsdk:"url_ui"`
+	state            attr.ValueState
 }
 
 func (v AllocationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 10)
+	attrTypes := make(map[string]tftypes.Type, 11)
 
 	var val tftypes.Value
 	var err error
 
 	attrTypes["allocation_type"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["anomaly_detection"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["create_time"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["description"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["folder_id"] = basetypes.StringType{}.TerraformType(ctx)
@@ -746,7 +791,7 @@ func (v AllocationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 10)
+		vals := make(map[string]tftypes.Value, 11)
 
 		val, err = v.AllocationType.ToTerraformValue(ctx)
 
@@ -755,6 +800,14 @@ func (v AllocationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		}
 
 		vals["allocation_type"] = val
+
+		val, err = v.AnomalyDetection.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["anomaly_detection"] = val
 
 		val, err = v.CreateTime.ToTerraformValue(ctx)
 
@@ -858,16 +911,17 @@ func (v AllocationsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 	var diags diag.Diagnostics
 
 	attributeTypes := map[string]attr.Type{
-		"allocation_type": basetypes.StringType{},
-		"create_time":     basetypes.Int64Type{},
-		"description":     basetypes.StringType{},
-		"folder_id":       basetypes.StringType{},
-		"id":              basetypes.StringType{},
-		"name":            basetypes.StringType{},
-		"owner":           basetypes.StringType{},
-		"type":            basetypes.StringType{},
-		"update_time":     basetypes.Int64Type{},
-		"url_ui":          basetypes.StringType{},
+		"allocation_type":   basetypes.StringType{},
+		"anomaly_detection": basetypes.BoolType{},
+		"create_time":       basetypes.Int64Type{},
+		"description":       basetypes.StringType{},
+		"folder_id":         basetypes.StringType{},
+		"id":                basetypes.StringType{},
+		"name":              basetypes.StringType{},
+		"owner":             basetypes.StringType{},
+		"type":              basetypes.StringType{},
+		"update_time":       basetypes.Int64Type{},
+		"url_ui":            basetypes.StringType{},
 	}
 
 	if v.IsNull() {
@@ -881,16 +935,17 @@ func (v AllocationsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"allocation_type": v.AllocationType,
-			"create_time":     v.CreateTime,
-			"description":     v.Description,
-			"folder_id":       v.FolderId,
-			"id":              v.Id,
-			"name":            v.Name,
-			"owner":           v.Owner,
-			"type":            v.AllocationsType,
-			"update_time":     v.UpdateTime,
-			"url_ui":          v.UrlUi,
+			"allocation_type":   v.AllocationType,
+			"anomaly_detection": v.AnomalyDetection,
+			"create_time":       v.CreateTime,
+			"description":       v.Description,
+			"folder_id":         v.FolderId,
+			"id":                v.Id,
+			"name":              v.Name,
+			"owner":             v.Owner,
+			"type":              v.AllocationsType,
+			"update_time":       v.UpdateTime,
+			"url_ui":            v.UrlUi,
 		})
 
 	return objVal, diags
@@ -912,6 +967,10 @@ func (v AllocationsValue) Equal(o attr.Value) bool {
 	}
 
 	if !v.AllocationType.Equal(other.AllocationType) {
+		return false
+	}
+
+	if !v.AnomalyDetection.Equal(other.AnomalyDetection) {
 		return false
 	}
 
@@ -964,15 +1023,16 @@ func (v AllocationsValue) Type(ctx context.Context) attr.Type {
 
 func (v AllocationsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"allocation_type": basetypes.StringType{},
-		"create_time":     basetypes.Int64Type{},
-		"description":     basetypes.StringType{},
-		"folder_id":       basetypes.StringType{},
-		"id":              basetypes.StringType{},
-		"name":            basetypes.StringType{},
-		"owner":           basetypes.StringType{},
-		"type":            basetypes.StringType{},
-		"update_time":     basetypes.Int64Type{},
-		"url_ui":          basetypes.StringType{},
+		"allocation_type":   basetypes.StringType{},
+		"anomaly_detection": basetypes.BoolType{},
+		"create_time":       basetypes.Int64Type{},
+		"description":       basetypes.StringType{},
+		"folder_id":         basetypes.StringType{},
+		"id":                basetypes.StringType{},
+		"name":              basetypes.StringType{},
+		"owner":             basetypes.StringType{},
+		"type":              basetypes.StringType{},
+		"update_time":       basetypes.Int64Type{},
+		"url_ui":            basetypes.StringType{},
 	}
 }

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -4007,8 +4007,8 @@ type Allocation struct {
 	// AllocationType Composition type of allocation.
 	AllocationType *AllocationAllocationType `json:"allocationType,omitempty"`
 
-	// AnomalyDetection Whether anomaly detection is enabled for this allocation.
-	AnomalyDetection nullable.Nullable[bool] `json:"anomalyDetection,omitempty"`
+	// AnomalyDetection Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
+	AnomalyDetection *bool `json:"anomalyDetection,omitempty"`
 
 	// CreateTime The time when the allocation was created (in UNIX timestamp).
 	CreateTime *int64 `json:"createTime,omitempty"`
@@ -4103,6 +4103,9 @@ type AllocationDimensionsTypes string
 type AllocationListItem struct {
 	// AllocationType Composition type of allocation (single or group).
 	AllocationType *AllocationListItemAllocationType `json:"allocationType,omitempty"`
+
+	// AnomalyDetection Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
+	AnomalyDetection *bool `json:"anomalyDetection,omitempty"`
 
 	// CreateTime The time when the allocation was created (in UNIX timestamp).
 	CreateTime *int64 `json:"createTime,omitempty"`
@@ -5936,6 +5939,9 @@ type CreateAccountRoleRequestBody struct {
 
 // CreateAllocationRequest Request body for creating an allocation.
 type CreateAllocationRequest struct {
+	// AnomalyDetection Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
+	AnomalyDetection *bool `json:"anomalyDetection,omitempty"`
+
 	// Description Allocation description.
 	Description string `json:"description"`
 
@@ -8395,6 +8401,9 @@ type TimeSettingsSecondaryCustomTimeRange struct {
 
 // UpdateAllocationRequest Request body for updating an allocation.
 type UpdateAllocationRequest struct {
+	// AnomalyDetection Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.
+	AnomalyDetection *bool `json:"anomalyDetection,omitempty"`
+
 	// Description Allocation description
 	Description nullable.Nullable[string] `json:"description,omitempty"`
 

--- a/internal/provider/planmodifier_null_on_config_null.go
+++ b/internal/provider/planmodifier_null_on_config_null.go
@@ -55,3 +55,37 @@ func (m useEmptyForUnknownWhenConfigNullModifier) PlanModifyString(_ context.Con
 		resp.PlanValue = types.StringValue("")
 	}
 }
+
+// useEmptyForUnknownBoolWhenConfigNull is the Bool analogue of
+// useEmptyForUnknownWhenConfigNull: it proposes the zero value (false) rather
+// than null when the config value is null and a prior state value exists.
+//
+// Use this — not useNullForUnknownBoolWhenConfigNull — when the API clears the
+// field via an explicit false and ignores an explicit null. doit_allocation's
+// anomaly_detection is such a field: PATCH {"anomalyDetection": null} returns
+// 200 but leaves the stored value untouched, while PATCH
+// {"anomalyDetection": false} clears it. Proposing null there would plan a value
+// the API never applies, leaving permanent drift between state and remote.
+//
+// Because the planned value is a known false (not Unknown), the overlay's
+// IsUnknown() guard leaves it in place and the request builder sends it verbatim.
+func useEmptyForUnknownBoolWhenConfigNull() planmodifier.Bool {
+	return useEmptyForUnknownBoolWhenConfigNullModifier{}
+}
+
+type useEmptyForUnknownBoolWhenConfigNullModifier struct{}
+
+func (m useEmptyForUnknownBoolWhenConfigNullModifier) Description(_ context.Context) string {
+	return "Proposes false when the config value is null (omitted or explicitly set) " +
+		"and a prior state value exists, allowing the attribute to be cleared."
+}
+
+func (m useEmptyForUnknownBoolWhenConfigNullModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m useEmptyForUnknownBoolWhenConfigNullModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	if req.ConfigValue.IsNull() && !req.StateValue.IsNull() {
+		resp.PlanValue = types.BoolValue(false)
+	}
+}

--- a/internal/provider/resource_allocation/allocation_resource_gen.go
+++ b/internal/provider/resource_allocation/allocation_resource_gen.go
@@ -28,9 +28,10 @@ func AllocationResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Composition type of allocation.",
 			},
 			"anomaly_detection": schema.BoolAttribute{
+				Optional:            true,
 				Computed:            true,
-				Description:         "Whether anomaly detection is enabled for this allocation.",
-				MarkdownDescription: "Whether anomaly detection is enabled for this allocation.",
+				Description:         "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.",
+				MarkdownDescription: "Whether anomaly detection is enabled for this allocation. Only applicable to single allocations.",
 			},
 			"create_time": schema.Int64Attribute{
 				Computed:            true,


### PR DESCRIPTION
## Summary

- `anomaly_detection` on `doit_allocation` is now `Optional + Computed` (was `Computed`-only), matching the upstream API change that made `anomalyDetection` writable via POST/PATCH.
- Clearing goes through a new `useEmptyForUnknownBoolWhenConfigNull()` plan modifier (bool analogue of the existing string zero-value clearing modifier) — it plans an explicit `false` on omission rather than `null`, because the live API silently ignores an explicit null `anomalyDetection` on PATCH (confirmed by probing prod) but does honor an explicit `false`.
- Added a `resourcevalidator.Conflicting(anomaly_detection, rules)` so setting it on a group allocation fails at plan time instead of hitting the API's 400 (`group allocation can not have 'anomalyDetection' field`).
- Added the new `anomaly_detection` field to the `doit_allocations` list data source mapping (`AllocationListItem` gained the field upstream; the generated `NewAllocationsValue` constructor would otherwise error at runtime on the missing key).
- Fixed a latent overlay bug: `update_time` was assigned unconditionally in `overlayAllocationComputedFields`, which a modifier-triggered update (the new clearing case) exposed as a "provider produced inconsistent result" error. Guarded with `IsUnknown()`, matching the existing pattern in `alert.go`/`annotation.go`/`budget.go`.
- A later upstream fix dropped `nullable: true` from `UpdateAllocationRequest.anomalyDetection` (it was meaningless — the API never treated null as a clear signal). This flipped the generated Go type from `nullable.Nullable[bool]` to `*bool` for `anomalyDetection` across `Allocation`, `CreateAllocationRequest`, and `UpdateAllocationRequest`; updated the four call sites accordingly (now plain pointer handling, no `nullableToPointer`/`valueToNullable`).

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — full unit suite passes
- [x] `make testacc-run` against live API, no reruns needed:
  - `TestAccAllocation_AnomalyDetectionLifecycle` (create/drift/flip/clear-via-omission/drift/import)
  - `TestAccAllocation_AnomalyDetection_OmittedOnCreate`
  - `TestAccAllocation_AnomalyDetection_ConflictsWithRules`
  - `TestAccAllocationDataSource`, `TestAccAllocationsDataSource_MaxResultsOnly` (updated to assert `anomaly_detection`)
  - Regression sweep: `TestAccAllocation`, `TestAccAllocation_Group`, `TestAccAllocation_SingleMinimal`, `TestAccAllocation_GroupUpdate*`, `TestAccAllocation_UnallocatedCosts_*`, `TestAccAllocation_Validation`, `TestAccAllocation_GroupOmittedDefaults`, `TestAccAllocation_Computed_Required_Fields`
- [x] `make docs` regenerated (`anomaly_detection` moved from Read-Only to Optional in `docs/resources/allocation.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)