### PR TITLE
fix(report): handle custom time ranges without a unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### BUG FIXES
 
-- **resource/doit_report, data-source/doit_report**: Fixed a provider crash when reading a report whose `config.time_range` omits `mode` or `unit`. The API now omits `unit` for custom time ranges, which the previous code dereferenced unconditionally. **Users managing reports with a custom time range should upgrade before the upstream API change is deployed**, as an older provider will panic when reading them
+- **resource/doit_report, data-source/doit_report**: Fixed a provider crash when reading a report whose `config.time_range` omits `mode` or `unit`. The API now omits `unit` for custom time ranges, which the previous code dereferenced unconditionally. **Users managing reports with a custom time range should upgrade as soon as possible**, as an older provider will panic when reading them
+- **resource/doit_report, data-source/doit_report_query**: `config.custom_time_range` no longer reports a spurious "Empty Custom Time Range" error when `from`/`to` are computed from another resource or data source. Unknown values are now deferred until they resolve, matching `forecast_settings.future_custom_date_range`
 
 ## v1.6.0 (2026-07-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Unreleased
 
+### BREAKING CHANGES
+
+- **resource/doit_report, data-source/doit_report_query**: Setting `config.time_range.unit` together with `config.time_range.mode = "custom"` is now rejected at plan time. A custom range takes its bounds from `config.custom_time_range`, so the unit has no effect; the upstream API is dropping `unit` from custom-mode responses and rejecting the combination on write. Configurations that specify both — which the API previously required — must remove `unit` from the `time_range` block
+
 ### ENHANCEMENTS
 
 - **resource/doit_allocation**: `anomaly_detection` is now writable on single allocations. Removing it from configuration disables it (the API clears the field with an explicit `false`); it is rejected at plan time when used with group allocations (`rules`)
 - **data-source/doit_allocations**: Added the `anomaly_detection` field to listed allocations
+
+### BUG FIXES
+
+- **resource/doit_report, data-source/doit_report**: Fixed a provider crash when reading a report whose `config.time_range` omits `mode` or `unit`. The API now omits `unit` for custom time ranges, which the previous code dereferenced unconditionally. **Users managing reports with a custom time range should upgrade before the upstream API change is deployed**, as an older provider will panic when reading them
 
 ## v1.6.0 (2026-07-30)
 

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -154,7 +154,6 @@ data "doit_report_query" "anomaly_cost_detail" {
     time_interval = "day"
     time_range = {
       mode = "custom"
-      unit = "day"
       custom_time_range = {
         # start_time / end_time are epoch milliseconds — divide by 1000 for seconds
         from = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor(local.unacknowledged[count.index].start_time / 1000)}s"))

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -27,9 +27,9 @@ data "doit_anomalies" "with_notifications" {
 
 output "notification_audit" {
   value = [for a in data.doit_anomalies.with_notifications.anomalies : {
-    id           = a.id
-    service      = a.service_name
-    severity     = a.severity_level
+    id       = a.id
+    service  = a.service_name
+    severity = a.severity_level
     notifications = [for n in a.notifications : {
       channel   = n.channel
       timestamp = n.timestamp
@@ -149,16 +149,16 @@ data "doit_report_query" "anomaly_cost_detail" {
   count = length(local.unacknowledged)
 
   config = {
-    metrics = [{ type = "basic", value = "cost" }]
+    metrics       = [{ type = "basic", value = "cost" }]
     currency      = "USD"
     time_interval = "day"
+    custom_time_range = {
+      # start_time / end_time are epoch milliseconds — divide by 1000 for seconds
+      from = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor(local.unacknowledged[count.index].start_time / 1000)}s"))
+      to   = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor((local.unacknowledged[count.index].end_time != null ? local.unacknowledged[count.index].end_time : local.unacknowledged[count.index].start_time + 86400000) / 1000)}s"))
+    }
     time_range = {
       mode = "custom"
-      custom_time_range = {
-        # start_time / end_time are epoch milliseconds — divide by 1000 for seconds
-        from = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor(local.unacknowledged[count.index].start_time / 1000)}s"))
-        to   = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor((local.unacknowledged[count.index].end_time != null ? local.unacknowledged[count.index].end_time : local.unacknowledged[count.index].start_time + 86400000) / 1000)}s"))
-      }
     }
     group = [
       { id = "sku_description", type = "fixed" }

--- a/examples/data-sources/doit_anomalies/data-source.tf
+++ b/examples/data-sources/doit_anomalies/data-source.tf
@@ -13,9 +13,9 @@ data "doit_anomalies" "with_notifications" {
 
 output "notification_audit" {
   value = [for a in data.doit_anomalies.with_notifications.anomalies : {
-    id           = a.id
-    service      = a.service_name
-    severity     = a.severity_level
+    id       = a.id
+    service  = a.service_name
+    severity = a.severity_level
     notifications = [for n in a.notifications : {
       channel   = n.channel
       timestamp = n.timestamp
@@ -135,16 +135,16 @@ data "doit_report_query" "anomaly_cost_detail" {
   count = length(local.unacknowledged)
 
   config = {
-    metrics = [{ type = "basic", value = "cost" }]
+    metrics       = [{ type = "basic", value = "cost" }]
     currency      = "USD"
     time_interval = "day"
+    custom_time_range = {
+      # start_time / end_time are epoch milliseconds — divide by 1000 for seconds
+      from = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor(local.unacknowledged[count.index].start_time / 1000)}s"))
+      to   = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor((local.unacknowledged[count.index].end_time != null ? local.unacknowledged[count.index].end_time : local.unacknowledged[count.index].start_time + 86400000) / 1000)}s"))
+    }
     time_range = {
       mode = "custom"
-      custom_time_range = {
-        # start_time / end_time are epoch milliseconds — divide by 1000 for seconds
-        from = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor(local.unacknowledged[count.index].start_time / 1000)}s"))
-        to   = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor((local.unacknowledged[count.index].end_time != null ? local.unacknowledged[count.index].end_time : local.unacknowledged[count.index].start_time + 86400000) / 1000)}s"))
-      }
     }
     group = [
       { id = "sku_description", type = "fixed" }

--- a/examples/data-sources/doit_anomalies/data-source.tf
+++ b/examples/data-sources/doit_anomalies/data-source.tf
@@ -140,7 +140,6 @@ data "doit_report_query" "anomaly_cost_detail" {
     time_interval = "day"
     time_range = {
       mode = "custom"
-      unit = "day"
       custom_time_range = {
         # start_time / end_time are epoch milliseconds — divide by 1000 for seconds
         from = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd("1970-01-01T00:00:00Z", "${floor(local.unacknowledged[count.index].start_time / 1000)}s"))

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -1682,12 +1682,23 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 
 	// Nested Object: TimeRange
 	if config.TimeRange != nil {
+		// mode and unit are nil-guarded rather than dereferenced: the API omits
+		// unit for a custom range, which carries no unit. Mirrors the handling
+		// of SecondaryTimeRange.Unit below.
 		trMap := map[string]attr.Value{
 			"amount":          types.Int64PointerValue(config.TimeRange.Amount),
 			"include_current": types.BoolPointerValue(config.TimeRange.IncludeCurrent),
-			"mode":            types.StringValue(string(*config.TimeRange.Mode)),
-			"unit":            types.StringValue(string(*config.TimeRange.Unit)),
+			"mode":            types.StringNull(),
+			"unit":            types.StringNull(),
 		}
+		if config.TimeRange.Mode != nil {
+			trMap["mode"] = types.StringValue(string(*config.TimeRange.Mode))
+		}
+
+		if config.TimeRange.Unit != nil {
+			trMap["unit"] = types.StringValue(string(*config.TimeRange.Unit))
+		}
+
 		trv, trvDiags := resource_report.NewTimeRangeValue(resource_report.TimeRangeValue{}.AttributeTypes(ctx), trMap)
 		diags.Append(trvDiags...)
 		configMap["time_range"] = trv

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -1682,9 +1682,7 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 
 	// Nested Object: TimeRange
 	if config.TimeRange != nil {
-		// mode and unit are nil-guarded rather than dereferenced: the API omits
-		// unit for a custom range, which carries no unit. Mirrors the handling
-		// of SecondaryTimeRange.Unit below.
+		// mode and unit are nil-guarded: the API omits unit for a custom range.
 		trMap := map[string]attr.Value{
 			"amount":          types.Int64PointerValue(config.TimeRange.Amount),
 			"include_current": types.BoolPointerValue(config.TimeRange.IncludeCurrent),

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -590,9 +590,7 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 
 	// Nested Object: TimeRange
 	if config.TimeRange != nil {
-		// mode and unit are nil-guarded rather than dereferenced: the API omits
-		// unit for a custom range, which carries no unit. Mirrors the handling
-		// of SecondaryTimeRange.Unit below.
+		// mode and unit are nil-guarded: the API omits unit for a custom range.
 		trMap := map[string]attr.Value{
 			"amount":          types.Int64PointerValue(config.TimeRange.Amount),
 			"include_current": types.BoolPointerValue(config.TimeRange.IncludeCurrent),

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -590,11 +590,21 @@ func (ds *reportDataSource) populateState(ctx context.Context, state *reportData
 
 	// Nested Object: TimeRange
 	if config.TimeRange != nil {
+		// mode and unit are nil-guarded rather than dereferenced: the API omits
+		// unit for a custom range, which carries no unit. Mirrors the handling
+		// of SecondaryTimeRange.Unit below.
 		trMap := map[string]attr.Value{
 			"amount":          types.Int64PointerValue(config.TimeRange.Amount),
 			"include_current": types.BoolPointerValue(config.TimeRange.IncludeCurrent),
-			"mode":            types.StringValue(string(*config.TimeRange.Mode)),
-			"unit":            types.StringValue(string(*config.TimeRange.Unit)),
+			"mode":            types.StringNull(),
+			"unit":            types.StringNull(),
+		}
+		if config.TimeRange.Mode != nil {
+			trMap["mode"] = types.StringValue(string(*config.TimeRange.Mode))
+		}
+
+		if config.TimeRange.Unit != nil {
+			trMap["unit"] = types.StringValue(string(*config.TimeRange.Unit))
 		}
 		trv, trvDiags := datasource_report.NewTimeRangeValue(datasource_report.TimeRangeValue{}.AttributeTypes(ctx), trMap)
 		diags.Append(trvDiags...)

--- a/internal/provider/report_external_api_regression_test.go
+++ b/internal/provider/report_external_api_regression_test.go
@@ -1,24 +1,10 @@
-// Regression tests for two bugs in the external Cloud Analytics API
-// (`/analytics/v1/...`), the surface this provider talks to.
+// Acceptance coverage for two behaviours of the external Cloud Analytics API:
+// custom time ranges, which carry no `unit`, and multi-metric queries, which
+// must return one column per requested metric.
 //
-// Tracked upstream as CMP-49333 (follow-up to CMP-47539), fixed by
-// doiteng/omni#60621. Until that fix is deployed, every test in this file
-// except the *WithUnit control is expected to FAIL against the live API:
-//
-//  1. `timeRange.mode = "custom"` without a `unit` is rejected, because
-//     TimeSettings.Validate() requires a unit for every mode. The provider
-//     omits `unit` from the payload when it is not configured, and the
-//     OpenAPI spec marks none of the timeRange fields required — so this is
-//     a spec-legal request the API refuses. Reaches both the report resource
-//     (create/update) and the report_query data source, since both flow
-//     through MergeConfigWithExternalConfig.
-//
-//  2. Queries requesting several metrics return only the first metric's
-//     column. ExternalAPIService.ProcessResult extracted a single metric via
-//     GetMetricIndex / GetFirstConfigMetric, so the remaining columns were
-//     dropped from both `schema` and `rows` with no error. Reaches
-//     report_query and report_result, the two data sources whose responses
-//     are built by ProcessResult.
+// Each spans two provider surfaces — custom ranges reach the report resource
+// and doit_report_query; multi-metric results reach doit_report_query and
+// doit_report_result — so both are asserted on each surface.
 package provider_test
 
 import (
@@ -34,12 +20,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
-// --- Bug 1: custom time range without a unit ---
+// --- Custom time ranges ---
 
-// TestAccReportQueryDataSource_CustomTimeRangeWithoutUnit runs an ad-hoc query
-// over an explicit date range, specifying only mode = "custom" in time_range.
-// unit is left unset, which is what a user writing a custom range would
-// naturally do: for a custom range the unit carries no meaning.
+// TestAccReportQueryDataSource_CustomTimeRangeWithoutUnit asserts an ad-hoc
+// query over an explicit date range succeeds with only mode = "custom" set, no
+// unit configured.
 func TestAccReportQueryDataSource_CustomTimeRangeWithoutUnit(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
@@ -63,12 +48,9 @@ func TestAccReportQueryDataSource_CustomTimeRangeWithoutUnit(t *testing.T) {
 	})
 }
 
-// TestAccReportQueryDataSource_CustomTimeRangeUnitRejected covers the other
-// half of the pair: supplying a unit alongside mode = "custom" is refused at
-// plan time by reportCustomTimeRangeUnitValidator, so the request is never
-// made. The API rejects the combination and omits unit from custom-mode
-// responses; catching it here turns that 400 into an actionable error and
-// avoids a configured value diffing forever against an absent one.
+// TestAccReportQueryDataSource_CustomTimeRangeUnitRejected asserts
+// reportCustomTimeRangeUnitValidator refuses a unit alongside mode = "custom"
+// at plan time, so no request is made.
 func TestAccReportQueryDataSource_CustomTimeRangeUnitRejected(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
@@ -83,8 +65,8 @@ func TestAccReportQueryDataSource_CustomTimeRangeUnitRejected(t *testing.T) {
 	})
 }
 
-// TestAccReport_CustomTimeRangeUnitRejected is the resource-side counterpart,
-// confirming the validator is wired into both surfaces.
+// TestAccReport_CustomTimeRangeUnitRejected asserts the same rejection on the
+// resource, confirming the validator is wired into both surfaces.
 func TestAccReport_CustomTimeRangeUnitRejected(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
@@ -99,13 +81,9 @@ func TestAccReport_CustomTimeRangeUnitRejected(t *testing.T) {
 	})
 }
 
-// TestAccReport_CustomTimeRangeWithoutUnit covers the same missing-unit payload
-// on the resource path (POST/PATCH /analytics/v1/reports) rather than the query
-// path. The second step re-applies to check for drift: once the API accepts the
-// request, timeRange serializes `unit` unconditionally, so a custom-mode report
-// created without a unit is expected to read back as unit = "" — an
-// Optional+Computed value outside the attribute's own enum. The drift step is
-// what will show whether that round-trips stably.
+// TestAccReport_CustomTimeRangeWithoutUnit asserts a report with a custom range
+// and no unit is created, that the unit the API omits from its response reads
+// back as null, and that the pair round-trips without drift.
 func TestAccReport_CustomTimeRangeWithoutUnit(t *testing.T) {
 	n := acctest.RandInt()
 
@@ -126,6 +104,12 @@ func TestAccReport_CustomTimeRangeWithoutUnit(t *testing.T) {
 						"doit_report.custom_range",
 						tfjsonpath.New("config").AtMapKey("time_range").AtMapKey("mode"),
 						knownvalue.StringExact("custom")),
+					// The API omits unit for a custom range; the mapper records
+					// the absent field as null rather than dereferencing it.
+					statecheck.ExpectKnownValue(
+						"doit_report.custom_range",
+						tfjsonpath.New("config").AtMapKey("time_range").AtMapKey("unit"),
+						knownvalue.Null()),
 					statecheck.ExpectKnownValue(
 						"doit_report.custom_range",
 						tfjsonpath.New("config").AtMapKey("custom_time_range").AtMapKey("from"),
@@ -145,14 +129,13 @@ func TestAccReport_CustomTimeRangeWithoutUnit(t *testing.T) {
 	})
 }
 
-// --- Bug 2: multi-metric queries drop every metric after the first ---
+// --- Multi-metric queries ---
 
-// TestAccReportQueryDataSource_MultiMetricReturnsAllColumns asks for two
-// metrics and asserts both reach the result. The live schema for this config is
-// [year, month, cost, usage, timestamp] — the trailing timestamp column is
-// appended for the datetime dimensions, so the width is compared against the
-// schema rather than pinned to a literal. With the bug, `usage` was absent from
-// both schema and rows.
+// TestAccReportQueryDataSource_MultiMetricReturnsAllColumns asserts every
+// requested metric reaches the result. The schema for this config is
+// [year, month, cost, usage, timestamp], the trailing timestamp column being
+// appended for the datetime dimensions, so row width is compared against the
+// schema rather than a literal.
 func TestAccReportQueryDataSource_MultiMetricReturnsAllColumns(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
@@ -162,12 +145,11 @@ func TestAccReportQueryDataSource_MultiMetricReturnsAllColumns(t *testing.T) {
 			{
 				Config: testAccReportQueryMultiMetricConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// Metric columns present, in the order requested. This is
-					// the assertion that detects the dropped metric.
+					// Both metric columns present, in the order requested.
 					resource.TestCheckOutput("query_metric_columns", "cost,usage"),
-					// Guards a partial fix where schema gains a column but rows
-					// do not. "no_rows" means the query returned nothing, which
-					// would make this inconclusive rather than passing.
+					// Row width matches the schema, so a schema column without a
+					// corresponding cell fails. "no_rows" marks the check
+					// inconclusive rather than passing it.
 					resource.TestCheckOutput("query_row_matches_schema", "true"),
 				),
 			},
@@ -175,11 +157,10 @@ func TestAccReportQueryDataSource_MultiMetricReturnsAllColumns(t *testing.T) {
 	})
 }
 
-// TestAccReportResultDataSource_MultiMetricReturnsAllColumns covers the other
-// ProcessResult caller: reading a saved two-metric report's results via
-// GET /analytics/v1/reports/{id}. Only the metric column names are asserted,
-// since the report config pins no dimensions and the API supplies its own —
-// making the total column count unpredictable.
+// TestAccReportResultDataSource_MultiMetricReturnsAllColumns asserts the same
+// for a saved report read through doit_report_result. Only the metric column
+// names are checked: the config pins no dimensions, so the API supplies its own
+// and the total column count is not predictable.
 func TestAccReportResultDataSource_MultiMetricReturnsAllColumns(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-rr-multimetric")
 
@@ -200,9 +181,9 @@ func TestAccReportResultDataSource_MultiMetricReturnsAllColumns(t *testing.T) {
 
 // --- Test config helpers ---
 
-// testAccReportQueryCustomTimeRangeConfig builds a custom-range query. extraTimeRange
-// is injected into the time_range block so the same config serves both the
-// unit-less case and the control that supplies a unit.
+// testAccReportQueryCustomTimeRangeConfig builds a custom-range query.
+// extraTimeRange is injected into the time_range block so one config serves both
+// the unit-less and unit-present cases.
 func testAccReportQueryCustomTimeRangeConfig(extraTimeRange string) string {
 	return fmt.Sprintf(`
 data "doit_report_query" "test" {
@@ -233,8 +214,7 @@ data "doit_report_query" "test" {
 }
 
 // testAccReportCustomTimeRangeWithUnit is the config the validator must refuse:
-// a custom range with a unit still present, as configs written against the old
-// API (which required one) look today.
+// a custom range with a unit set.
 func testAccReportCustomTimeRangeWithUnit(i int) string {
 	return fmt.Sprintf(`
 resource "doit_report" "custom_range_unit" {

--- a/internal/provider/report_external_api_regression_test.go
+++ b/internal/provider/report_external_api_regression_test.go
@@ -1,0 +1,399 @@
+// Regression tests for two bugs in the external Cloud Analytics API
+// (`/analytics/v1/...`), the surface this provider talks to.
+//
+// Tracked upstream as CMP-49333 (follow-up to CMP-47539), fixed by
+// doiteng/omni#60621. Until that fix is deployed, every test in this file
+// except the *WithUnit control is expected to FAIL against the live API:
+//
+//  1. `timeRange.mode = "custom"` without a `unit` is rejected, because
+//     TimeSettings.Validate() requires a unit for every mode. The provider
+//     omits `unit` from the payload when it is not configured, and the
+//     OpenAPI spec marks none of the timeRange fields required — so this is
+//     a spec-legal request the API refuses. Reaches both the report resource
+//     (create/update) and the report_query data source, since both flow
+//     through MergeConfigWithExternalConfig.
+//
+//  2. Queries requesting several metrics return only the first metric's
+//     column. ExternalAPIService.ProcessResult extracted a single metric via
+//     GetMetricIndex / GetFirstConfigMetric, so the remaining columns were
+//     dropped from both `schema` and `rows` with no error. Reaches
+//     report_query and report_result, the two data sources whose responses
+//     are built by ProcessResult.
+package provider_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// --- Bug 1: custom time range without a unit ---
+
+// TestAccReportQueryDataSource_CustomTimeRangeWithoutUnit runs an ad-hoc query
+// over an explicit date range, specifying only mode = "custom" in time_range.
+// unit is left unset, which is what a user writing a custom range would
+// naturally do: for a custom range the unit carries no meaning.
+func TestAccReportQueryDataSource_CustomTimeRangeWithoutUnit(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportQueryCustomTimeRangeConfig(""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.doit_report_query.test",
+						tfjsonpath.New("result_json"),
+						knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(
+						"data.doit_report_query.test",
+						tfjsonpath.New("row_count"),
+						knownvalue.NotNull()),
+				},
+			},
+		},
+	})
+}
+
+// TestAccReportQueryDataSource_CustomTimeRangeUnitRejected covers the other
+// half of the pair: supplying a unit alongside mode = "custom" is refused at
+// plan time by reportCustomTimeRangeUnitValidator, so the request is never
+// made. The API rejects the combination and omits unit from custom-mode
+// responses; catching it here turns that 400 into an actionable error and
+// avoids a configured value diffing forever against an absent one.
+func TestAccReportQueryDataSource_CustomTimeRangeUnitRejected(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccReportQueryCustomTimeRangeConfig(`unit = "day"`),
+				ExpectError: regexp.MustCompile(`Invalid Time Range Configuration`),
+			},
+		},
+	})
+}
+
+// TestAccReport_CustomTimeRangeUnitRejected is the resource-side counterpart,
+// confirming the validator is wired into both surfaces.
+func TestAccReport_CustomTimeRangeUnitRejected(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccReportCustomTimeRangeWithUnit(acctest.RandInt()),
+				ExpectError: regexp.MustCompile(`unit.*must not be set when|Invalid Time Range Configuration`),
+			},
+		},
+	})
+}
+
+// TestAccReport_CustomTimeRangeWithoutUnit covers the same missing-unit payload
+// on the resource path (POST/PATCH /analytics/v1/reports) rather than the query
+// path. The second step re-applies to check for drift: once the API accepts the
+// request, timeRange serializes `unit` unconditionally, so a custom-mode report
+// created without a unit is expected to read back as unit = "" — an
+// Optional+Computed value outside the attribute's own enum. The drift step is
+// what will show whether that round-trips stably.
+func TestAccReport_CustomTimeRangeWithoutUnit(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportCustomTimeRangeWithoutUnit(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_report.custom_range",
+						tfjsonpath.New("config").AtMapKey("time_range").AtMapKey("mode"),
+						knownvalue.StringExact("custom")),
+					statecheck.ExpectKnownValue(
+						"doit_report.custom_range",
+						tfjsonpath.New("config").AtMapKey("custom_time_range").AtMapKey("from"),
+						knownvalue.StringExact("2026-07-27T00:00:00Z")),
+				},
+			},
+			// Drift check.
+			{
+				Config: testAccReportCustomTimeRangeWithoutUnit(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// --- Bug 2: multi-metric queries drop every metric after the first ---
+
+// TestAccReportQueryDataSource_MultiMetricReturnsAllColumns asks for two
+// metrics and asserts both reach the result. The live schema for this config is
+// [year, month, cost, usage, timestamp] — the trailing timestamp column is
+// appended for the datetime dimensions, so the width is compared against the
+// schema rather than pinned to a literal. With the bug, `usage` was absent from
+// both schema and rows.
+func TestAccReportQueryDataSource_MultiMetricReturnsAllColumns(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportQueryMultiMetricConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Metric columns present, in the order requested. This is
+					// the assertion that detects the dropped metric.
+					resource.TestCheckOutput("query_metric_columns", "cost,usage"),
+					// Guards a partial fix where schema gains a column but rows
+					// do not. "no_rows" means the query returned nothing, which
+					// would make this inconclusive rather than passing.
+					resource.TestCheckOutput("query_row_matches_schema", "true"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccReportResultDataSource_MultiMetricReturnsAllColumns covers the other
+// ProcessResult caller: reading a saved two-metric report's results via
+// GET /analytics/v1/reports/{id}. Only the metric column names are asserted,
+// since the report config pins no dimensions and the API supplies its own —
+// making the total column count unpredictable.
+func TestAccReportResultDataSource_MultiMetricReturnsAllColumns(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-rr-multimetric")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportResultMultiMetricConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("result_metric_columns", "cost,usage"),
+				),
+			},
+		},
+	})
+}
+
+// --- Test config helpers ---
+
+// testAccReportQueryCustomTimeRangeConfig builds a custom-range query. extraTimeRange
+// is injected into the time_range block so the same config serves both the
+// unit-less case and the control that supplies a unit.
+func testAccReportQueryCustomTimeRangeConfig(extraTimeRange string) string {
+	return fmt.Sprintf(`
+data "doit_report_query" "test" {
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "day"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        custom_time_range = {
+          from = "2026-07-27T00:00:00Z"
+          to   = "2026-07-29T00:00:00Z"
+        }
+        time_range = {
+          mode = "custom"
+          %s
+        }
+    }
+}
+`, extraTimeRange)
+}
+
+// testAccReportCustomTimeRangeWithUnit is the config the validator must refuse:
+// a custom range with a unit still present, as configs written against the old
+// API (which required one) look today.
+func testAccReportCustomTimeRangeWithUnit(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "custom_range_unit" {
+    name        = "test-custom-range-with-unit-%d"
+    description = "custom time range with a unit that must be rejected at plan time"
+    config = {
+        metrics = [{ type = "basic", value = "cost" }]
+        aggregation    = "total"
+        time_interval  = "day"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        custom_time_range = {
+          from = "2026-07-27T00:00:00Z"
+          to   = "2026-07-29T00:00:00Z"
+        }
+        time_range = {
+          mode = "custom"
+          unit = "day"
+        }
+    }
+}
+`, i)
+}
+
+func testAccReportCustomTimeRangeWithoutUnit(i int) string {
+	return fmt.Sprintf(`
+resource "doit_report" "custom_range" {
+    name        = "test-custom-range-no-unit-%d"
+    description = "custom time range with no unit in time_range"
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "day"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        custom_time_range = {
+          from = "2026-07-27T00:00:00Z"
+          to   = "2026-07-29T00:00:00Z"
+        }
+        # unit deliberately omitted — it is meaningless for a custom range.
+        time_range = {
+          mode = "custom"
+        }
+    }
+}
+`, i)
+}
+
+func testAccReportQueryMultiMetricConfig() string {
+	return `
+data "doit_report_query" "test" {
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          },
+          {
+            type  = "basic"
+            value = "usage"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode            = "last"
+          amount          = 3
+          unit            = "month"
+          include_current = false
+        }
+        dimensions = [
+          {
+            id   = "year"
+            type = "datetime"
+          },
+          {
+            id   = "month"
+            type = "datetime"
+          }
+        ]
+    }
+}
+
+locals {
+  query_result = jsondecode(data.doit_report_query.test.result_json)
+}
+
+output "query_metric_columns" {
+  value = join(",", [
+    for field in local.query_result.schema : field.name
+    if contains(["cost", "usage"], field.name)
+  ])
+}
+
+output "query_row_matches_schema" {
+  value = length(local.query_result.rows) == 0 ? "no_rows" : tostring(
+    length(local.query_result.rows[0]) == length(local.query_result.schema)
+  )
+}
+`
+}
+
+func testAccReportResultMultiMetricConfig(name string) string {
+	return fmt.Sprintf(`
+resource "doit_report" "multi_metric" {
+    name        = %q
+    description = "two-metric report read back through report_result"
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          },
+          {
+            type  = "basic"
+            value = "usage"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode            = "last"
+          amount          = 3
+          unit            = "month"
+          include_current = false
+        }
+    }
+}
+
+data "doit_report_result" "multi_metric" {
+    id = doit_report.multi_metric.id
+}
+
+locals {
+  result_payload = jsondecode(data.doit_report_result.multi_metric.result_json)
+}
+
+output "result_metric_columns" {
+  value = join(",", [
+    for field in local.result_payload.schema : field.name
+    if contains(["cost", "usage"], field.name)
+  ])
+}
+`, name)
+}

--- a/internal/provider/report_query_data_source.go
+++ b/internal/provider/report_query_data_source.go
@@ -171,6 +171,7 @@ func (d *reportQueryDataSource) Configure(_ context.Context, req datasource.Conf
 // resource schema (which now marks them Required).
 func (d *reportQueryDataSource) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
 	validateReportCountAggregation(ctx, req.Config, &resp.Diagnostics)
+	validateReportCustomTimeRangeUnit(ctx, req.Config, &resp.Diagnostics)
 }
 
 func (d *reportQueryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/provider/report_resource.go
+++ b/internal/provider/report_resource.go
@@ -250,6 +250,8 @@ func (r *reportResource) ConfigValidators(_ context.Context) []resource.ConfigVa
 		reportTimestampValidator{},
 		// count is only valid when aggregation is "count".
 		reportCountAggregationValidator{},
+		// unit has no meaning when time_range.mode is "custom".
+		reportCustomTimeRangeUnitValidator{},
 		// Warn when legacy [... N/A] NullFallback sentinels are used in filter values.
 		reportFilterNAValidator{},
 	}

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -1708,6 +1708,75 @@ resource "doit_report" "secondary_update" {
 `, i)
 }
 
+// TestAccReport_CustomTimeRange_ComputedTimestamps verifies that
+// reportTimestampValidator defers on unknown from/to rather than treating them
+// as empty. custom_time_range values are commonly derived from another resource
+// or data source, which makes them unknown at plan time; rejecting that as an
+// "Empty Custom Time Range" would block a legitimate config outright.
+func TestAccReport_CustomTimeRange_ComputedTimestamps(t *testing.T) {
+	n := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportComputedCustomTimeRange(n),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"doit_report.computed_range",
+						tfjsonpath.New("config").AtMapKey("custom_time_range").AtMapKey("from"),
+						knownvalue.StringExact("2026-07-27T00:00:00Z")),
+				},
+			},
+			// Drift check.
+			{
+				Config: testAccReportComputedCustomTimeRange(n),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportComputedCustomTimeRange(i int) string {
+	return fmt.Sprintf(`
+# terraform_data yields values that are unknown during plan, mirroring
+# timestamps derived from another resource or data source.
+resource "terraform_data" "range_%[1]d" {
+    input = {
+        from = "2026-07-27T00:00:00Z"
+        to   = "2026-07-29T00:00:00Z"
+    }
+}
+
+resource "doit_report" "computed_range" {
+    name        = "test-computed-range-%[1]d"
+    description = "custom_time_range built from computed values"
+    config = {
+        metrics = [{ type = "basic", value = "cost" }]
+        aggregation    = "total"
+        time_interval  = "day"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        custom_time_range = {
+            from = terraform_data.range_%[1]d.output.from
+            to   = terraform_data.range_%[1]d.output.to
+        }
+        time_range = {
+            mode = "custom"
+        }
+    }
+}
+`, i)
+}
+
 // TestAccReport_InvalidTimestamp verifies that invalid RFC3339 timestamps in
 // custom_time_range.from are caught at plan time by the reportTimestampValidator,
 // rather than waiting for API rejection at apply time.

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -1708,11 +1708,10 @@ resource "doit_report" "secondary_update" {
 `, i)
 }
 
-// TestAccReport_CustomTimeRange_ComputedTimestamps verifies that
+// TestAccReport_CustomTimeRange_ComputedTimestamps asserts
 // reportTimestampValidator defers on unknown from/to rather than treating them
-// as empty. custom_time_range values are commonly derived from another resource
-// or data source, which makes them unknown at plan time; rejecting that as an
-// "Empty Custom Time Range" would block a legitimate config outright.
+// as empty, so a custom_time_range derived from another resource or data source
+// validates once its values resolve.
 func TestAccReport_CustomTimeRange_ComputedTimestamps(t *testing.T) {
 	n := acctest.RandInt()
 

--- a/internal/provider/report_resource_test.go
+++ b/internal/provider/report_resource_test.go
@@ -434,7 +434,6 @@ resource "doit_report" "this" {
 		}
 		time_range = {
 			mode = "custom"
-			unit = "day"
 		}
 		advanced_analysis = {
 		  trending_up   = true
@@ -705,7 +704,6 @@ resource "doit_report" "timezone_test" {
 		}
 		time_range = {
 			mode = "custom"
-			unit = "day"
 		}
 		data_source    = "billing"
 		display_values = "actuals_only"
@@ -1488,7 +1486,6 @@ resource "doit_report" "secondary_custom" {
         }
         time_range = {
           mode = "custom"
-          unit = "day"
         }
         secondary_time_range = {
           custom_time_range = {
@@ -1560,7 +1557,6 @@ resource "doit_report" "secondary_offset" {
         }
         time_range = {
           mode = "custom"
-          unit = "day"
         }
         secondary_time_range = {
           custom_time_range = {
@@ -1696,7 +1692,6 @@ resource "doit_report" "secondary_update" {
         }
         time_range = {
           mode = "custom"
-          unit = "day"
         }
         secondary_time_range = {
           custom_time_range = {
@@ -1749,7 +1744,6 @@ resource "doit_report" "invalid_ts" {
     }
     time_range = {
       mode = "custom"
-      unit = "day"
     }
     data_source    = "billing"
     display_values = "actuals_only"
@@ -1795,7 +1789,6 @@ resource "doit_report" "invalid_sec_ts" {
     }
     time_range = {
       mode = "custom"
-      unit = "day"
     }
     secondary_time_range = {
       custom_time_range = {
@@ -3489,7 +3482,6 @@ resource "doit_report" "forecast_custom_test" {
 		time_interval = "month"
 		time_range = {
 			mode = "custom"
-			unit = "day"
 		}
 		custom_time_range = {
 			from = "2023-01-01T00:00:00-05:00"
@@ -3674,7 +3666,6 @@ resource "doit_report" "forecast_intervals_test" {
 		time_interval = "month"
 		time_range = {
 			mode = "custom"
-			unit = "day"
 		}
 		custom_time_range = {
 			from = "2023-01-01T00:00:00-05:00"
@@ -3723,7 +3714,6 @@ resource "doit_report" "forecast_invalid" {
 		time_interval = "month"
 		time_range = {
 			mode = "custom"
-			unit = "day"
 		}
 		custom_time_range = {
 			from = "2023-01-01T00:00:00Z"
@@ -3762,7 +3752,6 @@ resource "doit_report" "forecast_empty" {
 		time_interval = "month"
 		time_range = {
 			mode = "custom"
-			unit = "day"
 		}
 		custom_time_range = {
 			from = "2023-01-01T00:00:00Z"
@@ -5587,7 +5576,6 @@ resource "doit_report" "ctr_clear" {
         layout         = "table"
         time_range = {
             mode = "custom"
-            unit = "day"
         }
         custom_time_range = {
             from = "2024-01-01T00:00:00Z"
@@ -5951,7 +5939,6 @@ resource "doit_report" "str_clear" {
         time_interval = "month"
         time_range = {
             mode = "custom"
-            unit = "day"
         }
         custom_time_range = {
             from = "2024-01-01T00:00:00Z"
@@ -5985,7 +5972,6 @@ resource "doit_report" "str_clear" {
         time_interval = "month"
         time_range = {
             mode = "custom"
-            unit = "day"
         }
         custom_time_range = {
             from = "2024-01-01T00:00:00Z"

--- a/internal/provider/report_time_range_nil_safety_internal_test.go
+++ b/internal/provider/report_time_range_nil_safety_internal_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 )
 
-// The API omits config.timeRange.unit when a report has no unit — a custom
-// range carries none, since its bounds come from customTimeRange. mode is
-// always sent today, but is guarded the same way so the pair cannot drift.
-// Both mappers must render the absent field as null instead of dereferencing
-// it, which would panic the provider on every read of such a report.
+// The API omits config.timeRange.unit for a custom range, whose bounds come
+// from customTimeRange instead. Both mappers must render an omitted mode or
+// unit as null rather than dereferencing it.
 func TestMapReportToModel_TimeRangeNilModeAndUnit(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/provider/report_time_range_nil_safety_internal_test.go
+++ b/internal/provider/report_time_range_nil_safety_internal_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+)
+
+// The API omits config.timeRange.unit when a report has no unit — a custom
+// range carries none, since its bounds come from customTimeRange. mode is
+// always sent today, but is guarded the same way so the pair cannot drift.
+// Both mappers must render the absent field as null instead of dereferencing
+// it, which would panic the provider on every read of such a report.
+func TestMapReportToModel_TimeRangeNilModeAndUnit(t *testing.T) {
+	ctx := context.Background()
+
+	customMode := models.TimeSettingsMode("custom")
+	amount := int64(0)
+
+	tests := []struct {
+		name         string
+		timeRange    *models.TimeSettings
+		wantModeNull bool
+		wantUnitNull bool
+		wantMode     string
+	}{
+		{
+			name:         "unit omitted for a custom range",
+			timeRange:    &models.TimeSettings{Mode: &customMode, Amount: &amount},
+			wantUnitNull: true,
+			wantMode:     "custom",
+		},
+		{
+			name:         "mode and unit both omitted",
+			timeRange:    &models.TimeSettings{Amount: &amount},
+			wantModeNull: true,
+			wantUnitNull: true,
+		},
+		{
+			name: "both populated",
+			timeRange: &models.TimeSettings{
+				Mode:   &customMode,
+				Amount: &amount,
+				Unit:   func() *models.TimeSettingsUnit { u := models.TimeSettingsUnit("day"); return &u }(),
+			},
+			wantMode: "custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &models.ExternalReport{
+				Config: &models.ExternalConfig{TimeRange: tt.timeRange},
+			}
+
+			// Resource mapper.
+			state := &reportResourceModel{}
+			if diags := mapReportToModel(ctx, resp, state); diags.HasError() {
+				t.Fatalf("mapReportToModel returned errors: %v", diags)
+			}
+
+			tr := state.Config.TimeRange
+
+			if got := tr.Unit.IsNull(); got != tt.wantUnitNull {
+				t.Errorf("resource unit IsNull() = %v, want %v", got, tt.wantUnitNull)
+			}
+
+			if got := tr.Mode.IsNull(); got != tt.wantModeNull {
+				t.Errorf("resource mode IsNull() = %v, want %v", got, tt.wantModeNull)
+			}
+
+			if !tt.wantModeNull && tr.Mode.ValueString() != tt.wantMode {
+				t.Errorf("resource mode = %q, want %q", tr.Mode.ValueString(), tt.wantMode)
+			}
+
+			// Data source mapper — same response, separate code path.
+			ds := &reportDataSource{}
+			dsState := &reportDataSourceModel{}
+			if diags := ds.populateState(ctx, dsState, resp); diags.HasError() {
+				t.Fatalf("populateState returned errors: %v", diags)
+			}
+
+			dsTR := dsState.Config.TimeRange
+
+			if got := dsTR.Unit.IsNull(); got != tt.wantUnitNull {
+				t.Errorf("data source unit IsNull() = %v, want %v", got, tt.wantUnitNull)
+			}
+
+			if got := dsTR.Mode.IsNull(); got != tt.wantModeNull {
+				t.Errorf("data source mode IsNull() = %v, want %v", got, tt.wantModeNull)
+			}
+		})
+	}
+}

--- a/internal/provider/report_validator.go
+++ b/internal/provider/report_validator.go
@@ -339,6 +339,65 @@ func (v reportCountAggregationValidator) ValidateResource(ctx context.Context, r
 	validateReportCountAggregation(ctx, req.Config, &resp.Diagnostics)
 }
 
+// reportCustomTimeRangeUnitValidator rejects time_range.unit alongside
+// time_range.mode = "custom". Same rationale as reportCountAggregationValidator
+// for being a ConfigValidator rather than an attribute validator: attribute
+// validators do not run on attributes inside a SingleNestedAttribute with a
+// CustomType.
+type reportCustomTimeRangeUnitValidator struct{}
+
+var _ resource.ConfigValidator = reportCustomTimeRangeUnitValidator{}
+
+func (v reportCustomTimeRangeUnitValidator) Description(_ context.Context) string {
+	return "Validates that unit is not set when time_range.mode is \"custom\""
+}
+
+func (v reportCustomTimeRangeUnitValidator) MarkdownDescription(_ context.Context) string {
+	return "Validates that `unit` is not set when `time_range.mode` is `\"custom\"`"
+}
+
+func (v reportCustomTimeRangeUnitValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	validateReportCustomTimeRangeUnit(ctx, req.Config, &resp.Diagnostics)
+}
+
+// validateReportCustomTimeRangeUnit enforces that time_range.unit is absent when
+// mode is "custom". A custom range takes its bounds from custom_time_range, so
+// the unit carries no meaning there; the API rejects the combination and omits
+// unit from custom-mode responses, which would otherwise leave the configured
+// value permanently diffed against an absent one. Catching it at plan time turns
+// an API 400 into an actionable error. Unknown values are deferred, since they
+// may resolve to a valid combination.
+func validateReportCustomTimeRangeUnit(ctx context.Context, config tfsdk.Config, diags *diag.Diagnostics) {
+	var timeRange resource_report.TimeRangeValue
+	d := config.GetAttribute(ctx, path.Root("config").AtName("time_range"), &timeRange)
+	diags.Append(d...)
+
+	if d.HasError() || timeRange.IsNull() || timeRange.IsUnknown() {
+		return
+	}
+
+	if timeRange.Mode.IsUnknown() || timeRange.Unit.IsUnknown() {
+		return
+	}
+
+	if timeRange.Mode.IsNull() || timeRange.Mode.ValueString() != "custom" {
+		return
+	}
+
+	if timeRange.Unit.IsNull() {
+		return
+	}
+
+	diags.AddAttributeError(
+		path.Root("config").AtName("time_range").AtName("unit"),
+		"Invalid Time Range Configuration",
+		fmt.Sprintf("`unit` must not be set when `time_range.mode` is \"custom\", but it is %q. "+
+			"A custom range takes its bounds from `custom_time_range`, so `unit` has no effect "+
+			"and the API rejects the combination. Remove `unit` from the `time_range` block.",
+			timeRange.Unit.ValueString()),
+	)
+}
+
 // validateReportCountAggregation is the shared body used by both the report
 // resource and the report_query data source, which build the same ExternalConfig
 // from an identical schema. It enforces the count/aggregation coupling in both

--- a/internal/provider/report_validator.go
+++ b/internal/provider/report_validator.go
@@ -342,10 +342,9 @@ func (v reportCountAggregationValidator) ValidateResource(ctx context.Context, r
 }
 
 // reportCustomTimeRangeUnitValidator rejects time_range.unit alongside
-// time_range.mode = "custom". Same rationale as reportCountAggregationValidator
-// for being a ConfigValidator rather than an attribute validator: attribute
-// validators do not run on attributes inside a SingleNestedAttribute with a
-// CustomType.
+// time_range.mode = "custom". A ConfigValidator rather than an attribute
+// validator because attribute validators do not run on attributes inside a
+// SingleNestedAttribute with a CustomType.
 type reportCustomTimeRangeUnitValidator struct{}
 
 var _ resource.ConfigValidator = reportCustomTimeRangeUnitValidator{}
@@ -363,12 +362,10 @@ func (v reportCustomTimeRangeUnitValidator) ValidateResource(ctx context.Context
 }
 
 // validateReportCustomTimeRangeUnit enforces that time_range.unit is absent when
-// mode is "custom". A custom range takes its bounds from custom_time_range, so
-// the unit carries no meaning there; the API rejects the combination and omits
-// unit from custom-mode responses, which would otherwise leave the configured
-// value permanently diffed against an absent one. Catching it at plan time turns
-// an API 400 into an actionable error. Unknown values are deferred, since they
-// may resolve to a valid combination.
+// mode is "custom": a custom range takes its bounds from custom_time_range, and
+// the API both rejects the combination and omits unit from custom-mode
+// responses. Shared by the report resource and the report_query data source.
+// Unknown values are deferred, since they may resolve to a valid combination.
 func validateReportCustomTimeRangeUnit(ctx context.Context, config tfsdk.Config, diags *diag.Diagnostics) {
 	var timeRange resource_report.TimeRangeValue
 	d := config.GetAttribute(ctx, path.Root("config").AtName("time_range"), &timeRange)

--- a/internal/provider/report_validator.go
+++ b/internal/provider/report_validator.go
@@ -231,9 +231,11 @@ func validateReportTimestamps(ctx context.Context, config tfsdk.Config, diags *d
 		if d.HasError() || ctr.IsNull() || ctr.IsUnknown() {
 			continue
 		}
-		fromEmpty := ctr.From.IsNull() || ctr.From.IsUnknown()
-		toEmpty := ctr.To.IsNull() || ctr.To.IsUnknown()
-		if fromEmpty && toEmpty {
+		if ctr.From.IsUnknown() || ctr.To.IsUnknown() {
+			continue // defer validation until values are known
+		}
+
+		if ctr.From.IsNull() && ctr.To.IsNull() {
 			diags.AddAttributeError(
 				p,
 				"Empty Custom Time Range",


### PR DESCRIPTION
## Summary

Adapts the provider to how the external Cloud Analytics API now treats `timeRange.unit` for custom time ranges (CMP-49333; upstream [doiteng/omni#60621](https://github.com/doiteng/omni/pull/60621), already deployed, and [#60646](https://github.com/doiteng/omni/pull/60646), pending), and fixes two bugs found along the way.

A custom range takes its bounds from `customTimeRange`, so `unit` has no meaning there. The API used to require one anyway — which is why every custom-mode config in this repo carried `unit = "day"`. It now accepts its absence, and is moving to omitting it from responses and rejecting it on write.

### 1. Fixes a provider crash (reachable today)

`mapReportToModel` and the report data source's `populateState` dereferenced `time_range.mode` and `unit` unconditionally, while `secondary_time_range.unit` a few lines below was already nil-guarded. Since #60621 deployed, a report created with `mode = "custom"` and no `unit` stores an empty unit that `omitempty` drops from the response — so reading one panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0]
	internal/provider/report.go:1689
```

Verified by stashing the fix and running against the live API. No existing report is affected yet, because reports created before #60621 all have a stored unit. **Once #60646 deploys, `unit` is stripped from every custom-mode response**, so any read of any custom-mode report panics on an older provider. The panic lands on `Read`, which also blocks `import`, so there is no in-place recovery without upgrading.

`mode` is safe today (upstream kept `json:"mode"` without `omitempty`) but is guarded alongside `unit` so the pair cannot drift apart.

### 2. Rejects the invalid combination at plan time

`reportCustomTimeRangeUnitValidator` refuses `unit` alongside `mode = "custom"`, wired into both the resource and `doit_report_query` — following `reportCountAggregationValidator`, since attribute validators don't run inside a `SingleNestedAttribute` with a `CustomType`. This turns #60646's 400 into an actionable plan-time error, and prevents a configured unit diffing forever against one the API no longer returns.

**This is a breaking change**: configs setting both must drop `unit`. Removing it converges cleanly — once the API omits `unit`, refresh nulls it in state, so the planned value is null and it is never sent.

### 3. Defers `custom_time_range` validation on unknown timestamps

`validateReportTimestamps` treated an unknown `from`/`to` as empty, so a `custom_time_range` derived from another resource or data source failed at plan time with `Empty Custom Time Range`. That contradicted the function's own doc comment ("Unknown values are deferred (not treated as empty) so dynamic references validate once resolved") and was inconsistent with the `forecast_settings.future_custom_date_range` check 20 lines below, which defers correctly.

Surfaced by fixing the `doit_anomalies` example, which nested `custom_time_range` **inside** `time_range` — not a schema attribute there, so it was silently ignored (see #74) and the custom range never applied. Moving it to config level exposed the validator bug.

## Test plan

- [x] **All 119 report acceptance tests pass locally** — 6 batches of 20, every batch exit 0, zero failures, all 119 accounted for in the PASS output
- [x] New coverage: 4 CMP-49333 regression tests (custom range without a unit on the query and resource paths; multi-metric columns via `doit_report_query` and `doit_report_result`), 2 validator tests, and `TestAccReport_CustomTimeRange_ComputedTimestamps`
- [x] Both new guards verified to actually pin behaviour by stashing the fix: the mapper test panics with `SIGSEGV`, and the computed-timestamp test fails with `Empty Custom Time Range`
- [x] `make test` exit 0 · `make lint` 0 issues · `make validate-examples` 85/85 · `make validate-docs` exit 0

## Notes for reviewers

- The multi-metric assertion compares row width against schema length rather than a literal column count: the live schema is `[year, month, cost, usage, timestamp]`, with the trailing `timestamp` appended for the datetime dimensions.
- `secondary_time_range.unit` is deliberately untouched — #60646 strips only the primary `TimeSettings.Unit`, and the secondary type has no `mode`.
- The 14 test configs that dropped `unit` were carrying it purely as a workaround for the old API requirement.
- Worth landing before #60646 deploys, so the crash fix is available to users first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
