### PR TITLE
fix(report): restore missing DeprecationMessage on config.metric

### DIFF
--- a/docs/data-sources/report_query.md
+++ b/docs/data-sources/report_query.md
@@ -129,7 +129,7 @@ at most two of those three limit types — not all three. When `displayValues` i
 Possible values: `none`, `top`, `all`
 - `limit_by_change` (Attributes) Limit by change filter. A report may configure at most two of
 `metricFilter`, `limitByChange`, and top/bottom `group` limits — not all three. (see [below for nested schema](#nestedatt--config--limit_by_change))
-- `metric` (Attributes) Deprecated: Use 'metrics' instead. (see [below for nested schema](#nestedatt--config--metric))
+- `metric` (Attributes, Deprecated) Deprecated: Use 'metrics' instead. (see [below for nested schema](#nestedatt--config--metric))
 - `metric_filter` (Attributes) Metric filter to limit report rows by metric value. (see [below for nested schema](#nestedatt--config--metric_filter))
 - `metrics` (Attributes List) The list of metrics to apply to the report. Custom metric can be used only once. Maximum number of metrics is 4. (see [below for nested schema](#nestedatt--config--metrics))
 - `secondary_time_range` (Attributes) Secondary time range for comparative reports. (see [below for nested schema](#nestedatt--config--secondary_time_range))

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -409,7 +409,7 @@ at most two of those three limit types — not all three. When `displayValues` i
 Possible values: `none`, `top`, `all`
 - `limit_by_change` (Attributes) Limit by change filter. A report may configure at most two of
 `metricFilter`, `limitByChange`, and top/bottom `group` limits — not all three. (see [below for nested schema](#nestedatt--config--limit_by_change))
-- `metric` (Attributes) Deprecated: Use 'metrics' instead. (see [below for nested schema](#nestedatt--config--metric))
+- `metric` (Attributes, Deprecated) Deprecated: Use 'metrics' instead. (see [below for nested schema](#nestedatt--config--metric))
 - `metric_filter` (Attributes) Metric filter to limit report rows by metric value. (see [below for nested schema](#nestedatt--config--metric_filter))
 - `metrics` (Attributes List) The list of metrics to apply to the report. Custom metric can be used only once. Maximum number of metrics is 4. (see [below for nested schema](#nestedatt--config--metrics))
 - `secondary_time_range` (Attributes) Secondary time range for comparative reports. (see [below for nested schema](#nestedatt--config--secondary_time_range))

--- a/internal/provider/report_query_data_source.go
+++ b/internal/provider/report_query_data_source.go
@@ -82,6 +82,9 @@ func (d *reportQueryDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 	// there do not carry over. Re-attach the ones that must hold for both.
 	if attr, ok := dsConfigAttrs["metric"].(dsschema.SingleNestedAttribute); ok {
 		attr.Validators = append(attr.Validators, metricMirrorConflictValidator())
+		// Workaround for https://github.com/doitintl/terraform-plugin-codegen-openapi/issues/5:
+		// the codegen fork drops the deprecation on allOf-composed properties.
+		attr.DeprecationMessage = "This attribute is deprecated."
 		dsConfigAttrs["metric"] = attr
 	}
 
@@ -287,6 +290,7 @@ func convertResourceAttrsToDataSource(attrs map[string]rsschema.Attribute) (map[
 			result[name] = dsschema.StringAttribute{
 				Description:         a.Description,
 				MarkdownDescription: a.MarkdownDescription,
+				DeprecationMessage:  a.DeprecationMessage,
 				Required:            a.Required,
 				Optional:            a.Optional,
 				Computed:            a.Computed,
@@ -298,6 +302,7 @@ func convertResourceAttrsToDataSource(attrs map[string]rsschema.Attribute) (map[
 			result[name] = dsschema.BoolAttribute{
 				Description:         a.Description,
 				MarkdownDescription: a.MarkdownDescription,
+				DeprecationMessage:  a.DeprecationMessage,
 				Required:            a.Required,
 				Optional:            a.Optional,
 				Computed:            a.Computed,
@@ -309,6 +314,7 @@ func convertResourceAttrsToDataSource(attrs map[string]rsschema.Attribute) (map[
 			result[name] = dsschema.Int64Attribute{
 				Description:         a.Description,
 				MarkdownDescription: a.MarkdownDescription,
+				DeprecationMessage:  a.DeprecationMessage,
 				Required:            a.Required,
 				Optional:            a.Optional,
 				Computed:            a.Computed,
@@ -320,6 +326,7 @@ func convertResourceAttrsToDataSource(attrs map[string]rsschema.Attribute) (map[
 			result[name] = dsschema.Float64Attribute{
 				Description:         a.Description,
 				MarkdownDescription: a.MarkdownDescription,
+				DeprecationMessage:  a.DeprecationMessage,
 				Required:            a.Required,
 				Optional:            a.Optional,
 				Computed:            a.Computed,
@@ -332,6 +339,7 @@ func convertResourceAttrsToDataSource(attrs map[string]rsschema.Attribute) (map[
 				ElementType:         a.ElementType,
 				Description:         a.Description,
 				MarkdownDescription: a.MarkdownDescription,
+				DeprecationMessage:  a.DeprecationMessage,
 				Required:            a.Required,
 				Optional:            a.Optional,
 				Computed:            a.Computed,
@@ -347,6 +355,7 @@ func convertResourceAttrsToDataSource(attrs map[string]rsschema.Attribute) (map[
 				CustomType:          a.CustomType,
 				Description:         a.Description,
 				MarkdownDescription: a.MarkdownDescription,
+				DeprecationMessage:  a.DeprecationMessage,
 				Required:            a.Required,
 				Optional:            a.Optional,
 				Computed:            a.Computed,
@@ -364,6 +373,7 @@ func convertResourceAttrsToDataSource(attrs map[string]rsschema.Attribute) (map[
 				},
 				Description:         a.Description,
 				MarkdownDescription: a.MarkdownDescription,
+				DeprecationMessage:  a.DeprecationMessage,
 				Required:            a.Required,
 				Optional:            a.Optional,
 				Computed:            a.Computed,

--- a/internal/provider/report_resource.go
+++ b/internal/provider/report_resource.go
@@ -111,6 +111,9 @@ func (r *reportResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 		if attr, ok := configAttr.Attributes["metric"].(schema.SingleNestedAttribute); ok {
 			attr.PlanModifiers = append(attr.PlanModifiers, useNullForUnconfiguredMetricMirror())
 			attr.Validators = append(attr.Validators, metricMirrorConflictValidator())
+			// Workaround for https://github.com/doitintl/terraform-plugin-codegen-openapi/issues/5:
+			// the codegen fork drops the deprecation on allOf-composed properties.
+			attr.DeprecationMessage = "This attribute is deprecated."
 			configAttr.Attributes["metric"] = attr
 		}
 		if attr, ok := configAttr.Attributes["metrics"].(schema.ListNestedAttribute); ok {


### PR DESCRIPTION
## Summary

- Our codegen fork (`doitintl/terraform-plugin-codegen-openapi`) drops `DeprecationMessage` for `allOf`-composed properties. `ExternalConfig.metric` is spec'd as `allOf: [$ref: ExternalMetric]` with a sibling `deprecated: true`/`description`, so the generated resource/query schemas silently lost the deprecation warning even though the description text still says "Deprecated: Use 'metrics' instead." Filed upstream as [doitintl/terraform-plugin-codegen-openapi#5](https://github.com/doitintl/terraform-plugin-codegen-openapi/issues/5).
- As a temporary workaround (until the codegen fork is fixed), this patches the generated schema in the existing `config.metric` post-processing blocks in `report_resource.go` and `report_query_data_source.go`, rather than hand-editing the generated `*_gen.go` files (which are overwritten by `make generate`).
- Also closes a related, independent gap in `convertResourceAttrsToDataSource`: it copied every other sibling schema field (`Description`, `Validators`, etc.) but never `DeprecationMessage`, for any attribute type converted through it.
- The plain `doit_report` data source's `config.metric` is intentionally left alone — it's `Computed`-only (never user-set), so the deprecation warning could never fire there; only the description text change would show up, which is cosmetic.

## Test plan

- [x] `go build ./...`
- [x] `make docs` — confirmed `config.metric` now renders as `(Attributes, Deprecated)` in `docs/resources/report.md` and `docs/data-sources/report_query.md`; `docs/data-sources/report.md` unchanged as expected
- [x] `make test` (full unit suite) — passing
- [x] `make testacc-run TEST=TestAccReport` — all 126 tests passing, no reruns/flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)