### PR TITLE
fix(datasource): correct maxResults param type from string to int64

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -315,7 +315,7 @@
 					},
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}
@@ -851,7 +851,7 @@
 				"attributes": [
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}
@@ -1092,7 +1092,7 @@
 				"attributes": [
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}
@@ -2622,7 +2622,7 @@
 				"attributes": [
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection."
 						}
@@ -7797,7 +7797,7 @@
 					},
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}
@@ -8330,7 +8330,7 @@
 				"attributes": [
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}
@@ -8473,7 +8473,7 @@
 				"attributes": [
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}
@@ -9712,7 +9712,7 @@
 				"attributes": [
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}
@@ -11953,7 +11953,7 @@
 				"attributes": [
 					{
 						"name": "max_results",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
 							"description": "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection."
 						}

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -1147,8 +1147,9 @@ paths:
           in: query
           description: The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
           schema:
-            type: string
-            default: "50"
+            type: integer
+            format: int64
+            default: 50
         - $ref: "#/components/parameters/pageToken"
         - name: filter
           in: query
@@ -1212,7 +1213,7 @@ paths:
             schema:
               $ref: "#/components/schemas/BudgetCreateUpdateRequest"
             example:
-              name: schemathesis-stateful-budget
+              name: monthly-cloud-budget
               amount: 100
               currency: USD
               usePrevSpend: false
@@ -1480,6 +1481,9 @@ paths:
       summary: Retrieve a dimension
       description: Returns a dimension by type and key.
       operationId: getDimensions
+      x-cli-name: get-dimension
+      x-cli-aliases:
+        - get-dimensions
       parameters:
         - name: type
           in: query
@@ -1820,8 +1824,8 @@ paths:
                   default: root
                   example: root
             example:
-              name: schemathesis-stateful-report
-              description: Schemathesis stateful test report
+              name: monthly-cost-by-service
+              description: Monthly cost grouped by service
               config:
                 includeSubtotals: false
                 sortGroups: asc
@@ -1890,45 +1894,17 @@ paths:
                   $ref: "#/components/schemas/ExternalConfig"
             example:
               config:
-                includeSubtotals: false
-                sortGroups: asc
-                sortDimensions: desc
+                dataSource: billing
                 metrics:
                   - type: basic
                     value: cost
-                  - type: basic
-                    value: usage
-                  - type: extended
-                    value: amortized_cost
-                metricFilter:
-                  metric:
-                    type: basic
-                    value: cost
-                  operator: gt
-                  values:
-                    - 0.1
                 timeRange:
-                  amount: 7
+                  amount: 30
                   includeCurrent: false
                   mode: last
                   unit: day
-                aggregation: total
-                dimensions:
-                  - id: year
-                    type: datetime
-                  - id: month
-                    type: datetime
-                  - id: day
-                    type: datetime
-                displayValues: actuals_only
                 group:
-                  - limit:
-                      metric:
-                        type: basic
-                        value: cost
-                      sort: desc
-                      value: 3
-                    id: service_description
+                  - id: service_description
                     type: fixed
                 timeInterval: day
       responses:
@@ -1969,7 +1945,7 @@ paths:
           in: query
           description: >-
             An optional parameter to override the report time settings. Must be
-            provided together with `endDate`. Format: yyyy-mm-dd
+            provided together with endDate. Format: yyyy-mm-dd
           schema:
             type: string
             format: date
@@ -1978,7 +1954,7 @@ paths:
           in: query
           description: >-
             An optional parameter to override the report time settings. Must be
-            provided together with `startDate`. Format: yyyy-mm-dd
+            provided together with startDate. Format: yyyy-mm-dd
           schema:
             type: string
             format: date
@@ -4149,6 +4125,9 @@ paths:
 
         Assets are returned in reverse chronological order by default.
       operationId: idOfAssets
+      x-cli-name: list-assets
+      x-cli-aliases:
+        - id-of-assets
       parameters:
         - name: maxResults
           in: query
@@ -4233,6 +4212,9 @@ paths:
       summary: Update an asset
       description: Updates an existing asset, such as G Suite/Workspace or Office 365 subscription, to add or remove licenses.
       operationId: idOfAsset
+      x-cli-name: update-asset
+      x-cli-aliases:
+        - id-of-asset
       parameters:
         - name: id
           in: path
@@ -4282,6 +4264,9 @@ paths:
         Returns a list of all historical requests that your account has access to.
         Tickets are returned in reverse chronological order by default.
       operationId: idOfTickets
+      x-cli-name: list-tickets
+      x-cli-aliases:
+        - id-of-tickets
       parameters:
         - name: maxResults
           in: query
@@ -4341,6 +4326,9 @@ paths:
       summary: Create a request
       description: Creates a new support request
       operationId: idOfTicketsPost
+      x-cli-name: create-ticket
+      x-cli-aliases:
+        - id-of-tickets-post
       requestBody:
         content:
           application/json:
@@ -4370,6 +4358,9 @@ paths:
       summary: Get a request
       description: Returns the details of a single support request by its ID.
       operationId: idOfTicketGet
+      x-cli-name: get-ticket
+      x-cli-aliases:
+        - id-of-ticket-get
       parameters:
         - name: ticketId
           in: path
@@ -4412,6 +4403,9 @@ paths:
         resolve to an active agent returns `400`. At least one mutable field
         must be present. The response echoes the fields that were applied.
       operationId: idOfTicketUpdate
+      x-cli-name: update-ticket
+      x-cli-aliases:
+        - id-of-ticket-update
       parameters:
         - name: ticketId
           in: path
@@ -4476,6 +4470,9 @@ paths:
         comments are returned. All comments are returned in a single response
         (no pagination).
       operationId: idOfTicketCommentsList
+      x-cli-name: list-ticket-comments
+      x-cli-aliases:
+        - id-of-ticket-comments-list
       parameters:
         - name: ticketId
           in: path
@@ -4510,6 +4507,9 @@ paths:
         are always public. For DoiT employees, comments can be marked as
         private (internal notes) by setting the `private` field to `true`.
       operationId: idOfTicketCommentsPost
+      x-cli-name: create-ticket-comment
+      x-cli-aliases:
+        - id-of-ticket-comments-post
       parameters:
         - name: ticketId
           in: path
@@ -4593,6 +4593,9 @@ paths:
         response echoes the actual stored strings so callers can verify the
         transform.
       operationId: idOfTicketTagsAdd
+      x-cli-name: add-ticket-tags
+      x-cli-aliases:
+        - id-of-ticket-tags-add
       parameters:
         - name: ticketId
           in: path
@@ -4636,6 +4639,9 @@ paths:
         mapping as on add, so a customer who added `my_tag` (stored as
         `customer_tag/my_tag`) can remove it by sending `my_tag`.
       operationId: idOfTicketTagsRemove
+      x-cli-name: remove-ticket-tags
+      x-cli-aliases:
+        - id-of-ticket-tags-remove
       parameters:
         - name: ticketId
           in: path
@@ -8329,7 +8335,6 @@ components:
       required:
         - name
         - platform
-        - structure
         - eligibleFrom
       properties:
         name:
@@ -8337,6 +8342,9 @@ components:
         platform:
           type: string
         structure:
+          description: >-
+            Which preset the template started from. Optional — an omitted or
+            blank value is recorded as "blank".
           type: string
         eligibleFrom:
           type: string
@@ -15015,8 +15023,9 @@ components:
       description: >-
         The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
       schema:
-        type: string
-        default: "50"
+        type: integer
+        format: int64
+        default: 50
     pageToken:
       name: pageToken
       in: query

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -1116,8 +1116,9 @@ paths:
           in: query
           description: The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
           schema:
-            type: string
-            default: "50"
+            type: integer
+            format: int64
+            default: 50
         - $ref: "#/components/parameters/pageToken"
         - name: filter
           in: query
@@ -1164,7 +1165,7 @@ paths:
             schema:
               $ref: "#/components/schemas/BudgetCreateUpdateRequest"
             example:
-              name: schemathesis-stateful-budget
+              name: monthly-cloud-budget
               amount: 100
               currency: USD
               usePrevSpend: false
@@ -1332,6 +1333,9 @@ paths:
       summary: Retrieve a dimension
       description: Returns a dimension by type and key.
       operationId: getDimensions
+      x-cli-name: get-dimension
+      x-cli-aliases:
+        - get-dimensions
       parameters:
         - name: type
           in: query
@@ -1635,8 +1639,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateReportRequestBody'
             example:
-              name: schemathesis-stateful-report
-              description: Schemathesis stateful test report
+              name: monthly-cost-by-service
+              description: Monthly cost grouped by service
               config:
                 includeSubtotals: false
                 sortGroups: asc
@@ -1701,45 +1705,17 @@ paths:
               $ref: '#/components/schemas/QueryRequestBody'
             example:
               config:
-                includeSubtotals: false
-                sortGroups: asc
-                sortDimensions: desc
+                dataSource: billing
                 metrics:
                   - type: basic
                     value: cost
-                  - type: basic
-                    value: usage
-                  - type: extended
-                    value: amortized_cost
-                metricFilter:
-                  metric:
-                    type: basic
-                    value: cost
-                  operator: gt
-                  values:
-                    - 0.1
                 timeRange:
-                  amount: 7
+                  amount: 30
                   includeCurrent: false
                   mode: last
                   unit: day
-                aggregation: total
-                dimensions:
-                  - id: year
-                    type: datetime
-                  - id: month
-                    type: datetime
-                  - id: day
-                    type: datetime
-                displayValues: actuals_only
                 group:
-                  - limit:
-                      metric:
-                        type: basic
-                        value: cost
-                      sort: desc
-                      value: 3
-                    id: service_description
+                  - id: service_description
                     type: fixed
                 timeInterval: day
       responses:
@@ -1776,7 +1752,7 @@ paths:
         - name: startDate
           in: query
           description: >-
-            An optional parameter to override the report time settings. Must be provided together with `endDate`. Format: yyyy-mm-dd
+            An optional parameter to override the report time settings. Must be provided together with endDate. Format: yyyy-mm-dd
           schema:
             type: string
             format: date
@@ -1784,7 +1760,7 @@ paths:
         - name: endDate
           in: query
           description: >-
-            An optional parameter to override the report time settings. Must be provided together with `startDate`. Format: yyyy-mm-dd
+            An optional parameter to override the report time settings. Must be provided together with startDate. Format: yyyy-mm-dd
           schema:
             type: string
             format: date
@@ -2664,6 +2640,9 @@ paths:
 
         Assets are returned in reverse chronological order by default.
       operationId: idOfAssets
+      x-cli-name: list-assets
+      x-cli-aliases:
+        - id-of-assets
       parameters:
         - name: maxResults
           in: query
@@ -2735,6 +2714,9 @@ paths:
       summary: Update an asset
       description: Updates an existing asset, such as G Suite/Workspace or Office 365 subscription, to add or remove licenses.
       operationId: idOfAsset
+      x-cli-name: update-asset
+      x-cli-aliases:
+        - id-of-asset
       parameters:
         - name: id
           in: path
@@ -2773,6 +2755,9 @@ paths:
         Returns a list of all historical requests that your account has access to.
         Tickets are returned in reverse chronological order by default.
       operationId: idOfTickets
+      x-cli-name: list-tickets
+      x-cli-aliases:
+        - id-of-tickets
       parameters:
         - name: maxResults
           in: query
@@ -2829,6 +2814,9 @@ paths:
       summary: Get a request
       description: Returns the details of a single support request by its ID.
       operationId: idOfTicketGet
+      x-cli-name: get-ticket
+      x-cli-aliases:
+        - id-of-ticket-get
       parameters:
         - name: ticketId
           in: path
@@ -2867,6 +2855,9 @@ paths:
         comments are returned. All comments are returned in a single response
         (no pagination).
       operationId: idOfTicketCommentsList
+      x-cli-name: list-ticket-comments
+      x-cli-aliases:
+        - id-of-ticket-comments-list
       parameters:
         - name: ticketId
           in: path
@@ -2946,6 +2937,9 @@ paths:
         response echoes the actual stored strings so callers can verify the
         transform.
       operationId: idOfTicketTagsAdd
+      x-cli-name: add-ticket-tags
+      x-cli-aliases:
+        - id-of-ticket-tags-add
       parameters:
         - name: ticketId
           in: path
@@ -2989,6 +2983,9 @@ paths:
         mapping as on add, so a customer who added `my_tag` (stored as
         `customer_tag/my_tag`) can remove it by sending `my_tag`.
       operationId: idOfTicketTagsRemove
+      x-cli-name: remove-ticket-tags
+      x-cli-aliases:
+        - id-of-ticket-tags-remove
       parameters:
         - name: ticketId
           in: path
@@ -11163,8 +11160,9 @@ components:
       description: >-
         The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
       schema:
-        type: string
-        default: "50"
+        type: integer
+        format: int64
+        default: 50
     pageToken:
       name: pageToken
       in: query

--- a/docs/data-sources/alerts.md
+++ b/docs/data-sources/alerts.md
@@ -55,7 +55,7 @@ output "alert_details" {
 
 - `filter` (String) An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 Available filter keys: **owner**, **name**
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `name`, `createTime`, `updateTime`, `lastAlerted`

--- a/docs/data-sources/allocations.md
+++ b/docs/data-sources/allocations.md
@@ -39,7 +39,7 @@ output "allocation_names" {
 
 - `filter` (String) An expression for filtering the results.
 Valid fields: **type**, **owner**, **name**, **folderId**.
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `id`, `name`, `owner`, `description`, `type`, `createTime`, `updateTime`

--- a/docs/data-sources/annotations.md
+++ b/docs/data-sources/annotations.md
@@ -37,7 +37,7 @@ output "annotation_summary" {
 
 - `filter` (String) An expression for filtering the results.
 Valid fields: **content**, **timestamp**, **labels**.
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `id`, `content`, `timestamp`, `timeCreated`, `timeModified`

--- a/docs/data-sources/budgets.md
+++ b/docs/data-sources/budgets.md
@@ -36,7 +36,7 @@ output "budget_names" {
 - `filter` (String) An expression for filtering the results of the request. The syntax is "key:[<value>]".
 Available keys: owner, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
 - `max_creation_time` (String) Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.
-- `max_results` (String) The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
 - `min_creation_time` (String) Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/docs/data-sources/commitments.md
+++ b/docs/data-sources/commitments.md
@@ -18,7 +18,7 @@ data "doit_commitments" "all" {
 
 # List commitments with a result limit
 data "doit_commitments" "recent" {
-  max_results = "10"
+  max_results = 10
 }
 
 # Filter commitments by provider
@@ -40,7 +40,7 @@ output "commitment_count" {
 
 - `filter` (String) An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 Available filter keys: **name**, **provider**
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `name`, `startDate`, `endDate`, `provider`, `createTime`, `updateTime`

--- a/docs/data-sources/dimensions.md
+++ b/docs/data-sources/dimensions.md
@@ -48,7 +48,7 @@ output "dimension_count" {
 
 - `filter` (String) An expression for filtering the results.
 The fields eligible for filtering are: type, label, key.
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `type`, `label`, `key`, `timestamp`

--- a/docs/data-sources/folders.md
+++ b/docs/data-sources/folders.md
@@ -28,7 +28,7 @@ output "folder_names" {
 
 # Retrieve the first page of folders
 data "doit_folders" "first_page" {
-  max_results = "5"
+  max_results = 5
 }
 ```
 
@@ -37,7 +37,7 @@ data "doit_folders" "first_page" {
 
 ### Optional
 
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/docs/data-sources/labels.md
+++ b/docs/data-sources/labels.md
@@ -40,7 +40,7 @@ output "label_names" {
 
 - `filter` (String) An expression for filtering the results.
 Valid fields: **name**, **type**.
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `id`, `name`, `type`, `createTime`, `updateTime`

--- a/docs/data-sources/reports.md
+++ b/docs/data-sources/reports.md
@@ -61,7 +61,7 @@ output "reports_with_labels" {
 The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 Possible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**
 - `max_creation_time` (String) Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.
-- `max_results` (String) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `min_creation_time` (String) Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/examples/data-sources/doit_commitments/data-source.tf
+++ b/examples/data-sources/doit_commitments/data-source.tf
@@ -4,7 +4,7 @@ data "doit_commitments" "all" {
 
 # List commitments with a result limit
 data "doit_commitments" "recent" {
-  max_results = "10"
+  max_results = 10
 }
 
 # Filter commitments by provider

--- a/examples/data-sources/doit_folders/data-source.tf
+++ b/examples/data-sources/doit_folders/data-source.tf
@@ -13,5 +13,5 @@ output "folder_names" {
 
 # Retrieve the first page of folders
 data "doit_folders" "first_page" {
-  max_results = "5"
+  max_results = 5
 }

--- a/internal/provider/alerts_data_source.go
+++ b/internal/provider/alerts_data_source.go
@@ -100,7 +100,7 @@ func (d *alertsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}

--- a/internal/provider/allocations_data_source.go
+++ b/internal/provider/allocations_data_source.go
@@ -93,7 +93,7 @@ func (d *allocationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}

--- a/internal/provider/annotations_data_source.go
+++ b/internal/provider/annotations_data_source.go
@@ -100,7 +100,7 @@ func (d *annotationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}

--- a/internal/provider/budgets_data_source.go
+++ b/internal/provider/budgets_data_source.go
@@ -100,7 +100,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}
@@ -173,7 +173,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		data.RowCount = types.Int64Value(int64(len(allBudgets)))
 		data.PageToken = types.StringNull()
 		// max_results was not set by user; normalize to null
-		data.MaxResults = types.StringNull()
+		data.MaxResults = types.Int64Null()
 	}
 
 	// Map budgets list

--- a/internal/provider/commitments_data_source.go
+++ b/internal/provider/commitments_data_source.go
@@ -104,7 +104,7 @@ func (d *commitmentsDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
@@ -159,7 +159,7 @@ func (d *commitmentsDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 		data.RowCount = types.Int64Value(int64(len(allCommitments)))
 		data.PageToken = types.StringNull()
-		data.MaxResults = types.StringNull()
+		data.MaxResults = types.Int64Null()
 	}
 
 	// Map commitment items with proper diagnostics.

--- a/internal/provider/commitments_data_source_test.go
+++ b/internal/provider/commitments_data_source_test.go
@@ -57,7 +57,7 @@ data "doit_commitments" "limited" {
 
 // TestAccCommitmentsDataSource_PageTokenOnly tests using a page_token from a previous API call.
 func TestAccCommitmentsDataSource_PageTokenOnly(t *testing.T) {
-	pageToken := getCommitmentFirstPageToken(t, "1")
+	pageToken := getCommitmentFirstPageToken(t, 1)
 	if pageToken == "" {
 		t.Skip("No page_token returned (need more than 1 commitment)")
 	}
@@ -87,7 +87,7 @@ data "doit_commitments" "from_token" {
 
 // TestAccCommitmentsDataSource_MaxResultsAndPageToken tests using both parameters together.
 func TestAccCommitmentsDataSource_MaxResultsAndPageToken(t *testing.T) {
-	pageToken := getCommitmentFirstPageToken(t, "1")
+	pageToken := getCommitmentFirstPageToken(t, 1)
 	if pageToken == "" {
 		t.Skip("No page_token returned (need more than 1 commitment)")
 	}
@@ -265,7 +265,7 @@ func computeCommitmentCount(t *testing.T) int {
 	return total
 }
 
-func getCommitmentFirstPageToken(t *testing.T, maxResults string) string {
+func getCommitmentFirstPageToken(t *testing.T, maxResults int64) string {
 	t.Helper()
 	skipIfNoAcc(t)
 	client := getAPIClient(t)

--- a/internal/provider/datasource_alerts/alerts_data_source_gen.go
+++ b/internal/provider/datasource_alerts/alerts_data_source_gen.go
@@ -200,7 +200,7 @@ func AlertsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nAvailable filter keys: **owner**, **name**",
 				MarkdownDescription: "An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nAvailable filter keys: **owner**, **name**",
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -252,7 +252,7 @@ func AlertsDataSourceSchema(ctx context.Context) schema.Schema {
 type AlertsModel struct {
 	Alerts     types.List   `tfsdk:"alerts"`
 	Filter     types.String `tfsdk:"filter"`
-	MaxResults types.String `tfsdk:"max_results"`
+	MaxResults types.Int64  `tfsdk:"max_results"`
 	PageToken  types.String `tfsdk:"page_token"`
 	RowCount   types.Int64  `tfsdk:"row_count"`
 	SortBy     types.String `tfsdk:"sort_by"`

--- a/internal/provider/datasource_allocations/allocations_data_source_gen.go
+++ b/internal/provider/datasource_allocations/allocations_data_source_gen.go
@@ -93,7 +93,7 @@ func AllocationsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**, **folderId**.",
 				MarkdownDescription: "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**, **folderId**.",
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -148,7 +148,7 @@ func AllocationsDataSourceSchema(ctx context.Context) schema.Schema {
 type AllocationsModel struct {
 	Allocations types.List   `tfsdk:"allocations"`
 	Filter      types.String `tfsdk:"filter"`
-	MaxResults  types.String `tfsdk:"max_results"`
+	MaxResults  types.Int64  `tfsdk:"max_results"`
 	PageToken   types.String `tfsdk:"page_token"`
 	RowCount    types.Int64  `tfsdk:"row_count"`
 	SortBy      types.String `tfsdk:"sort_by"`

--- a/internal/provider/datasource_annotations/annotations_data_source_gen.go
+++ b/internal/provider/datasource_annotations/annotations_data_source_gen.go
@@ -93,7 +93,7 @@ func AnnotationsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "An expression for filtering the results.\nValid fields: **content**, **timestamp**, **labels**.",
 				MarkdownDescription: "An expression for filtering the results.\nValid fields: **content**, **timestamp**, **labels**.",
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -146,7 +146,7 @@ func AnnotationsDataSourceSchema(ctx context.Context) schema.Schema {
 type AnnotationsModel struct {
 	Annotations types.List   `tfsdk:"annotations"`
 	Filter      types.String `tfsdk:"filter"`
-	MaxResults  types.String `tfsdk:"max_results"`
+	MaxResults  types.Int64  `tfsdk:"max_results"`
 	PageToken   types.String `tfsdk:"page_token"`
 	RowCount    types.Int64  `tfsdk:"row_count"`
 	SortBy      types.String `tfsdk:"sort_by"`

--- a/internal/provider/datasource_budgets/budgets_data_source_gen.go
+++ b/internal/provider/datasource_budgets/budgets_data_source_gen.go
@@ -158,7 +158,7 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.",
 				MarkdownDescription: "Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.",
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.",
@@ -191,7 +191,7 @@ type BudgetsModel struct {
 	Budgets         types.List   `tfsdk:"budgets"`
 	Filter          types.String `tfsdk:"filter"`
 	MaxCreationTime types.String `tfsdk:"max_creation_time"`
-	MaxResults      types.String `tfsdk:"max_results"`
+	MaxResults      types.Int64  `tfsdk:"max_results"`
 	MinCreationTime types.String `tfsdk:"min_creation_time"`
 	PageToken       types.String `tfsdk:"page_token"`
 	RowCount        types.Int64  `tfsdk:"row_count"`

--- a/internal/provider/datasource_commitments/commitments_data_source_gen.go
+++ b/internal/provider/datasource_commitments/commitments_data_source_gen.go
@@ -149,7 +149,7 @@ func CommitmentsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nAvailable filter keys: **name**, **provider**",
 				MarkdownDescription: "An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nAvailable filter keys: **name**, **provider**",
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -203,7 +203,7 @@ func CommitmentsDataSourceSchema(ctx context.Context) schema.Schema {
 type CommitmentsModel struct {
 	Commitments types.List   `tfsdk:"commitments"`
 	Filter      types.String `tfsdk:"filter"`
-	MaxResults  types.String `tfsdk:"max_results"`
+	MaxResults  types.Int64  `tfsdk:"max_results"`
 	PageToken   types.String `tfsdk:"page_token"`
 	RowCount    types.Int64  `tfsdk:"row_count"`
 	SortBy      types.String `tfsdk:"sort_by"`

--- a/internal/provider/datasource_dimensions/dimensions_data_source_gen.go
+++ b/internal/provider/datasource_dimensions/dimensions_data_source_gen.go
@@ -55,7 +55,7 @@ func DimensionsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "An expression for filtering the results.\nThe fields eligible for filtering are: type, label, key.",
 				MarkdownDescription: "An expression for filtering the results.\nThe fields eligible for filtering are: type, label, key.",
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -105,7 +105,7 @@ func DimensionsDataSourceSchema(ctx context.Context) schema.Schema {
 type DimensionsModel struct {
 	Dimensions types.List   `tfsdk:"dimensions"`
 	Filter     types.String `tfsdk:"filter"`
-	MaxResults types.String `tfsdk:"max_results"`
+	MaxResults types.Int64  `tfsdk:"max_results"`
 	PageToken  types.String `tfsdk:"page_token"`
 	RowCount   types.Int64  `tfsdk:"row_count"`
 	SortBy     types.String `tfsdk:"sort_by"`

--- a/internal/provider/datasource_folders/folders_data_source_gen.go
+++ b/internal/provider/datasource_folders/folders_data_source_gen.go
@@ -50,7 +50,7 @@ func FoldersDataSourceSchema(ctx context.Context) schema.Schema {
 				},
 				Computed: true,
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -75,7 +75,7 @@ func FoldersDataSourceSchema(ctx context.Context) schema.Schema {
 
 type FoldersModel struct {
 	Folders    types.List   `tfsdk:"folders"`
-	MaxResults types.String `tfsdk:"max_results"`
+	MaxResults types.Int64  `tfsdk:"max_results"`
 	PageToken  types.String `tfsdk:"page_token"`
 	RowCount   types.Int64  `tfsdk:"row_count"`
 }

--- a/internal/provider/datasource_labels/labels_data_source_gen.go
+++ b/internal/provider/datasource_labels/labels_data_source_gen.go
@@ -68,7 +68,7 @@ func LabelsDataSourceSchema(ctx context.Context) schema.Schema {
 				},
 				Computed: true,
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -121,7 +121,7 @@ func LabelsDataSourceSchema(ctx context.Context) schema.Schema {
 type LabelsModel struct {
 	Filter     types.String `tfsdk:"filter"`
 	Labels     types.List   `tfsdk:"labels"`
-	MaxResults types.String `tfsdk:"max_results"`
+	MaxResults types.Int64  `tfsdk:"max_results"`
 	PageToken  types.String `tfsdk:"page_token"`
 	RowCount   types.Int64  `tfsdk:"row_count"`
 	SortBy     types.String `tfsdk:"sort_by"`

--- a/internal/provider/datasource_reports/reports_data_source_gen.go
+++ b/internal/provider/datasource_reports/reports_data_source_gen.go
@@ -30,7 +30,7 @@ func ReportsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.",
 				MarkdownDescription: "Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.",
 			},
-			"max_results": schema.StringAttribute{
+			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
@@ -131,7 +131,7 @@ func ReportsDataSourceSchema(ctx context.Context) schema.Schema {
 type ReportsModel struct {
 	Filter          types.String `tfsdk:"filter"`
 	MaxCreationTime types.String `tfsdk:"max_creation_time"`
-	MaxResults      types.String `tfsdk:"max_results"`
+	MaxResults      types.Int64  `tfsdk:"max_results"`
 	MinCreationTime types.String `tfsdk:"min_creation_time"`
 	PageToken       types.String `tfsdk:"page_token"`
 	Reports         types.List   `tfsdk:"reports"`

--- a/internal/provider/dimensions_data_source.go
+++ b/internal/provider/dimensions_data_source.go
@@ -99,7 +99,7 @@ func (d *dimensionsDataSource) Read(ctx context.Context, req datasource.ReadRequ
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}

--- a/internal/provider/folders_data_source.go
+++ b/internal/provider/folders_data_source.go
@@ -96,7 +96,7 @@ func (d *foldersDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}

--- a/internal/provider/labels_data_source.go
+++ b/internal/provider/labels_data_source.go
@@ -99,7 +99,7 @@ func (d *labelsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -8809,7 +8809,7 @@ type Value2 = int
 type ManagementAccountId = string
 
 // MaxResults defines model for maxResults.
-type MaxResults = string
+type MaxResults = int64
 
 // PageToken defines model for pageToken.
 type PageToken = string
@@ -8958,7 +8958,7 @@ type ListAnnotationsParamsSortOrder string
 // ListBudgetsParams defines parameters for ListBudgets.
 type ListBudgetsParams struct {
 	// MaxResults The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
-	MaxResults *string `form:"maxResults,omitempty" json:"maxResults,omitempty"`
+	MaxResults *int64 `form:"maxResults,omitempty" json:"maxResults,omitempty"`
 
 	// PageToken Page token, returned by a previous call, to request the next page of results
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
@@ -9092,10 +9092,10 @@ type GetReportParams struct {
 	// TimeRange An optional parameter to override the report time settings. Value should be represented in the format P[n]Y[n]M[n]D[n]. In the representations, the [n] is replaced by the value for each of the date and time elements that follow the [n].
 	TimeRange *string `form:"timeRange,omitempty" json:"timeRange,omitempty"`
 
-	// StartDate An optional parameter to override the report time settings. Must be provided together with `endDate`. Format: yyyy-mm-dd
+	// StartDate An optional parameter to override the report time settings. Must be provided together with endDate. Format: yyyy-mm-dd
 	StartDate *openapi_types.Date `form:"startDate,omitempty" json:"startDate,omitempty"`
 
-	// EndDate An optional parameter to override the report time settings. Must be provided together with `startDate`. Format: yyyy-mm-dd
+	// EndDate An optional parameter to override the report time settings. Must be provided together with startDate. Format: yyyy-mm-dd
 	EndDate *openapi_types.Date `form:"endDate,omitempty" json:"endDate,omitempty"`
 }
 
@@ -14185,7 +14185,7 @@ func NewListAlertsRequest(server string, params *ListAlertsParams) (*http.Reques
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -14418,7 +14418,7 @@ func NewListAllocationsRequest(server string, params *ListAllocationsParams) (*h
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -14675,7 +14675,7 @@ func NewListAnnotationsRequest(server string, params *ListAnnotationsParams) (*h
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -14959,7 +14959,7 @@ func NewListBudgetsRequest(server string, params *ListBudgetsParams) (*http.Requ
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -15240,7 +15240,7 @@ func NewListCommitmentsRequest(server string, params *ListCommitmentsParams) (*h
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -15410,7 +15410,7 @@ func NewListDimensionsRequest(server string, params *ListDimensionsParams) (*htt
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -15512,7 +15512,7 @@ func NewListFoldersRequest(server string, params *ListFoldersParams) (*http.Requ
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -15733,7 +15733,7 @@ func NewListLabelsRequest(server string, params *ListLabelsParams) (*http.Reques
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -16071,7 +16071,7 @@ func NewListReportsRequest(server string, params *ListReportsParams) (*http.Requ
 
 		if params.MaxResults != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxResults", *params.MaxResults, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/internal/provider/reports_data_source.go
+++ b/internal/provider/reports_data_source.go
@@ -100,7 +100,7 @@ func (d *reportsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
-		params.MaxResults = new(data.MaxResults.ValueString())
+		params.MaxResults = new(data.MaxResults.ValueInt64())
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}


### PR DESCRIPTION
## Summary

Upstream OpenAPI spec fixed the `maxResults` query parameter: it was incorrectly typed as `string` (default `"50"`) and is now correctly `integer`/`int64` (default `50`). This propagated through codegen into `models_gen.go` and the `datasource_*_gen.go` schemas for `alerts`, `allocations`, `annotations`, `budgets`, `commitments`, `dimensions`, `folders`, `labels`, and `reports` — breaking the 9 hand-written `Read` methods that still called `.ValueString()` / `types.StringNull()` on the now-`Int64` `MaxResults` field.

- `maxResults` is a **request-only** query parameter — it never appears in any JSON response body. HTTP query values serialize to text regardless of the Go type used to build them, so this is a pure client-side modeling correction with **no behavior change on the wire**. Acceptance tests passed both before and after for that reason.
- Swapped `.ValueString()` → `.ValueInt64()` in the 9 affected data sources' manual-pagination branch, matching the pattern already used by `anomalies`/`assets`/`invoices`/etc.
- Swapped `types.StringNull()` → `types.Int64Null()` in `budgets`/`commitments`'s auto-pagination reset.
- Fixed `commitments_data_source_test.go`'s `getCommitmentFirstPageToken` helper, which built `ListCommitmentsParams` with a `*string`.
- Regenerated docs (`make docs`) and updated the two examples (`doit_commitments`, `doit_folders`) that passed `max_results` as a quoted string, to match the corrected `Number` type.

## Test plan

- [x] `go build ./...` / `go vet ./...` — clean
- [x] `make test` — unit suite passes
- [x] `make testacc-run` for all 36 acceptance tests across the 9 affected data sources (batched to avoid known API throttling under full parallelism) — all pass
- [x] Applied the two updated examples (`doit_commitments`, `doit_folders`) end-to-end via `dev_overrides` against the live API — both apply cleanly with unquoted `max_results`

🤖 Generated with [Claude Code](https://claude.com/claude-code)