### PR TITLE
(chore) sync upstream spec delete json responses (no provider changes)

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -420,6 +420,12 @@ paths:
       responses:
         "200":
           description: OK - Allocation deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -627,6 +633,12 @@ paths:
       responses:
         "200":
           description: OK - Annotation deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -816,6 +828,12 @@ paths:
       responses:
         "200":
           description: OK - Label deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -1076,6 +1094,12 @@ paths:
       responses:
         "200":
           description: OK - Custom theme deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -1305,7 +1329,12 @@ paths:
       responses:
         "200":
           description: OK - Budget deleted.
-          content: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -1989,6 +2018,12 @@ paths:
       responses:
         "200":
           description: OK - Report deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
           links:
             listReports:
               operationId: listReports

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -408,6 +408,12 @@ paths:
       responses:
         "200":
           description: OK - Allocation deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -604,6 +610,12 @@ paths:
       responses:
         "200":
           description: OK - Annotation deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -793,6 +805,12 @@ paths:
       responses:
         "200":
           description: OK - Label deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -1045,6 +1063,12 @@ paths:
       responses:
         "200":
           description: OK - Custom theme deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -1257,7 +1281,12 @@ paths:
       responses:
         "200":
           description: OK - Budget deleted.
-          content: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -1795,6 +1824,12 @@ paths:
       responses:
         "200":
           description: OK - Report deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+              example: {}
           links:
             listReports:
               operationId: listReports

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -21994,6 +21994,8 @@ func (r CreateAllocationResp) ContentType() string {
 type DeleteAllocationResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
 	// JSON400 the response for an HTTP 400 `application/json` response
 	JSON400 *N400
 	// JSON401 the response for an HTTP 401 `application/json` response
@@ -22004,6 +22006,11 @@ type DeleteAllocationResp struct {
 	JSON404 *N404
 	// JSON409 the response for an HTTP 409 `application/json` response
 	JSON409 *[]AllocationDeleteValidation
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r DeleteAllocationResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
 }
 
 // GetJSON400 returns the response for an HTTP 400 `application/json` response
@@ -22339,6 +22346,8 @@ func (r CreateAnnotationResp) ContentType() string {
 type DeleteAnnotationResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
 	// JSON400 the response for an HTTP 400 `application/json` response
 	JSON400 *N400
 	// JSON401 the response for an HTTP 401 `application/json` response
@@ -22347,6 +22356,11 @@ type DeleteAnnotationResp struct {
 	JSON403 *N403
 	// JSON404 the response for an HTTP 404 `application/json` response
 	JSON404 *N404
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r DeleteAnnotationResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
 }
 
 // GetJSON400 returns the response for an HTTP 400 `application/json` response
@@ -22739,6 +22753,8 @@ func (r CreateBudgetResp) ContentType() string {
 type DeleteBudgetResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
 	// JSON400 the response for an HTTP 400 `application/json` response
 	JSON400 *N400
 	// JSON401 the response for an HTTP 401 `application/json` response
@@ -22747,6 +22763,11 @@ type DeleteBudgetResp struct {
 	JSON403 *N403
 	// JSON404 the response for an HTTP 404 `application/json` response
 	JSON404 *N404
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r DeleteBudgetResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
 }
 
 // GetJSON400 returns the response for an HTTP 400 `application/json` response
@@ -23712,6 +23733,8 @@ func (r CreateLabelResp) ContentType() string {
 type DeleteLabelResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
 	// JSON400 the response for an HTTP 400 `application/json` response
 	JSON400 *N400
 	// JSON401 the response for an HTTP 401 `application/json` response
@@ -23720,6 +23743,11 @@ type DeleteLabelResp struct {
 	JSON403 *N403
 	// JSON404 the response for an HTTP 404 `application/json` response
 	JSON404 *N404
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r DeleteLabelResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
 }
 
 // GetJSON400 returns the response for an HTTP 400 `application/json` response
@@ -24243,6 +24271,8 @@ func (r QueryResp) ContentType() string {
 type DeleteReportResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
 	// JSON400 the response for an HTTP 400 `application/json` response
 	JSON400 *N400
 	// JSON401 the response for an HTTP 401 `application/json` response
@@ -24253,6 +24283,11 @@ type DeleteReportResp struct {
 	JSON404 *N404
 	// JSON500 the response for an HTTP 500 `application/json` response
 	JSON500 *N500
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r DeleteReportResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
 }
 
 // GetJSON400 returns the response for an HTTP 400 `application/json` response
@@ -24788,6 +24823,8 @@ func (r CreateCustomThemeResp) ContentType() string {
 type DeleteCustomThemeResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
 	// JSON400 the response for an HTTP 400 `application/json` response
 	JSON400 *N400
 	// JSON401 the response for an HTTP 401 `application/json` response
@@ -24796,6 +24833,11 @@ type DeleteCustomThemeResp struct {
 	JSON403 *N403
 	// JSON404 the response for an HTTP 404 `application/json` response
 	JSON404 *N404
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r DeleteCustomThemeResp) GetJSON200() *map[string]interface{} {
+	return r.JSON200
 }
 
 // GetJSON400 returns the response for an HTTP 400 `application/json` response
@@ -31792,8 +31834,12 @@ func ParseDeleteAllocationResp(rsp *http.Response) (*DeleteAllocationResp, error
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400
@@ -32065,8 +32111,12 @@ func ParseDeleteAnnotationResp(rsp *http.Response) (*DeleteAnnotationResp, error
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400
@@ -32378,8 +32428,12 @@ func ParseDeleteBudgetResp(rsp *http.Response) (*DeleteBudgetResp, error) {
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400
@@ -33147,8 +33201,12 @@ func ParseDeleteLabelResp(rsp *http.Response) (*DeleteLabelResp, error) {
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400
@@ -33564,8 +33622,12 @@ func ParseDeleteReportResp(rsp *http.Response) (*DeleteReportResp, error) {
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400
@@ -33992,8 +34054,12 @@ func ParseDeleteCustomThemeResp(rsp *http.Response) (*DeleteCustomThemeResp, err
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest N400


### PR DESCRIPTION
## What changed

Synced the upstream OpenAPI spec after [doiteng/omni#60704](https://github.com/doiteng/omni/pull/60704) ([CMP-48643](https://doitintl.atlassian.net/browse/CMP-48643)) shipped to prod, then reran `make generate`.

Six external Cloud Analytics delete endpoints now answer `200` with `{}` and `Content-Type: application/json`, where they previously sent an empty body and no content type:

| Operation | Path |
| --- | --- |
| `deleteAllocation` | `/analytics/v1/allocations/{id}` |
| `deleteAnnotation` | `/analytics/v1/annotations/{id}` |
| `deleteBudget` | `/analytics/v1/budgets/{id}` |
| `deleteCustomTheme` | `/analytics/v1/settings/themes/{id}` |
| `deleteLabel` | `/analytics/v1/labels/{id}` |
| `deleteReport` | `/analytics/v1/reports/{id}` |

The spec declares `application/json` with `type: object, additionalProperties: false` on each of those `200` responses.

## Generated impact

`models_gen.go` is the only code file touched, and the change is uniform across the six operations:

- Each `Delete*Resp` struct gains `JSON200 *map[string]interface{}` and a `GetJSON200()` accessor.
- Each `ParseDelete*Resp` switches its `200` arm from `break // No content-type` to a `json.Unmarshal` guarded by `strings.Contains(rsp.Header.Get("Content-Type"), "json")`.

## Why no hand-written changes

All six `Delete()` methods decide purely on `StatusCode()`, accepting `200`, `204`, and `404`, and never read the response body. Switching them to `JSON200` would be strictly less tolerant — it would drop the `204` and `404` paths that make deletes idempotent — so they stay as they are and the new accessors go unused.

`make docs` produces no diff: delete response bodies do not reach the generated schema documentation. No CHANGELOG entry, since there is no user-visible behavior change.

## Testing

The unmarshal arm was unreachable before this deployed, so it is exercised here for the first time. Acceptance tests for all six resources ran against prod, each performing a real create and a real delete:

```
--- PASS: TestAccCustomTheme (14.85s)
--- PASS: TestAccReport (14.85s)
--- PASS: TestAccAnnotation (15.40s)
--- PASS: TestAccLabel (15.50s)
--- PASS: TestAccAllocation (19.39s)
--- PASS: TestAccBudget (29.44s)
```

`go build ./...`, `make test`, and `make lint` (0 issues) are all clean.

## Reviewer notes

The parse arm is gated on the JSON content type, so this is safe in both rollout directions and needed no coordination with the deploy — an undeclared content type falls through to the default case and leaves `JSON200` nil.

One consequence worth recording: because the `200` arm now unmarshals, a future response that carries a JSON content type with a genuinely empty body would fail the delete with `unexpected end of JSON input` rather than passing silently. Guarding against that would mean hand-patching generated code, which is not worth doing — the contract now declares JSON and upstream added regression tests asserting the `{}` body on all six handlers.

Three delete endpoints still declare no content on their `200` — `deleteAlert`, `deleteAccountRole`, and `deleteAvaConversation` — and `deleteAlert` backs a resource this provider manages. Worth a follow-up upstream; nothing to do here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CMP-48643]: https://doitintl.atlassian.net/browse/CMP-48643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ