### PR TITLE
fix(provider): surface API 524 responses instead of retrying opaque timeouts

### DIFF
--- a/.agents/skills/implementation-conventions/SKILL.md
+++ b/.agents/skills/implementation-conventions/SKILL.md
@@ -240,8 +240,13 @@ All resources and data sources must include timeout support. This is a two-layer
 
 | Layer | Controls | Default |
 |-------|----------|---------|
-| **Request timeout** (provider `request_timeout`) | Individual HTTP request | 120s |
-| **Operation timeout** (resource `timeouts = {}`) | Entire Terraform operation incl. retries | CRUD: 5m, Read: 2m |
+| **Request timeout** (provider `request_timeout`) | Individual HTTP request | `DefaultRequestTimeout` |
+| **Operation timeout** (resource `timeouts = {}`) | Entire Terraform operation incl. retries | `Default{Create,Read,Update,Delete}Timeout` |
+
+> **Source of truth:** all five defaults are defined in `internal/provider/timeouts.go`, which
+> also documents the ordering invariant they must satisfy
+> (`operation timeout > request timeout > the API's 120s edge timeout`) and enforces it at compile
+> time. Never write a literal duration at a call site — read the values from there.
 
 ### For Resources (3 steps)
 
@@ -269,12 +274,15 @@ resp.Schema.Attributes["timeouts"] = timeouts.Attributes(ctx, timeouts.Opts{
 **Step 3:** Wrap CRUD methods with `context.WithTimeout`:
 
 ```go
-createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 resp.Diagnostics.Append(diags...)
 if resp.Diagnostics.HasError() { return }
 ctx, cancel := context.WithTimeout(ctx, createTimeout)
 defer cancel()
 ```
+
+Use the matching constant for each operation: `DefaultCreateTimeout`, `DefaultReadTimeout`,
+`DefaultUpdateTimeout`, `DefaultDeleteTimeout`.
 
 ### For Data Sources
 
@@ -285,8 +293,12 @@ Same pattern, simpler — only Read timeout. Use `datasource/timeouts` import (n
 1. **Schema/struct mismatch** — model has `Timeouts` but schema doesn't → runtime error
 2. **Wrong import** — resources use `resource/timeouts`, data sources use `datasource/timeouts`
 3. **Nested attribute syntax** — users write `timeouts = { create = "10m" }` with `=`, not `timeouts { ... }`
+4. **Literal duration as the default** — never `plan.Timeouts.Create(ctx, 5*time.Minute)`. Use the
+   named constant from `internal/provider/timeouts.go` so the defaults stay changeable in one place
+   and the ordering invariant holds.
 
-> **Linter:** `timeoutcheck` — flags CRUD methods missing `context.WithTimeout`.
+> **Linter:** `timeoutcheck` — flags CRUD methods missing `context.WithTimeout`, and literal
+> durations passed as a `Timeouts.*` default.
 
 ## API Authentication
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - **provider**: A `524` response from the API is now reported as itself instead of being masked. Previously the default `request_timeout` of `120s` collided with the API's own 120-second edge timeout, so the request was usually cancelled locally first; that cancellation is indistinguishable from a network fault and was therefore retried, re-running an expensive query until the operation deadline expired. Affected slow reads such as `data-source/doit_report_result` against large reports
 - **provider**: A `Retry-After` header of `0`, a negative value, or a date already in the past no longer schedules an immediate retry. Such values were previously honored literally, producing a hot retry loop against a rate-limited API and pinning the backoff to a flat cadence that never grew
 - **provider**: `Retry-After` now accepts all three HTTP-date formats permitted by RFC 7231 (IMF-fixdate, RFC 850, and asctime); only IMF-fixdate was previously recognized
-- **provider**: An outsized `Retry-After` value is now capped at 5 minutes rather than being allowed to consume the whole operation budget
+- **provider**: An outsized `Retry-After` value is now capped at 60 seconds — the retry policy's own maximum interval — rather than being allowed to consume the whole operation budget. A large negative value is also rejected outright; it previously overflowed to a positive duration and was honored as a legitimate wait
 
 ### INTERNAL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### BREAKING CHANGES
+
+- **provider**: `request_timeout` values at or below `120s` are now rejected at validation time. The DoiT API's edge proxy answers requests still running after 120 seconds with a `524`, and a local timeout at or below that threshold cancels the request before that response can arrive — turning a definitive, fast failure into an opaque `context deadline exceeded` that is then retried. Configurations setting a lower value must raise it; the default is `150s`
+
+### ENHANCEMENTS
+
+- **provider**: The default `request_timeout` is now `150s` (was `120s`), so a slow request surfaces the API's own `524` response rather than racing it
+- **provider**: The default `read` and `delete` operation timeouts are now 5 minutes (were 2 minutes), matching `create` and `update`. Every operation default now exceeds `request_timeout`, so a single slow request can no longer consume the entire operation budget and leave no room to retry a transient failure
+- **provider**: Retry backoff for rate-limited (`429`) requests now starts at 2 seconds and doubles, up to 60 seconds. It previously started at 500ms with a 1.5x multiplier, issuing roughly five requests in the first four seconds against an API that had just asked the client to slow down. The DoiT API does not send `Retry-After`, so this policy governs the pace of nearly every retry
+- **provider**: `request_timeout` now emits a warning when it is not below the default operation timeout, since that leaves no room for retries
+
+### BUG FIXES
+
+- **provider**: A `524` response from the API is now reported as itself instead of being masked. Previously the default `request_timeout` of `120s` collided with the API's own 120-second edge timeout, so the request was usually cancelled locally first; that cancellation is indistinguishable from a network fault and was therefore retried, re-running an expensive query until the operation deadline expired. Affected slow reads such as `data-source/doit_report_result` against large reports
+- **provider**: A `Retry-After` header of `0`, a negative value, or a date already in the past no longer schedules an immediate retry. Such values were previously honored literally, producing a hot retry loop against a rate-limited API and pinning the backoff to a flat cadence that never grew
+- **provider**: `Retry-After` now accepts all three HTTP-date formats permitted by RFC 7231 (IMF-fixdate, RFC 850, and asctime); only IMF-fixdate was previously recognized
+- **provider**: An outsized `Retry-After` value is now capped at 5 minutes rather than being allowed to consume the whole operation budget
+
+### INTERNAL
+
+- Timeout defaults are now defined once in `internal/provider/timeouts.go`, replacing literal durations at 136 call sites across 84 files. The file documents the ordering invariant between the layers and enforces it at compile time
+- The `timeoutcheck` linter now also rejects literal durations passed as a `Timeouts.*` default, so the defaults cannot drift back out of one place
+- Added unit coverage for the retry client's `429`, `524`, `404`, and `500` handling and for `Retry-After` parsing, none of which was previously tested
+
 ## v1.7.0 (2026-08-12)
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The provider supports four configuration options, all of which can be set via en
 | `api_token`        | `DOIT_API_TOKEN`        | Yes      | Your DoiT API key                                             |
 | `host`             | `DOIT_HOST`             | No       | API host (defaults to `https://api.doit.com`)                 |
 | `customer_context` | `DOIT_CUSTOMER_CONTEXT` | No\*     | Customer context (_required for DoiT employees only_)         |
-| `request_timeout`  | `DOIT_REQUEST_TIMEOUT`  | No       | Timeout per HTTP request, e.g. `30s`, `2m` (defaults to `120s`) |
+| `request_timeout`  | `DOIT_REQUEST_TIMEOUT`  | No       | Timeout per HTTP request, e.g. `150s`, `4m` (defaults to `150s`). Must be greater than `120s` — see the [Timeouts guide](https://registry.terraform.io/providers/doitintl/doit/latest/docs/guides/timeouts) |
 
 ### Provider Configuration
 

--- a/docs/guides/timeouts.md
+++ b/docs/guides/timeouts.md
@@ -10,11 +10,11 @@ The DoiT provider supports configurable timeouts at two levels: a **global provi
 
 ## Provider-Level Request Timeout
 
-The `request_timeout` attribute controls the timeout for each individual HTTP request to the DoiT API. It defaults to `120s` and can be set via the provider block or the `DOIT_REQUEST_TIMEOUT` environment variable.
+The `request_timeout` attribute controls the timeout for each individual HTTP request to the DoiT API. It defaults to `150s` and can be set via the provider block or the `DOIT_REQUEST_TIMEOUT` environment variable.
 
 ```hcl
 provider "doit" {
-  request_timeout = "120s"  # Default value, shown for documentation
+  request_timeout = "150s"  # Default value, shown for documentation
 }
 ```
 
@@ -24,9 +24,11 @@ Or using the environment variable:
 export DOIT_REQUEST_TIMEOUT="180s"
 ```
 
-The value must be a positive Go duration string (e.g., `"30s"`, `"2m"`, `"1h"`). The HCL attribute takes precedence over the environment variable when both are set.
+The value must be a Go duration string (e.g., `"150s"`, `"4m"`) greater than `120s`. The HCL attribute takes precedence over the environment variable when both are set.
 
 -> This timeout applies to each individual HTTP request, including retries. If a single API call takes longer than this value, it will be cancelled and retried.
+
+~> **Values at or below `120s` are rejected.** The DoiT API sits behind an edge proxy that answers requests still running after 120 seconds with a `524` status. The provider treats that response as a definitive failure and does not retry it. But if `request_timeout` is at or below 120 seconds, the request is cancelled locally *before* that response can arrive — and a local cancellation is indistinguishable from a network fault, so it *is* retried. The result is that a slow call fails with an opaque `context deadline exceeded` after repeatedly re-running an expensive query, instead of reporting the `524` immediately.
 
 ## Resource Timeouts
 
@@ -42,8 +44,8 @@ resource "doit_allocation" "large_group" {
   timeouts = {
     create = "10m"  # Large allocations with many rules may need more time
     update = "10m"
-    read   = "2m"   # Default
-    delete = "2m"   # Default
+    read   = "5m"   # Default
+    delete = "5m"   # Default
   }
 }
 ```
@@ -53,9 +55,9 @@ resource "doit_allocation" "large_group" {
 | Operation | Default |
 | --------- | ------- |
 | Create    | 5 min   |
-| Read      | 2 min   |
+| Read      | 5 min   |
 | Update    | 5 min   |
-| Delete    | 2 min   |
+| Delete    | 5 min   |
 
 Only specify `timeouts` when you need to override the defaults — Terraform won't show any diff for resources without this attribute.
 
@@ -73,7 +75,7 @@ data "doit_report_query" "heavy_report" {
 }
 ```
 
-The default read timeout for data sources is **2 minutes**.
+The default read timeout for data sources is **5 minutes**.
 
 ## How Timeouts Interact
 
@@ -87,16 +89,23 @@ The **operation timeout is the outer boundary**. Retries continue until the oper
 | Layer | Controls | Example |
 | ----- | -------- | ------- |
 | **Operation timeout** (outer) | Total time for the Terraform operation, including all retries | `timeouts = { create = "10m" }` |
-| **Request timeout** (inner) | Time for a single HTTP request to the API | `request_timeout = "120s"` |
+| **Request timeout** (inner) | Time for a single HTTP request to the API | `request_timeout = "150s"` |
 
 Within a single operation (e.g., `create`), the flow is:
 
-1. **Request 1**: The provider sends an HTTP request. If the API doesn't respond within `request_timeout` (e.g., 120s), the request is cancelled.
-2. **Backoff**: The provider waits with exponential backoff before retrying.
+1. **Request 1**: The provider sends an HTTP request. If the API doesn't respond within `request_timeout` (e.g., 150s), the request is cancelled.
+2. **Backoff**: The provider waits with exponential backoff before retrying. Backoff starts at 2 seconds and doubles, up to 60 seconds, with jitter.
 3. **Request 2**: A retry is attempted. This cycle repeats.
 4. **Deadline**: Once the operation timeout (e.g., 10m) is reached, all remaining retries are cancelled and Terraform reports the error.
 
-~> **Important:** Ensure that your operation timeout is larger than your `request_timeout`. If `request_timeout` is larger than the operation timeout, a single slow request could consume the entire operation budget with no room for retries. For example, `request_timeout = "300s"` with `timeouts = { create = "2m" }` means the first request could take up to 2 minutes before being cancelled by the operation timeout — leaving zero time for retries.
+### Keep the layers ordered
+
+The defaults satisfy `operation timeout > request timeout > 120s`, and both bounds matter:
+
+- **Operation timeout above request timeout.** Otherwise a single slow request consumes the entire operation budget with no room for retries. For example, `request_timeout = "300s"` with `timeouts = { create = "2m" }` means the first request could still be running when the operation deadline cancels it — leaving zero time for a retry.
+- **Request timeout above 120s.** See the note under [Provider-Level Request Timeout](#provider-level-request-timeout): below that threshold the API's own `524` response cannot reach the provider, and slow calls degrade into retried, opaque deadline errors.
+
+If you raise `request_timeout`, raise the `timeouts {}` blocks on the affected resources and data sources to match. The provider emits a warning when `request_timeout` is not below the default operation timeout, since it cannot see the per-resource blocks — they are resolved later, per operation.
 
 ## Troubleshooting
 
@@ -122,13 +131,21 @@ This error means a timeout was exceeded. Check which level caused it:
   }
   ```
 
+### `status: 524`
+
+A `524` comes from the DoiT API's edge proxy and means the API did not finish the request within its own 120-second limit. The provider reports it immediately and **does not retry** — the query already ran for the full edge timeout, so an identical retry would only re-run expensive work that is going to time out again.
+
+Raising `request_timeout` will not help, because the limit is enforced upstream rather than locally. Reduce the amount of work in the request instead — for example, narrow a report's time range, or add filters to reduce the number of rows.
+
+Seeing `context deadline exceeded` instead of `524` on a request you expect to be slow is a sign that `request_timeout` is at or below 120 seconds.
+
 ### Large Allocations
 
 Allocation groups with many rules (100+) may require larger timeouts because the API processes all rules in a single request. Recommended settings:
 
 ```hcl
 provider "doit" {
-  request_timeout = "300s"  # 5 minutes per request
+  request_timeout = "290s"  # just under 5 minutes per request
 }
 
 resource "doit_allocation" "large_group" {
@@ -140,3 +157,5 @@ resource "doit_allocation" "large_group" {
   }
 }
 ```
+
+-> `request_timeout` is deliberately just under the 5-minute default operation timeout here. Raising it to `300s` or beyond triggers the ordering warning described above, because it would leave a default-timeout operation no room to retry.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,4 +35,4 @@ provider "doit" {
 - `api_token` (String, Sensitive) API Token to access DoiT API. May also be provided by DOIT_API_TOKEN environment variable. Refer to https://developer.doit.com/docs/start
 - `customer_context` (String) Customer context. May also be provided by DOIT_CUSTOMER_CONTEXT environment variable. This field is required for DoiT employees only.
 - `host` (String) URI for DoiT API. May also be provided via DOIT_HOST environment variable. Defaults to https://api.doit.com.
-- `request_timeout` (String) Timeout for individual HTTP requests to the DoiT API, as a duration string (e.g. "30s", "2m"). Defaults to "120s". May also be provided via DOIT_REQUEST_TIMEOUT environment variable.
+- `request_timeout` (String) Timeout for individual HTTP requests to the DoiT API, as a duration string (e.g. "150s", "4m"). Defaults to "150s". Must be greater than "120s" so that slow requests surface the API's own timeout response instead of an opaque local deadline error, and should stay below the operation timeouts so retries remain possible. May also be provided via DOIT_REQUEST_TIMEOUT environment variable.

--- a/internal/provider/account_team_data_source.go
+++ b/internal/provider/account_team_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_account_team"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *accountTeamDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/active_theme_data_source.go
+++ b/internal/provider/active_theme_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_active_theme"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -69,7 +68,7 @@ func (d *activeThemeDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/active_theme_resource.go
+++ b/internal/provider/active_theme_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_active_theme"
@@ -101,7 +100,7 @@ func (r *activeThemeResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -149,7 +148,7 @@ func (r *activeThemeResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -178,7 +177,7 @@ func (r *activeThemeResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -226,7 +225,7 @@ func (r *activeThemeResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/alert_data_source.go
+++ b/internal/provider/alert_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_alert"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -64,7 +63,7 @@ func (ds *alertDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_alert"
@@ -130,7 +129,7 @@ func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -191,7 +190,7 @@ func (r *alertResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -224,7 +223,7 @@ func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -294,7 +293,7 @@ func (r *alertResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/alerts_data_source.go
+++ b/internal/provider/alerts_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_alerts"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -67,7 +66,7 @@ func (d *alertsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/allocation_data_source.go
+++ b/internal/provider/allocation_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_allocation"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -69,7 +68,7 @@ func (ds *allocationDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/allocation_resource.go
+++ b/internal/provider/allocation_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 
@@ -194,7 +193,7 @@ func (r *allocationResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -264,7 +263,7 @@ func (r *allocationResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -295,7 +294,7 @@ func (r *allocationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -378,7 +377,7 @@ func (r *allocationResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/allocations_data_source.go
+++ b/internal/provider/allocations_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_allocations"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *allocationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/annotation_data_source.go
+++ b/internal/provider/annotation_data_source.go
@@ -68,7 +68,7 @@ func (d *annotationDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/annotation_resource.go
+++ b/internal/provider/annotation_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_annotation"
@@ -113,7 +112,7 @@ func (r *annotationResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	createTimeout, createDiags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, createDiags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(createDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -175,7 +174,7 @@ func (r *annotationResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	readTimeout, readDiags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, readDiags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(readDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -208,7 +207,7 @@ func (r *annotationResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	updateTimeout, updateDiags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, updateDiags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(updateDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -278,7 +277,7 @@ func (r *annotationResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	deleteTimeout, deleteDiags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, deleteDiags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(deleteDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/annotations_data_source.go
+++ b/internal/provider/annotations_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_annotations"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -67,7 +66,7 @@ func (d *annotationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/anomalies_data_source.go
+++ b/internal/provider/anomalies_data_source.go
@@ -67,7 +67,7 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/anomaly_data_source.go
+++ b/internal/provider/anomaly_data_source.go
@@ -64,7 +64,7 @@ func (ds *anomalyDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/asset_data_source.go
+++ b/internal/provider/asset_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_asset"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -64,7 +63,7 @@ func (ds *assetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/asset_resource.go
+++ b/internal/provider/asset_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_asset"
@@ -140,7 +139,7 @@ func (r *assetResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	readTimeout, readDiags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, readDiags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(readDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -170,7 +169,7 @@ func (r *assetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	updateTimeout, updateDiags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, updateDiags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(updateDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/assets_data_source.go
+++ b/internal/provider/assets_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_assets"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *assetsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ava_data_source.go
+++ b/internal/provider/ava_data_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 
@@ -92,7 +91,7 @@ func (d *avaDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/budget_data_source.go
+++ b/internal/provider/budget_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_budget"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -69,7 +68,7 @@ func (d *budgetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/budget_resource.go
+++ b/internal/provider/budget_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_budget"
@@ -172,7 +171,7 @@ func (r *budgetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -236,7 +235,7 @@ func (r *budgetResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -269,7 +268,7 @@ func (r *budgetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -339,7 +338,7 @@ func (r *budgetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/budget_suggestions_data_source.go
+++ b/internal/provider/budget_suggestions_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_budget_suggestions"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -69,7 +68,7 @@ func (d *budgetSuggestionsDataSource) Read(ctx context.Context, req datasource.R
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/budgets_data_source.go
+++ b/internal/provider/budgets_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_budgets"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -67,7 +66,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -106,8 +106,9 @@ const (
 
 // The Retry-After cap is only meaningful if a capped wait still leaves room for
 // the retry itself. Enforced at compile time; see timeouts.go for the same
-// technique applied to the timeout defaults.
-const _ = uint(DefaultReadTimeout - maxRetryAfter - minRetryHeadroom)
+// technique applied to the timeout defaults, and for why this is uint64 rather
+// than uint.
+const _ = uint64(DefaultReadTimeout - maxRetryAfter - minRetryHeadroom)
 
 // newRetryBackOff builds the default exponential retry policy.
 //

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -94,9 +94,20 @@ const (
 
 	// maxRetryAfter caps how long a server-supplied Retry-After is honored.
 	// Without it, an outsized value (e.g. "86400") would sit and burn the whole
-	// operation budget doing nothing.
-	maxRetryAfter = 5 * time.Minute
+	// operation budget doing nothing: the retry loop waits on the context, so
+	// once the wait reaches the operation timeout no retry can ever happen.
+	//
+	// It is deliberately tied to retryMaxInterval — we never wait longer than
+	// our own policy's ceiling — which also keeps it well inside the smallest
+	// operation default, so a capped wait still leaves budget for the retry it
+	// was waiting for.
+	maxRetryAfter = retryMaxInterval
 )
+
+// The Retry-After cap is only meaningful if a capped wait still leaves room for
+// the retry itself. Enforced at compile time; see timeouts.go for the same
+// technique applied to the timeout defaults.
+const _ = uint(DefaultReadTimeout - maxRetryAfter - minRetryHeadroom)
 
 // newRetryBackOff builds the default exponential retry policy.
 //
@@ -125,7 +136,7 @@ func newRetryBackOff() *backoff.ExponentialBackOff {
 // cadence that never grows. Falling back to exponential backoff instead keeps
 // the retries spreading out.
 //
-// A honored value is clamped to [retryInitialInterval, maxRetryAfter], so a
+// An honored value is clamped to [retryInitialInterval, maxRetryAfter], so a
 // date a few milliseconds out cannot produce a near-immediate retry either.
 func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 	header = strings.TrimSpace(header)
@@ -135,6 +146,16 @@ func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 
 	var wait time.Duration
 	if seconds, err := strconv.Atoi(header); err == nil {
+		// Reject and cap in units of seconds, before converting to a Duration:
+		// seconds * time.Second overflows int64 for large magnitudes, and a
+		// large negative value would wrap to a positive duration that then
+		// looks like a legitimate wait.
+		if seconds <= 0 {
+			return 0, false
+		}
+		if seconds >= int(maxRetryAfter/time.Second) {
+			return maxRetryAfter, true
+		}
 		wait = time.Duration(seconds) * time.Second
 	} else {
 		t, parseErr := http.ParseTime(header)

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -14,12 +14,9 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"golang.org/x/oauth2"
 )
-
-// DefaultRequestTimeout is the default timeout for individual HTTP requests
-// to the DoiT API. This matches the Google Cloud Terraform provider's default.
-const DefaultRequestTimeout = 120 * time.Second
 
 // DCIRetryClient wraps an HTTP client with retry logic tailored for the DoiT Console API (DCI).
 //
@@ -47,7 +44,8 @@ const DefaultRequestTimeout = 120 * time.Second
 //   - 503 (Service Unavailable): Temporary server overload
 //   - 504 (Gateway Timeout): Temporary timeout
 //
-// All other 4xx/5xx errors are treated as permanent failures (no retry).
+// All other 4xx/5xx errors are treated as permanent failures (no retry). This
+// deliberately includes 524 — see httpStatusCloudflareTimeout.
 //
 // # NOT Suitable For
 //
@@ -59,6 +57,97 @@ const DefaultRequestTimeout = 120 * time.Second
 // If you need a general-purpose retry client, use go-retryablehttp instead.
 type DCIRetryClient struct {
 	client *http.Client
+
+	// newBackOff builds the retry policy for a single Do call. When nil,
+	// newRetryBackOff is used. Tests inject a fast policy so they do not sleep
+	// for real — the backoff library's timer hook is unexported, so this is the
+	// only way to control retry timing.
+	//
+	// This is deliberately a factory rather than a backoff.BackOff value:
+	// ExponentialBackOff is not thread-safe and NextBackOff mutates its own
+	// state, while one DCIRetryClient is shared by every resource for the whole
+	// provider lifetime and Terraform runs operations concurrently. A shared
+	// instance would have concurrent Do calls resetting and advancing each
+	// other's intervals.
+	newBackOff func() backoff.BackOff
+}
+
+// httpStatusCloudflareTimeout is Cloudflare's non-standard 524 "A Timeout
+// Occurred" status, returned when the origin does not respond within the edge
+// timeout (see cloudflareEdgeTimeout). Go's net/http has no constant for it.
+//
+// It is intentionally NOT retryable: the query already ran for the full edge
+// timeout, so an immediate identical retry would only re-run an expensive query
+// that is going to time out again. Falling through to the permanent-error branch
+// turns it into one fast, self-explanatory failure.
+const httpStatusCloudflareTimeout = 524
+
+// Retry policy tuning. The DoiT API returns 429 without a Retry-After header,
+// so the exponential policy — not the server's guidance — governs the pace of
+// nearly every retry. It therefore starts conservatively: a 429 means the
+// backend is already under pressure, and retrying a few hundred milliseconds
+// later just sustains the condition.
+const (
+	retryInitialInterval = 2 * time.Second
+	retryMultiplier      = 2.0
+	retryMaxInterval     = 60 * time.Second
+
+	// maxRetryAfter caps how long a server-supplied Retry-After is honored.
+	// Without it, an outsized value (e.g. "86400") would sit and burn the whole
+	// operation budget doing nothing.
+	maxRetryAfter = 5 * time.Minute
+)
+
+// newRetryBackOff builds the default exponential retry policy.
+//
+// It returns the concrete type rather than backoff.BackOff so tests can assert
+// on the configured fields directly.
+func newRetryBackOff() *backoff.ExponentialBackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = retryInitialInterval
+	b.Multiplier = retryMultiplier
+	b.MaxInterval = retryMaxInterval
+	return b
+}
+
+// parseRetryAfter interprets an HTTP Retry-After header value, returning the
+// duration to wait and whether the header was usable.
+//
+// Both forms from RFC 7231 are accepted: delay-seconds, and an HTTP-date (all
+// three date formats, via http.ParseTime). An absent, malformed, or already-past
+// value returns false, leaving the caller on exponential backoff.
+//
+// Non-positive values ("0", "-5", or a date already in the past) are rejected
+// rather than honored as "retry immediately". Honoring them would be actively
+// harmful twice over: it schedules a retry with no delay, and because the
+// backoff library resets the exponential policy whenever a Retry-After is
+// honored, a server repeatedly sending such a value would pin us to a flat
+// cadence that never grows. Falling back to exponential backoff instead keeps
+// the retries spreading out.
+//
+// A honored value is clamped to [retryInitialInterval, maxRetryAfter], so a
+// date a few milliseconds out cannot produce a near-immediate retry either.
+func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, false
+	}
+
+	var wait time.Duration
+	if seconds, err := strconv.Atoi(header); err == nil {
+		wait = time.Duration(seconds) * time.Second
+	} else {
+		t, parseErr := http.ParseTime(header)
+		if parseErr != nil {
+			return 0, false
+		}
+		wait = t.Sub(now)
+	}
+
+	if wait <= 0 {
+		return 0, false
+	}
+	return min(max(wait, retryInitialInterval), maxRetryAfter), true
 }
 
 // Do executes an HTTP request with retry logic for transient errors.
@@ -76,11 +165,14 @@ type DCIRetryClient struct {
 // | 404 | Pass through - NOT an error (for Terraform resource semantics) |
 // | 429 | Retry with Retry-After or exponential backoff |
 // | 502, 503, 504 | Retry with exponential backoff |
+// | 524 | Permanent error - no retry (Cloudflare edge timeout) |
 // | Other 4xx/5xx | Permanent error - no retry |
 //
 // # Timeout
 //
-// Operations have a maximum elapsed time of 2 minutes, after which they fail.
+// The retry loop has no elapsed-time limit of its own (MaxElapsedTime is 0). It
+// defers entirely to the deadline on the request's context, which is the
+// Terraform operation timeout — see timeouts.go.
 func (c *DCIRetryClient) Do(req *http.Request) (*http.Response, error) {
 	// Preserve the original body for retries.
 	// If the request has a body, we need to be able to re-read it on retries.
@@ -121,23 +213,18 @@ func (c *DCIRetryClient) Do(req *http.Request) (*http.Response, error) {
 				log.Printf("[WARN] Error closing response body: %v", closeErr)
 			}
 
-			if retryAfter != "" {
-				// Try parsing as seconds (most common)
-				if seconds, parseErr := strconv.Atoi(retryAfter); parseErr == nil {
-					// Use backoff v5's integrated RetryAfter to respect the header
-					return nil, backoff.RetryAfter(seconds)
-				}
-				// Try parsing as HTTP-date (RFC 7231)
-				if t, parseErr := time.Parse(time.RFC1123, retryAfter); parseErr == nil {
-					waitDuration := time.Until(t)
-					if waitDuration > 0 {
-						// Round up to ensure we wait at least the requested time
-						seconds := int(waitDuration.Seconds()) + 1
-						return nil, backoff.RetryAfter(seconds)
-					}
-				}
-				// If parsing fails, fall back to exponential backoff
+			if wait, ok := parseRetryAfter(retryAfter, time.Now()); ok {
+				tflog.Debug(req.Context(), "Rate limited, honoring Retry-After", map[string]any{
+					"url":         req.URL.String(),
+					"retry_after": retryAfter,
+					"wait":        wait.String(),
+				})
+				return nil, &backoff.RetryAfterError{Duration: wait}
 			}
+			tflog.Debug(req.Context(), "Rate limited, falling back to exponential backoff", map[string]any{
+				"url":         req.URL.String(),
+				"retry_after": retryAfter,
+			})
 			return nil, fmt.Errorf("rate limit exceeded: %d", resp.StatusCode)
 
 		case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
@@ -160,6 +247,10 @@ func (c *DCIRetryClient) Do(req *http.Request) (*http.Response, error) {
 			// This includes:
 			// - 4xx client errors (400, 401, 403, etc.)
 			// - 5xx server errors that shouldn't be retried (500, 501, etc.)
+			// - 524 (httpStatusCloudflareTimeout): the edge already waited out
+			//   the full origin timeout, so retrying re-runs a query that will
+			//   time out again. Failing fast here is what surfaces the 524 to
+			//   the user instead of an opaque deadline error.
 			if resp.StatusCode >= 400 {
 				respBodyBytes, readErr := io.ReadAll(resp.Body)
 				closeErr := resp.Body.Close()
@@ -176,11 +267,18 @@ func (c *DCIRetryClient) Do(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	// A fresh policy per call: ExponentialBackOff is not thread-safe, and this
+	// client is shared across concurrent Terraform operations.
+	newBackOff := c.newBackOff
+	if newBackOff == nil {
+		newBackOff = func() backoff.BackOff { return newRetryBackOff() }
+	}
+
 	// Retry with exponential backoff. MaxElapsedTime is disabled (0) so the
 	// retry loop defers entirely to the provided context's deadline
 	// (e.g., Terraform's timeouts {} block).
 	return backoff.Retry(req.Context(), operation,
-		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithBackOff(newBackOff()),
 		backoff.WithMaxElapsedTime(0),
 	)
 }

--- a/internal/provider/cloud_diagrams_activity_groups_data_source.go
+++ b/internal/provider/cloud_diagrams_activity_groups_data_source.go
@@ -72,7 +72,7 @@ func (d *cloudDiagramsActivityGroupsDataSource) Read(ctx context.Context, req da
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_cost_snapshot_data_source.go
+++ b/internal/provider/cloud_diagrams_cost_snapshot_data_source.go
@@ -73,7 +73,7 @@ func (d *cloudDiagramsCostSnapshotDataSource) Read(ctx context.Context, req data
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_data_source.go
+++ b/internal/provider/cloud_diagrams_data_source.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_cloud_diagrams"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -93,7 +92,7 @@ func (d *cloudDiagramsDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_export_data_source.go
+++ b/internal/provider/cloud_diagrams_export_data_source.go
@@ -74,7 +74,7 @@ func (d *cloudDiagramsExportDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_node_activities_data_source.go
+++ b/internal/provider/cloud_diagrams_node_activities_data_source.go
@@ -87,7 +87,7 @@ func (d *cloudDiagramsNodeActivitiesDataSource) Read(ctx context.Context, req da
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_relationships_data_source.go
+++ b/internal/provider/cloud_diagrams_relationships_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	ds "github.com/doitintl/terraform-provider-doit/internal/provider/datasource_cloud_diagrams_relationships"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -71,7 +70,7 @@ func (d *cloudDiagramsRelationshipsDataSource) Read(ctx context.Context, req dat
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_schemes_data_source.go
+++ b/internal/provider/cloud_diagrams_schemes_data_source.go
@@ -106,7 +106,7 @@ func (d *cloudDiagramsSchemesDataSource) Read(ctx context.Context, req datasourc
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_search_data_source.go
+++ b/internal/provider/cloud_diagrams_search_data_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_cloud_diagrams_search"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -121,7 +120,7 @@ func (d *cloudDiagramsSearchDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_snapshot_data_source.go
+++ b/internal/provider/cloud_diagrams_snapshot_data_source.go
@@ -82,7 +82,7 @@ func (d *cloudDiagramsSnapshotDataSource) Read(ctx context.Context, req datasour
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_snapshots_data_source.go
+++ b/internal/provider/cloud_diagrams_snapshots_data_source.go
@@ -69,7 +69,7 @@ func (d *cloudDiagramsSnapshotsDataSource) Read(ctx context.Context, req datasou
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_stats_data_source.go
+++ b/internal/provider/cloud_diagrams_stats_data_source.go
@@ -94,7 +94,7 @@ func (d *cloudDiagramsStatsDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_diagrams_statussheet_data_source.go
+++ b/internal/provider/cloud_diagrams_statussheet_data_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_cloud_diagrams_statussheet"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -134,7 +133,7 @@ func (d *cloudDiagramsStatussheetDataSource) Read(ctx context.Context, req datas
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_incident_data_source.go
+++ b/internal/provider/cloud_incident_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_cloud_incident"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -62,7 +61,7 @@ func (ds *cloudIncidentDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_incidents_data_source.go
+++ b/internal/provider/cloud_incidents_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_cloud_incidents"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *cloudIncidentsDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloudconnect_aws_account_data_source.go
+++ b/internal/provider/cloudconnect_aws_account_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_cloudconnect_aws_account"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -73,7 +72,7 @@ func (d *cloudconnectAwsAccountDataSource) Read(ctx context.Context, req datasou
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloudconnect_aws_account_resource.go
+++ b/internal/provider/cloudconnect_aws_account_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_cloudconnect_aws_account"
@@ -132,7 +131,7 @@ func (r *cloudconnectAwsAccountResource) Create(ctx context.Context, req resourc
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -206,7 +205,7 @@ func (r *cloudconnectAwsAccountResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -239,7 +238,7 @@ func (r *cloudconnectAwsAccountResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -310,7 +309,7 @@ func (r *cloudconnectAwsAccountResource) Delete(ctx context.Context, req resourc
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/commitment_data_source.go
+++ b/internal/provider/commitment_data_source.go
@@ -77,7 +77,7 @@ func (ds *commitmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/commitments_data_source.go
+++ b/internal/provider/commitments_data_source.go
@@ -64,7 +64,7 @@ func (d *commitmentsDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/current_user_data_source.go
+++ b/internal/provider/current_user_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_current_user"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -65,7 +64,7 @@ func (d *currentUserDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/custom_theme_data_source.go
+++ b/internal/provider/custom_theme_data_source.go
@@ -71,7 +71,7 @@ func (d *customThemeDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/custom_theme_resource.go
+++ b/internal/provider/custom_theme_resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_custom_theme"
@@ -125,7 +124,7 @@ func (r *customThemeResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -185,7 +184,7 @@ func (r *customThemeResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -218,7 +217,7 @@ func (r *customThemeResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -286,7 +285,7 @@ func (r *customThemeResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/custom_themes_data_source.go
+++ b/internal/provider/custom_themes_data_source.go
@@ -71,7 +71,7 @@ func (d *customThemesDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/datahub_dataset_data_source.go
+++ b/internal/provider/datahub_dataset_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_datahub_dataset"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -64,7 +63,7 @@ func (ds *datahubDatasetDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/datahub_dataset_resource.go
+++ b/internal/provider/datahub_dataset_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_datahub_dataset"
@@ -95,7 +94,7 @@ func (r *datahubDatasetResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -143,7 +142,7 @@ func (r *datahubDatasetResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -174,7 +173,7 @@ func (r *datahubDatasetResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -228,7 +227,7 @@ func (r *datahubDatasetResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/datahub_datasets_data_source.go
+++ b/internal/provider/datahub_datasets_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_datahub_datasets"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -65,7 +64,7 @@ func (d *datahubDatasetsDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dimension_data_source.go
+++ b/internal/provider/dimension_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_dimension"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -63,7 +62,7 @@ func (d *dimensionDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dimensions_data_source.go
+++ b/internal/provider/dimensions_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_dimensions"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *dimensionsDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/folder_data_source.go
+++ b/internal/provider/folder_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_folder"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -69,7 +68,7 @@ func (d *folderDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/folder_resource.go
+++ b/internal/provider/folder_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_folder"
@@ -107,7 +106,7 @@ func (r *folderResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -160,7 +159,7 @@ func (r *folderResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -193,7 +192,7 @@ func (r *folderResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -254,7 +253,7 @@ func (r *folderResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/folders_data_source.go
+++ b/internal/provider/folders_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_folders"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -69,7 +68,7 @@ func (d *foldersDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/insight_data_source.go
+++ b/internal/provider/insight_data_source.go
@@ -62,7 +62,7 @@ func (ds *insightDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/insight_resource.go
+++ b/internal/provider/insight_resource.go
@@ -300,7 +300,7 @@ func (r *insightResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	createTimeout, createDiags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, createDiags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(createDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -360,7 +360,7 @@ func (r *insightResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	readTimeout, readDiags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, readDiags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(readDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -391,7 +391,7 @@ func (r *insightResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	updateTimeout, updateDiags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, updateDiags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(updateDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -453,7 +453,7 @@ func (r *insightResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	deleteTimeout, deleteDiags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, deleteDiags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(deleteDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/insight_resource_results_data_source.go
+++ b/internal/provider/insight_resource_results_data_source.go
@@ -62,7 +62,7 @@ func (ds *insightResourceResultsDataSource) Read(ctx context.Context, req dataso
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/insight_resource_results_resource.go
+++ b/internal/provider/insight_resource_results_resource.go
@@ -685,7 +685,7 @@ func (r *insightResourceResultsResource) Create(ctx context.Context, req resourc
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -744,7 +744,7 @@ func (r *insightResourceResultsResource) Read(ctx context.Context, req resource.
 		}
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -844,7 +844,7 @@ func (r *insightResourceResultsResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -893,7 +893,7 @@ func (r *insightResourceResultsResource) Delete(ctx context.Context, req resourc
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/insights_data_source.go
+++ b/internal/provider/insights_data_source.go
@@ -62,7 +62,7 @@ func (ds *insightsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/invoice_data_source.go
+++ b/internal/provider/invoice_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_invoice"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -63,7 +62,7 @@ func (ds *invoiceDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/invoices_data_source.go
+++ b/internal/provider/invoices_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_invoices"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *invoicesDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/label_assignments_data_source.go
+++ b/internal/provider/label_assignments_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_label_assignments"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -67,7 +66,7 @@ func (d *labelAssignmentsDataSource) Read(ctx context.Context, req datasource.Re
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/label_assignments_resource.go
+++ b/internal/provider/label_assignments_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -146,7 +145,7 @@ func (r *labelAssignmentsResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -195,7 +194,7 @@ func (r *labelAssignmentsResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -253,7 +252,7 @@ func (r *labelAssignmentsResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -310,7 +309,7 @@ func (r *labelAssignmentsResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/label_data_source.go
+++ b/internal/provider/label_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_label"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -67,7 +66,7 @@ func (d *labelDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/label_resource.go
+++ b/internal/provider/label_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_label"
@@ -99,7 +98,7 @@ func (r *labelResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -152,7 +151,7 @@ func (r *labelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -185,7 +184,7 @@ func (r *labelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -246,7 +245,7 @@ func (r *labelResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/labels_data_source.go
+++ b/internal/provider/labels_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_labels"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *labelsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/organizations_data_source.go
+++ b/internal/provider/organizations_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_organizations"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -68,7 +67,7 @@ func (d *organizationsDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/platforms_data_source.go
+++ b/internal/provider/platforms_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_platforms"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *platformsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/products_data_source.go
+++ b/internal/provider/products_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_products"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *productsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -213,7 +213,7 @@ func (p *doitProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 			resp.Diagnostics.AddAttributeError(
 				path.Root("request_timeout"),
 				"Invalid Request Timeout",
-				fmt.Sprintf("Could not parse request_timeout %q as a duration: %s. Use Go duration format, e.g. \"30s\", \"2m\", \"1h\".", config.RequestTimeout.ValueString(), err),
+				fmt.Sprintf("Could not parse request_timeout %q as a duration: %s. Use Go duration format, e.g. \"150s\", \"4m\", \"1h\".", config.RequestTimeout.ValueString(), err),
 			)
 		}
 	}
@@ -222,7 +222,7 @@ func (p *doitProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		resp.Diagnostics.AddAttributeError(
 			path.Root("request_timeout"),
 			"Invalid Request Timeout",
-			fmt.Sprintf("request_timeout must be a positive duration, got %q. Use Go duration format, e.g. \"30s\", \"2m\", \"1h\".", requestTimeout.String()),
+			fmt.Sprintf("request_timeout must be a positive duration, got %q. Use Go duration format, e.g. \"150s\", \"4m\", \"1h\".", requestTimeout.String()),
 		)
 	} else {
 		// Check the resolved value against the timeout ordering invariant. The

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -78,10 +79,19 @@ func (p *doitProvider) Schema(ctx context.Context, _ provider.SchemaRequest, res
 				Optional: true,
 			},
 			"request_timeout": schema.StringAttribute{
+				// Durations are spelled out rather than interpolated from the
+				// constants: Duration.String() would render 150s as "2m30s",
+				// which is not how a user writes the value.
 				Description: "Timeout for individual HTTP requests to the DoiT API, as a duration " +
-					"string (e.g. \"30s\", \"2m\"). Defaults to \"120s\". " +
+					"string (e.g. \"150s\", \"4m\"). Defaults to \"150s\". " +
+					"Must be greater than \"120s\" so that slow requests surface the API's own " +
+					"timeout response instead of an opaque local deadline error, and should stay " +
+					"below the operation timeouts so retries remain possible. " +
 					"May also be provided via DOIT_REQUEST_TIMEOUT environment variable.",
 				Optional: true,
+				Validators: []validator.String{
+					requestTimeoutValidator{},
+				},
 			},
 		},
 	}
@@ -214,6 +224,11 @@ func (p *doitProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 			"Invalid Request Timeout",
 			fmt.Sprintf("request_timeout must be a positive duration, got %q. Use Go duration format, e.g. \"30s\", \"2m\", \"1h\".", requestTimeout.String()),
 		)
+	} else {
+		// Check the resolved value against the timeout ordering invariant. The
+		// schema validator covers the HCL attribute at validate time; this is
+		// the only path that also covers DOIT_REQUEST_TIMEOUT.
+		resp.Diagnostics.Append(validateRequestTimeout(requestTimeout)...)
 	}
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/ps4c_aws_organization_data_source.go
+++ b/internal/provider/ps4c_aws_organization_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_ps4c_aws_organization"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -65,7 +64,7 @@ func (d *ps4cAwsOrganizationDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ps4c_aws_organizations_data_source.go
+++ b/internal/provider/ps4c_aws_organizations_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_ps4c_aws_organizations"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *ps4cAwsOrganizationsDataSource) Read(ctx context.Context, req datasourc
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/report_data_source.go
+++ b/internal/provider/report_data_source.go
@@ -70,7 +70,7 @@ func (ds *reportDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/report_query_data_source.go
+++ b/internal/provider/report_query_data_source.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_report"
@@ -183,7 +182,7 @@ func (d *reportQueryDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/report_resource.go
+++ b/internal/provider/report_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_report"
@@ -303,7 +302,7 @@ func (r *reportResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -371,7 +370,7 @@ func (r *reportResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -402,7 +401,7 @@ func (r *reportResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -474,7 +473,7 @@ func (r *reportResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/report_result_data_source.go
+++ b/internal/provider/report_result_data_source.go
@@ -188,7 +188,7 @@ func (d *reportResultDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/reports_data_source.go
+++ b/internal/provider/reports_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_reports"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -67,7 +66,7 @@ func (d *reportsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/request_timeout_validator.go
+++ b/internal/provider/request_timeout_validator.go
@@ -39,7 +39,7 @@ func (v requestTimeoutValidator) ValidateString(_ context.Context, req validator
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Invalid Request Timeout",
-			fmt.Sprintf("Could not parse request_timeout %q as a duration: %s. Use Go duration format, e.g. \"30s\", \"2m\", \"1h\".", value, err),
+			fmt.Sprintf("Could not parse request_timeout %q as a duration: %s. Use Go duration format, e.g. \"150s\", \"4m\", \"1h\".", value, err),
 		)
 		return
 	}

--- a/internal/provider/request_timeout_validator.go
+++ b/internal/provider/request_timeout_validator.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// requestTimeoutValidator validates the provider's request_timeout attribute:
+// the value must be a Go duration string, and must satisfy the timeout ordering
+// invariant documented in timeouts.go.
+//
+// This runs at terraform validate time, so a misconfigured timeout is reported
+// before any API call. It only sees the HCL attribute — the equivalent check on
+// the resolved value (which also covers DOIT_REQUEST_TIMEOUT) lives in the
+// provider's Configure. Both delegate to validateRequestTimeout.
+var _ validator.String = requestTimeoutValidator{}
+
+type requestTimeoutValidator struct{}
+
+func (v requestTimeoutValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("Validates that the value is a Go duration string greater than %s.", cloudflareEdgeTimeout)
+}
+
+func (v requestTimeoutValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Validates that the value is a Go duration string greater than `%s`.", cloudflareEdgeTimeout)
+}
+
+func (v requestTimeoutValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+	requestTimeout, err := time.ParseDuration(value)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Request Timeout",
+			fmt.Sprintf("Could not parse request_timeout %q as a duration: %s. Use Go duration format, e.g. \"30s\", \"2m\", \"1h\".", value, err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(validateRequestTimeout(requestTimeout)...)
+}

--- a/internal/provider/roles_data_source.go
+++ b/internal/provider/roles_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_roles"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -66,7 +65,7 @@ func (d *rolesDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/service_quotas_data_source.go
+++ b/internal/provider/service_quotas_data_source.go
@@ -74,7 +74,7 @@ func (d *serviceQuotasDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/sharing_data_source.go
+++ b/internal/provider/sharing_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_sharing"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -75,7 +74,7 @@ func (d *sharingDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/sharing_resource.go
+++ b/internal/provider/sharing_resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_sharing"
@@ -169,7 +168,7 @@ func (r *sharingResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -230,7 +229,7 @@ func (r *sharingResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -260,7 +259,7 @@ func (r *sharingResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -321,7 +320,7 @@ func (r *sharingResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/support_request_comments_data_source.go
+++ b/internal/provider/support_request_comments_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	ds "github.com/doitintl/terraform-provider-doit/internal/provider/datasource_support_request_comments"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -65,7 +64,7 @@ func (d *supportRequestCommentsDataSource) Read(ctx context.Context, req datasou
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/support_request_data_source.go
+++ b/internal/provider/support_request_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_support_request"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -64,7 +63,7 @@ func (ds *supportRequestDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/support_request_tags_resource.go
+++ b/internal/provider/support_request_tags_resource.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -130,7 +129,7 @@ func (r *supportRequestTagsResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,7 +178,7 @@ func (r *supportRequestTagsResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -209,7 +208,7 @@ func (r *supportRequestTagsResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -241,7 +240,7 @@ func (r *supportRequestTagsResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/support_requests_data_source.go
+++ b/internal/provider/support_requests_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/datasource_support_requests"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
@@ -67,7 +66,7 @@ func (d *supportRequestsDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/timeout_test.go
+++ b/internal/provider/timeout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -23,101 +24,334 @@ func newTimeoutTestServer(handler http.HandlerFunc) *httptest.Server {
 	}))
 }
 
+// countingServer returns a test server wrapping handler with a request counter.
+// The counter is incremented before handler runs, so it reflects requests that
+// reached the server even if the client later abandons them.
+func countingServer(count *atomic.Int64, handler http.HandlerFunc) *httptest.Server {
+	return newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		handler(w, r)
+	})
+}
+
+// respondAfter writes status once delay has elapsed, or returns immediately if
+// the client disconnects first. Honoring the request context matters: without it
+// httptest.Server.Close blocks draining handlers the client already abandoned,
+// which would add the full delay to every timeout test.
+func respondAfter(delay time.Duration, status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(delay):
+			w.WriteHeader(status)
+		case <-r.Context().Done():
+		}
+	}
+}
+
+// doGet issues a GET through the retry client and closes any response body.
+func doGet(ctx context.Context, t *testing.T, c *DCIRetryClient, url string) (*http.Response, error) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() error = %v", err)
+	}
+
+	resp, err := c.Do(req)
+	if resp != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+	return resp, err
+}
+
 // TestDCIRetryClient_RequestTimeout verifies that a per-request timeout is
-// enforced: when the server takes longer than the configured timeout, the
-// client returns a timeout error for each attempt. With MaxElapsedTime=0,
-// retries continue until the context deadline.
+// enforced: when the server takes longer than the configured timeout, each
+// attempt is cancelled locally. With MaxElapsedTime=0, retries continue until
+// the context deadline.
 func TestDCIRetryClient_RequestTimeout(t *testing.T) {
 	t.Parallel()
 
-	serverDelay := 3 * time.Second
-	clientTimeout := 1 * time.Second
+	const (
+		serverDelay   = 200 * time.Millisecond
+		clientTimeout = 50 * time.Millisecond
+	)
 
 	var requestCount atomic.Int64
-	server := newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
-		time.Sleep(serverDelay)
-		w.WriteHeader(http.StatusOK)
-	})
+	server := countingServer(&requestCount, respondAfter(serverDelay, http.StatusOK))
 	defer server.Close()
 
-	client, err := NewClient(
-		context.Background(),
-		server.URL, "test-token", "", "1.0.0", "dev", clientTimeout,
-	)
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
-	}
+	client := newTestRetryClient(clientTimeout, constantBackOff(time.Millisecond))
 
-	// Use a bounded context — with MaxElapsedTime=0, retries continue
-	// until the context deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	start := time.Now()
-	_, err = client.GetAlertWithResponse(ctx, "test-id")
+	_, err := doGet(ctx, t, client, server.URL)
 	elapsed := time.Since(start)
 
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
 
-	count := requestCount.Load()
-
-	// Should have made multiple attempts (each timing out at clientTimeout)
-	if count < 2 {
+	// Each attempt should be cut off at clientTimeout, leaving room for several
+	// attempts inside the context deadline.
+	if count := requestCount.Load(); count < 2 {
 		t.Fatalf("expected at least 2 attempts, got %d", count)
 	}
 
-	t.Logf("Made %d attempts in %v (per-request timeout %v)", count, elapsed, clientTimeout)
+	t.Logf("Made %d attempts in %v (per-request timeout %v)", requestCount.Load(), elapsed, clientTimeout)
 }
 
 // TestDCIRetryClient_ContextCancellation verifies that a parent context
-// cancellation propagates through the retry loop and stops retries early.
+// cancellation propagates through the retry loop and stops retries early, even
+// when the per-request timeout is far larger.
 func TestDCIRetryClient_ContextCancellation(t *testing.T) {
 	t.Parallel()
 
-	clientTimeout := 30 * time.Second // High per-request timeout
-	parentTimeout := 2 * time.Second  // Short parent context
+	const (
+		clientTimeout = 10 * time.Second       // deliberately never reached
+		parentTimeout = 300 * time.Millisecond // the real bound
+	)
 
-	server := newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(5 * time.Second) // Always slow
-		w.WriteHeader(http.StatusOK)
-	})
+	server := newTimeoutTestServer(respondAfter(5*time.Second, http.StatusOK))
 	defer server.Close()
 
-	client, err := NewClient(
-		context.Background(),
-		server.URL, "test-token", "", "1.0.0", "dev", clientTimeout,
-	)
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
-	}
+	client := newTestRetryClient(clientTimeout, constantBackOff(time.Millisecond))
 
 	ctx, cancel := context.WithTimeout(context.Background(), parentTimeout)
 	defer cancel()
 
 	start := time.Now()
-	_, err = client.GetAlertWithResponse(ctx, "test-id")
+	_, err := doGet(ctx, t, client, server.URL)
 	elapsed := time.Since(start)
 
 	if err == nil {
 		t.Fatal("expected context cancellation error, got nil")
 	}
 
-	// Should complete around the parent timeout, not the per-request timeout
-	maxExpected := 2 * parentTimeout
-	if elapsed > maxExpected {
+	// Should complete around the parent timeout, not the per-request timeout.
+	if maxExpected := 2 * parentTimeout; elapsed > maxExpected {
 		t.Fatalf("expected to complete within %v, took %v", maxExpected, elapsed)
 	}
 	t.Logf("Cancelled after %v (parent timeout %v)", elapsed, parentTimeout)
+}
+
+// TestDCIRetryClient_RetryRespectsContextDeadline verifies that the retry loop
+// defers to the context deadline (MaxElapsedTime = 0). Retries continue until
+// the context is cancelled, not until a hardcoded elapsed time.
+func TestDCIRetryClient_RetryRespectsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	const contextDeadline = 300 * time.Millisecond
+
+	var requestCount atomic.Int64
+	server := countingServer(&requestCount, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // 503 triggers retry
+	})
+	defer server.Close()
+
+	client := newTestRetryClient(10*time.Second, constantBackOff(25*time.Millisecond))
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextDeadline)
+	defer cancel()
+
+	start := time.Now()
+	_, err := doGet(ctx, t, client, server.URL)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected context deadline error, got nil")
+	}
+
+	if maxExpected := 2 * contextDeadline; elapsed > maxExpected {
+		t.Fatalf("expected to complete around %v, took %v", contextDeadline, elapsed)
+	}
+	if count := requestCount.Load(); count < 2 {
+		t.Fatalf("expected at least 2 retry attempts, got %d", count)
+	}
+
+	t.Logf("Retried %d times in %v (context deadline %v)", requestCount.Load(), elapsed, contextDeadline)
+}
+
+// TestDCIRetryClient_CloudflareTimeoutIsPermanent is the regression test for the
+// failure this timeout work addresses.
+//
+// A 524 means the API's edge already waited out the full origin timeout, so the
+// response must fail fast rather than re-running an expensive query. The injected
+// backoff is long enough that a single retry would blow the context deadline —
+// so the request count is what proves no retry happened.
+func TestDCIRetryClient_CloudflareTimeoutIsPermanent(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int64
+	server := countingServer(&requestCount, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(httpStatusCloudflareTimeout)
+		_, _ = w.Write([]byte("error code: 524"))
+	})
+	defer server.Close()
+
+	client := newTestRetryClient(10*time.Second, constantBackOff(10*time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := doGet(ctx, t, client, server.URL)
+
+	if err == nil {
+		t.Fatal("expected an error for 524, got nil")
+	}
+	if count := requestCount.Load(); count != 1 {
+		t.Errorf("expected exactly 1 attempt (524 must not be retried), got %d", count)
+	}
+	// backoff.Retry unwraps PermanentError, so the caller sees the inner error
+	// rather than a *backoff.PermanentError — assert on the message instead.
+	if !strings.Contains(err.Error(), "524") {
+		t.Errorf("error should mention the 524 status, got: %v", err)
+	}
+}
+
+// TestDCIRetryClient_429NoRetryAfter_Retries covers the DoiT API's actual
+// observed behavior: 429 responses carry no Retry-After header, so the retry
+// falls back to the exponential policy.
+func TestDCIRetryClient_429NoRetryAfter_Retries(t *testing.T) {
+	t.Parallel()
+
+	const failures = 2
+
+	var requestCount atomic.Int64
+	server := countingServer(&requestCount, func(w http.ResponseWriter, _ *http.Request) {
+		if requestCount.Load() <= failures {
+			w.WriteHeader(http.StatusTooManyRequests) // deliberately no Retry-After
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer server.Close()
+
+	client := newTestRetryClient(10*time.Second, constantBackOff(time.Millisecond))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := doGet(ctx, t, client, server.URL)
+
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if count := requestCount.Load(); count != failures+1 {
+		t.Errorf("expected %d attempts, got %d", failures+1, count)
+	}
+}
+
+// TestDCIRetryClient_429WithRetryAfter_Honored verifies a server-supplied
+// Retry-After takes precedence over the exponential policy. The injected policy
+// would wait 10s, so completing in roughly the header's delay proves the header
+// won.
+func TestDCIRetryClient_429WithRetryAfter_Honored(t *testing.T) {
+	t.Parallel()
+
+	// retryInitialInterval is the floor parseRetryAfter clamps to, so asking for
+	// exactly that keeps the test as short as the floor allows.
+	retryAfter := retryInitialInterval
+
+	var requestCount atomic.Int64
+	server := countingServer(&requestCount, func(w http.ResponseWriter, _ *http.Request) {
+		if requestCount.Load() == 1 {
+			w.Header().Set("Retry-After", strconv.Itoa(int(retryAfter.Seconds())))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer server.Close()
+
+	client := newTestRetryClient(10*time.Second, constantBackOff(10*time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := doGet(ctx, t, client, server.URL)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected success after honoring Retry-After, got error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if count := requestCount.Load(); count != 2 {
+		t.Errorf("expected 2 attempts, got %d", count)
+	}
+	// Generous lower bound for timer granularity; the upper bound is what proves
+	// the 10s policy was not used.
+	if elapsed < retryAfter-50*time.Millisecond || elapsed > 5*time.Second {
+		t.Errorf("elapsed = %v, want approximately the Retry-After delay of %v", elapsed, retryAfter)
+	}
+}
+
+// TestDCIRetryClient_404PassesThrough guards the client's most load-bearing
+// documented behavior: a 404 is returned as a normal response, not an error, so
+// resource handlers can interpret it contextually (Read: externally deleted,
+// Delete: already gone).
+func TestDCIRetryClient_404PassesThrough(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int64
+	server := countingServer(&requestCount, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer server.Close()
+
+	client := newTestRetryClient(10*time.Second, constantBackOff(10*time.Second))
+
+	resp, err := doGet(context.Background(), t, client, server.URL)
+
+	if err != nil {
+		t.Fatalf("404 must not be an error, got: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	if count := requestCount.Load(); count != 1 {
+		t.Errorf("expected exactly 1 attempt (404 must not be retried), got %d", count)
+	}
+}
+
+// TestDCIRetryClient_500NotRetried guards the documented decision not to retry
+// 500, unlike 502/503/504.
+func TestDCIRetryClient_500NotRetried(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int64
+	server := countingServer(&requestCount, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	client := newTestRetryClient(10*time.Second, constantBackOff(10*time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := doGet(ctx, t, client, server.URL)
+
+	if err == nil {
+		t.Fatal("expected an error for 500, got nil")
+	}
+	if count := requestCount.Load(); count != 1 {
+		t.Errorf("expected exactly 1 attempt (500 must not be retried), got %d", count)
+	}
 }
 
 // TestNewClient_CustomTimeout verifies that NewClient accepts a custom timeout.
 func TestNewClient_CustomTimeout(t *testing.T) {
 	t.Parallel()
 
-	server := newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
+	server := newTimeoutTestServer(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	defer server.Close()
@@ -134,12 +368,12 @@ func TestNewClient_CustomTimeout(t *testing.T) {
 	}
 }
 
-// TestNewClient_DefaultTimeout verifies that DefaultRequestTimeout (120s)
-// is a valid configuration value.
+// TestNewClient_DefaultTimeout verifies that DefaultRequestTimeout is a valid
+// configuration value.
 func TestNewClient_DefaultTimeout(t *testing.T) {
 	t.Parallel()
 
-	server := newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
+	server := newTimeoutTestServer(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	defer server.Close()
@@ -154,54 +388,4 @@ func TestNewClient_DefaultTimeout(t *testing.T) {
 	if client == nil {
 		t.Fatal("NewClient() returned nil client")
 	}
-}
-
-// TestDCIRetryClient_RetryRespectsContextDeadline verifies that the retry
-// loop defers to the context deadline (MaxElapsedTime = 0). Retries continue
-// until the context is cancelled, not until a hardcoded elapsed time.
-func TestDCIRetryClient_RetryRespectsContextDeadline(t *testing.T) {
-	t.Parallel()
-
-	requestTimeout := 30 * time.Second // High per-request timeout
-	contextDeadline := 3 * time.Second // Short context deadline
-
-	var requestCount atomic.Int64
-	server := newTimeoutTestServer(func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
-		w.WriteHeader(http.StatusServiceUnavailable) // 503 triggers retry
-	})
-	defer server.Close()
-
-	client, err := NewClient(
-		context.Background(),
-		server.URL, "test-token", "", "1.0.0", "dev", requestTimeout,
-	)
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), contextDeadline)
-	defer cancel()
-
-	start := time.Now()
-	_, err = client.GetAlertWithResponse(ctx, "test-id")
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected context deadline error, got nil")
-	}
-
-	count := requestCount.Load()
-
-	// Should have retried until the context deadline, not a hardcoded max elapsed time
-	if elapsed > 2*contextDeadline {
-		t.Fatalf("expected to complete around %v, took %v", contextDeadline, elapsed)
-	}
-
-	// Should have made multiple attempts within the deadline
-	if count < 2 {
-		t.Fatalf("expected at least 2 retry attempts, got %d", count)
-	}
-
-	t.Logf("Retried %d times in %v (context deadline %v)", count, elapsed, contextDeadline)
 }

--- a/internal/provider/timeouts.go
+++ b/internal/provider/timeouts.go
@@ -78,16 +78,21 @@ const (
 )
 
 // Compile-time enforcement of the ordering invariant. Converting a negative
-// constant to uint is not representable, so any edit that breaks the ordering
-// fails to compile with "constant -X overflows uint" pointing at the offending
-// line. TestTimeoutDefaults_Ordering asserts the same thing with a readable
-// failure message.
+// constant to an unsigned type is not representable, so any edit that breaks the
+// ordering fails to compile with "constant -X overflows uint64" pointing at the
+// offending line. TestTimeoutDefaults_Ordering asserts the same thing with a
+// readable failure message.
+//
+// uint64, not uint: these margins are Durations in nanoseconds, so a valid
+// 120-second margin is 120,000,000,000 — which does not fit in a 32-bit uint and
+// would break the 386 and arm release targets in .goreleaser.yml. uint64 holds
+// any time.Duration while still rejecting negative values.
 const (
-	_ = uint(DefaultRequestTimeout - cloudflareEdgeTimeout - minRetryHeadroom)
-	_ = uint(DefaultCreateTimeout - DefaultRequestTimeout - minRetryHeadroom)
-	_ = uint(DefaultReadTimeout - DefaultRequestTimeout - minRetryHeadroom)
-	_ = uint(DefaultUpdateTimeout - DefaultRequestTimeout - minRetryHeadroom)
-	_ = uint(DefaultDeleteTimeout - DefaultRequestTimeout - minRetryHeadroom)
+	_ = uint64(DefaultRequestTimeout - cloudflareEdgeTimeout - minRetryHeadroom)
+	_ = uint64(DefaultCreateTimeout - DefaultRequestTimeout - minRetryHeadroom)
+	_ = uint64(DefaultReadTimeout - DefaultRequestTimeout - minRetryHeadroom)
+	_ = uint64(DefaultUpdateTimeout - DefaultRequestTimeout - minRetryHeadroom)
+	_ = uint64(DefaultDeleteTimeout - DefaultRequestTimeout - minRetryHeadroom)
 )
 
 // requestTimeoutPath is the provider attribute both validation paths report against.

--- a/internal/provider/timeouts.go
+++ b/internal/provider/timeouts.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// This file is the single source of truth for the provider's timeout defaults.
+// Changing a default means editing exactly one line here — every resource and
+// data source references these constants rather than a literal duration, and
+// the timeoutcheck linter rejects literal durations at Timeouts.* call sites.
+//
+// # The Two Layers
+//
+// The provider has two nested timeout layers:
+//
+//   - Request timeout (DefaultRequestTimeout, overridable via the provider's
+//     request_timeout attribute): bounds a single HTTP attempt.
+//   - Operation timeout (Default{Create,Read,Update,Delete}Timeout, overridable
+//     via a resource's timeouts {} block): bounds the whole Terraform
+//     operation, including every retry.
+//
+// # The Ordering Invariant
+//
+//	operation timeout > request timeout > cloudflareEdgeTimeout
+//
+// Both inequalities are load-bearing, and violating either produces a confusing
+// failure rather than a clean one:
+//
+// Request timeout must exceed the Cloudflare edge timeout. A slow query is
+// answered with a 524, which DCIRetryClient classifies as permanent — one
+// attempt, then a clear error. But if the request timeout is at or below the
+// edge timeout, http.Client aborts the socket first and we never receive that
+// response. The result is a bare transport error, which is indistinguishable
+// from a network blip and therefore retried, so an expensive query is re-issued
+// until the operation deadline expires. Historically both values were 120s,
+// making it a coin flip which one fired first.
+//
+// Operation timeout must exceed the request timeout so that a single slow
+// attempt cannot consume the entire operation budget, leaving no room to retry
+// a genuinely transient failure.
+const (
+	// cloudflareEdgeTimeout is the DoiT API's Cloudflare origin-response
+	// timeout: requests still unanswered at this point receive a 524. This is
+	// observed edge behavior we do not control, and exists here only as the
+	// floor the request timeout must clear.
+	cloudflareEdgeTimeout = 120 * time.Second
+
+	// minRetryHeadroom is the margin by which each layer must clear the one
+	// below it. Equal values are not sufficient — that is the coin flip
+	// described above.
+	minRetryHeadroom = 30 * time.Second
+)
+
+// Default timeouts. See the ordering invariant above before changing these.
+const (
+	// DefaultRequestTimeout bounds a single HTTP request to the DoiT API.
+	// Overridable via the provider's request_timeout attribute or the
+	// DOIT_REQUEST_TIMEOUT environment variable.
+	DefaultRequestTimeout = 150 * time.Second
+
+	// DefaultCreateTimeout bounds a whole Create operation, retries included.
+	DefaultCreateTimeout = 5 * time.Minute
+
+	// DefaultReadTimeout bounds a whole Read operation, retries included.
+	// This applies to both resource reads and data source reads.
+	DefaultReadTimeout = 5 * time.Minute
+
+	// DefaultUpdateTimeout bounds a whole Update operation, retries included.
+	DefaultUpdateTimeout = 5 * time.Minute
+
+	// DefaultDeleteTimeout bounds a whole Delete operation, retries included.
+	DefaultDeleteTimeout = 5 * time.Minute
+)
+
+// Compile-time enforcement of the ordering invariant. Converting a negative
+// constant to uint is not representable, so any edit that breaks the ordering
+// fails to compile with "constant -X overflows uint" pointing at the offending
+// line. TestTimeoutDefaults_Ordering asserts the same thing with a readable
+// failure message.
+const (
+	_ = uint(DefaultRequestTimeout - cloudflareEdgeTimeout - minRetryHeadroom)
+	_ = uint(DefaultCreateTimeout - DefaultRequestTimeout - minRetryHeadroom)
+	_ = uint(DefaultReadTimeout - DefaultRequestTimeout - minRetryHeadroom)
+	_ = uint(DefaultUpdateTimeout - DefaultRequestTimeout - minRetryHeadroom)
+	_ = uint(DefaultDeleteTimeout - DefaultRequestTimeout - minRetryHeadroom)
+)
+
+// requestTimeoutPath is the provider attribute both validation paths report against.
+var requestTimeoutPath = path.Root("request_timeout")
+
+// formatSeconds renders a duration the way a user writes it in configuration:
+// whole seconds, e.g. "120s". Duration.String() would render that as "2m0s",
+// which does not match anything the user typed.
+func formatSeconds(d time.Duration) string {
+	return strconv.FormatFloat(d.Seconds(), 'f', -1, 64) + "s"
+}
+
+// validateRequestTimeout checks a request timeout against the ordering
+// invariant described above.
+//
+// It is shared by two callers so both agree on the rules: requestTimeoutValidator
+// (which sees the HCL attribute at terraform validate time) and the provider's
+// Configure (which sees the resolved value, and so is the only path that covers
+// the DOIT_REQUEST_TIMEOUT environment variable).
+//
+// Too low is an error: at or below cloudflareEdgeTimeout the provider cannot
+// observe the API's own 524 and degrades into retrying opaque local timeouts.
+//
+// Too high is only a warning. Exceeding the operation defaults is legitimate
+// when the user raises their timeouts {} blocks to match, and the provider
+// cannot see those — they are resolved later, inside each CRUD method.
+func validateRequestTimeout(requestTimeout time.Duration) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if requestTimeout <= cloudflareEdgeTimeout {
+		diags.AddAttributeError(
+			requestTimeoutPath,
+			"Request Timeout Too Low",
+			fmt.Sprintf("request_timeout must be greater than %s, the DoiT API's edge timeout, but is %s. "+
+				"At or below that threshold the API's 524 response cannot arrive before the local timeout "+
+				"cancels the request, so slow calls fail with an opaque deadline error and are retried "+
+				"instead of failing fast. The default is %s.",
+				formatSeconds(cloudflareEdgeTimeout), formatSeconds(requestTimeout), formatSeconds(DefaultRequestTimeout)),
+		)
+		return diags
+	}
+
+	// DefaultReadTimeout is the smallest of the operation defaults.
+	if requestTimeout >= DefaultReadTimeout {
+		diags.AddAttributeWarning(
+			requestTimeoutPath,
+			"Request Timeout Exceeds Operation Defaults",
+			fmt.Sprintf("request_timeout is %s, which is not below the default operation timeout of %s. "+
+				"A single slow request can consume the entire operation budget, leaving no room to retry a "+
+				"transient failure. Raise the timeouts {} block on the affected resources and data sources "+
+				"to at least %s so retries remain possible.",
+				formatSeconds(requestTimeout), formatSeconds(DefaultReadTimeout), formatSeconds(requestTimeout+minRetryHeadroom)),
+		)
+	}
+
+	return diags
+}

--- a/internal/provider/timeouts_internal_test.go
+++ b/internal/provider/timeouts_internal_test.go
@@ -57,6 +57,25 @@ func TestTimeoutDefaults_ReadIsSmallestOperation(t *testing.T) {
 	}
 }
 
+// TestMaxRetryAfter_LeavesRetryBudget verifies a Retry-After honored at the cap
+// still leaves room for the retry it is waiting for. A cap equal to the
+// operation timeout would defeat its own purpose: the retry loop waits on the
+// context, so the operation would expire mid-wait and never retry at all.
+//
+// timeouts.go-style compile-time assertion covers this too; this is the readable
+// counterpart.
+func TestMaxRetryAfter_LeavesRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	smallest := min(DefaultCreateTimeout, DefaultReadTimeout, DefaultUpdateTimeout, DefaultDeleteTimeout)
+
+	if got := smallest - maxRetryAfter; got < minRetryHeadroom {
+		t.Errorf("maxRetryAfter (%s) must be below the smallest operation default (%s) by at least %s, "+
+			"but the margin is %s — a wait at the cap would consume the whole operation budget",
+			maxRetryAfter, smallest, minRetryHeadroom, got)
+	}
+}
+
 // TestNewRetryBackOff_Config verifies the retry policy is configured from the
 // retry* constants. The DoiT API returns 429 without a Retry-After header, so
 // this policy governs the pace of nearly every retry.
@@ -144,8 +163,11 @@ func TestParseRetryAfter(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
-	future := now.Add(90 * time.Second)
+	// Comfortably inside [retryInitialInterval, maxRetryAfter] so these cases
+	// exercise date parsing rather than the clamps.
+	future := now.Add(30 * time.Second)
 	past := now.Add(-90 * time.Second)
+	farFuture := now.Add(10 * time.Minute)
 
 	tests := []struct {
 		name   string
@@ -161,12 +183,18 @@ func TestParseRetryAfter(t *testing.T) {
 		{"seconds above cap is clamped", "86400", maxRetryAfter, true},
 		{"zero seconds falls back", "0", 0, false},
 		{"negative seconds falls back", "-5", 0, false},
+		// A large negative value overflows seconds*time.Second and wraps to a
+		// positive duration, which would otherwise pass the non-positive check
+		// and be honored as a legitimate wait.
+		{"overflowing negative seconds falls back", "-10000000000", 0, false},
+		{"overflowing positive seconds is clamped", "10000000000", maxRetryAfter, true},
 
 		// HTTP-date, all three formats RFC 7231 permits
-		{"IMF-fixdate in future", future.Format(http.TimeFormat), 90 * time.Second, true},
-		{"RFC 850 in future", future.Format(time.RFC850), 90 * time.Second, true},
-		{"asctime in future", future.Format(time.ANSIC), 90 * time.Second, true},
+		{"IMF-fixdate in future", future.Format(http.TimeFormat), 30 * time.Second, true},
+		{"RFC 850 in future", future.Format(time.RFC850), 30 * time.Second, true},
+		{"asctime in future", future.Format(time.ANSIC), 30 * time.Second, true},
 		{"IMF-fixdate in past falls back", past.Format(http.TimeFormat), 0, false},
+		{"IMF-fixdate beyond cap is clamped", farFuture.Format(http.TimeFormat), maxRetryAfter, true},
 
 		// unusable
 		{"garbage falls back", "not-a-date", 0, false},

--- a/internal/provider/timeouts_internal_test.go
+++ b/internal/provider/timeouts_internal_test.go
@@ -1,0 +1,285 @@
+package provider
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// TestTimeoutDefaults_Ordering verifies the timeout ordering invariant:
+//
+//	operation timeout > request timeout > cloudflareEdgeTimeout
+//
+// timeouts.go also enforces this at compile time, but that failure surfaces as
+// "constant -X overflows uint". This test is the readable counterpart, and names
+// the offending pair.
+func TestTimeoutDefaults_Ordering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		outer time.Duration
+		inner time.Duration
+	}{
+		{"request timeout over Cloudflare edge timeout", DefaultRequestTimeout, cloudflareEdgeTimeout},
+		{"create timeout over request timeout", DefaultCreateTimeout, DefaultRequestTimeout},
+		{"read timeout over request timeout", DefaultReadTimeout, DefaultRequestTimeout},
+		{"update timeout over request timeout", DefaultUpdateTimeout, DefaultRequestTimeout},
+		{"delete timeout over request timeout", DefaultDeleteTimeout, DefaultRequestTimeout},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tc.outer - tc.inner; got < minRetryHeadroom {
+				t.Errorf("%s: outer (%s) must exceed inner (%s) by at least %s, but the margin is %s",
+					tc.name, tc.outer, tc.inner, minRetryHeadroom, got)
+			}
+		})
+	}
+}
+
+// TestTimeoutDefaults_ReadIsSmallestOperation guards the assumption in
+// validateRequestTimeout, which compares against DefaultReadTimeout as a proxy
+// for "the smallest operation default".
+func TestTimeoutDefaults_ReadIsSmallestOperation(t *testing.T) {
+	t.Parallel()
+
+	for _, other := range []time.Duration{DefaultCreateTimeout, DefaultUpdateTimeout, DefaultDeleteTimeout} {
+		if DefaultReadTimeout > other {
+			t.Errorf("DefaultReadTimeout (%s) is no longer the smallest operation default (found %s); "+
+				"validateRequestTimeout compares against it and must be updated", DefaultReadTimeout, other)
+		}
+	}
+}
+
+// TestNewRetryBackOff_Config verifies the retry policy is configured from the
+// retry* constants. The DoiT API returns 429 without a Retry-After header, so
+// this policy governs the pace of nearly every retry.
+func TestNewRetryBackOff_Config(t *testing.T) {
+	t.Parallel()
+
+	b := newRetryBackOff()
+
+	if b.InitialInterval != retryInitialInterval {
+		t.Errorf("InitialInterval = %s, want %s", b.InitialInterval, retryInitialInterval)
+	}
+	if b.Multiplier != retryMultiplier {
+		t.Errorf("Multiplier = %v, want %v", b.Multiplier, retryMultiplier)
+	}
+	if b.MaxInterval != retryMaxInterval {
+		t.Errorf("MaxInterval = %s, want %s", b.MaxInterval, retryMaxInterval)
+	}
+	// Jitter is deliberately left at the library default: concurrent operations
+	// hitting the same rate limit should not retry in lockstep.
+	if b.RandomizationFactor == 0 {
+		t.Error("RandomizationFactor = 0, want jitter to be enabled")
+	}
+}
+
+// TestNewRetryBackOff_Grows verifies the interval sequence grows geometrically
+// and saturates at retryMaxInterval.
+//
+// Jitter is disabled for this check. With the production RandomizationFactor the
+// windows of consecutive intervals overlap, so asserting that each interval
+// exceeds its predecessor would be intermittently flaky —
+// TestNewRetryBackOff_JitterBounds covers the randomized case instead.
+func TestNewRetryBackOff_Grows(t *testing.T) {
+	t.Parallel()
+
+	b := newRetryBackOff()
+	b.RandomizationFactor = 0
+	b.Reset()
+
+	// 2s, 4s, 8s, 16s, 32s, then capped at retryMaxInterval.
+	want := []time.Duration{
+		retryInitialInterval,
+		2 * retryInitialInterval,
+		4 * retryInitialInterval,
+		8 * retryInitialInterval,
+		16 * retryInitialInterval,
+		retryMaxInterval,
+		retryMaxInterval,
+	}
+
+	for i, w := range want {
+		if got := b.NextBackOff(); got != w {
+			t.Errorf("interval %d = %s, want %s", i+1, got, w)
+		}
+	}
+}
+
+// TestNewRetryBackOff_JitterBounds verifies every randomized interval stays
+// within the jitter window around its base interval.
+func TestNewRetryBackOff_JitterBounds(t *testing.T) {
+	t.Parallel()
+
+	b := newRetryBackOff()
+	b.Reset()
+
+	base := retryInitialInterval
+	for i := range 7 {
+		got := b.NextBackOff()
+
+		lower := time.Duration(float64(base) * (1 - b.RandomizationFactor))
+		// The library's randomization widens the range by 1ns, so the upper
+		// bound is inclusive of that extra nanosecond.
+		upper := time.Duration(float64(base)*(1+b.RandomizationFactor)) + time.Nanosecond
+
+		if got < lower || got > upper {
+			t.Errorf("interval %d = %s, want within [%s, %s] for base %s", i+1, got, lower, upper, base)
+		}
+
+		base = min(2*base, retryMaxInterval)
+	}
+}
+
+// TestParseRetryAfter covers both Retry-After forms from RFC 7231 plus the
+// degenerate values that must fall back to exponential backoff.
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	future := now.Add(90 * time.Second)
+	past := now.Add(-90 * time.Second)
+
+	tests := []struct {
+		name   string
+		header string
+		want   time.Duration
+		wantOK bool
+	}{
+		// delay-seconds
+		{"absent", "", 0, false},
+		{"seconds", "30", 30 * time.Second, true},
+		{"seconds with surrounding space", "  30  ", 30 * time.Second, true},
+		{"seconds below floor is raised", "1", retryInitialInterval, true},
+		{"seconds above cap is clamped", "86400", maxRetryAfter, true},
+		{"zero seconds falls back", "0", 0, false},
+		{"negative seconds falls back", "-5", 0, false},
+
+		// HTTP-date, all three formats RFC 7231 permits
+		{"IMF-fixdate in future", future.Format(http.TimeFormat), 90 * time.Second, true},
+		{"RFC 850 in future", future.Format(time.RFC850), 90 * time.Second, true},
+		{"asctime in future", future.Format(time.ANSIC), 90 * time.Second, true},
+		{"IMF-fixdate in past falls back", past.Format(http.TimeFormat), 0, false},
+
+		// unusable
+		{"garbage falls back", "not-a-date", 0, false},
+		{"float notation falls back", "1e3", 0, false},
+		{"fractional seconds falls back", "0.5", 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := parseRetryAfter(tc.header, now)
+
+			if ok != tc.wantOK {
+				t.Fatalf("parseRetryAfter(%q) ok = %v, want %v", tc.header, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("parseRetryAfter(%q) = %s, want %s", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateRequestTimeout verifies the ordering invariant is enforced against
+// user-supplied values: too low is an error, exceeding the operation defaults is
+// only a warning.
+func TestValidateRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		timeout      time.Duration
+		wantErrors   int
+		wantWarnings int
+	}{
+		{"well below the edge timeout", 60 * time.Second, 1, 0},
+		{"exactly the edge timeout", cloudflareEdgeTimeout, 1, 0},
+		{"just above the edge timeout", cloudflareEdgeTimeout + time.Second, 0, 0},
+		{"the default", DefaultRequestTimeout, 0, 0},
+		{"just below the read default", DefaultReadTimeout - time.Second, 0, 0},
+		{"exactly the read default", DefaultReadTimeout, 0, 1},
+		{"well above the read default", 10 * time.Minute, 0, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := validateRequestTimeout(tc.timeout)
+
+			if got := diags.ErrorsCount(); got != tc.wantErrors {
+				t.Errorf("validateRequestTimeout(%s) errors = %d, want %d: %v",
+					tc.timeout, got, tc.wantErrors, diags.Errors())
+			}
+			if got := diags.WarningsCount(); got != tc.wantWarnings {
+				t.Errorf("validateRequestTimeout(%s) warnings = %d, want %d: %v",
+					tc.timeout, got, tc.wantWarnings, diags.Warnings())
+			}
+		})
+	}
+}
+
+// TestValidateRequestTimeout_AttributePath verifies diagnostics are attached to
+// the request_timeout attribute so Terraform points at the right line.
+func TestValidateRequestTimeout_AttributePath(t *testing.T) {
+	t.Parallel()
+
+	errDiags := validateRequestTimeout(time.Second)
+	if len(errDiags.Errors()) != 1 {
+		t.Fatalf("expected exactly 1 error, got %d", len(errDiags.Errors()))
+	}
+
+	warnDiags := validateRequestTimeout(10 * time.Minute)
+	if len(warnDiags.Warnings()) != 1 {
+		t.Fatalf("expected exactly 1 warning, got %d", len(warnDiags.Warnings()))
+	}
+
+	// Both must be attribute diagnostics rooted at request_timeout.
+	for _, d := range append(errDiags.Errors(), warnDiags.Warnings()...) {
+		withPath, ok := d.(diag.DiagnosticWithPath)
+		if !ok {
+			t.Errorf("diagnostic %q is not an attribute diagnostic", d.Summary())
+			continue
+		}
+		if got := withPath.Path(); !got.Equal(requestTimeoutPath) {
+			t.Errorf("diagnostic %q path = %s, want %s", d.Summary(), got, requestTimeoutPath)
+		}
+	}
+}
+
+// constantBackOff returns a factory for a fixed-delay, jitter-free retry policy.
+//
+// Tests inject this so retry timing is deterministic and cheap: the backoff
+// library's timer hook is unexported, so replacing the policy is the only way to
+// control how long the retry loop sleeps. A long delay is equally useful — it
+// proves a response was NOT retried, or that a Retry-After header took
+// precedence over the policy.
+func constantBackOff(d time.Duration) func() backoff.BackOff {
+	return func() backoff.BackOff {
+		b := backoff.NewExponentialBackOff()
+		b.InitialInterval = d
+		b.RandomizationFactor = 0
+		b.Multiplier = 1
+		b.MaxInterval = d
+		return b
+	}
+}
+
+// newTestRetryClient builds a DCIRetryClient with an injected backoff policy,
+// bypassing NewClient (and its /auth/v1/validate handshake).
+func newTestRetryClient(requestTimeout time.Duration, newBackOff func() backoff.BackOff) *DCIRetryClient {
+	return &DCIRetryClient{
+		client:     &http.Client{Timeout: requestTimeout},
+		newBackOff: newBackOff,
+	}
+}

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"time"
 
 	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
 	"github.com/doitintl/terraform-provider-doit/internal/provider/resource_user"
@@ -198,7 +197,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 5*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultCreateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -326,7 +325,7 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -357,7 +356,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 5*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -421,7 +420,7 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/users_data_source.go
+++ b/internal/provider/users_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -77,7 +76,7 @@ func (d *usersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	readTimeout, diags := data.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/templates/guides/timeouts.md
+++ b/templates/guides/timeouts.md
@@ -10,11 +10,11 @@ The DoiT provider supports configurable timeouts at two levels: a **global provi
 
 ## Provider-Level Request Timeout
 
-The `request_timeout` attribute controls the timeout for each individual HTTP request to the DoiT API. It defaults to `120s` and can be set via the provider block or the `DOIT_REQUEST_TIMEOUT` environment variable.
+The `request_timeout` attribute controls the timeout for each individual HTTP request to the DoiT API. It defaults to `150s` and can be set via the provider block or the `DOIT_REQUEST_TIMEOUT` environment variable.
 
 ```hcl
 provider "doit" {
-  request_timeout = "120s"  # Default value, shown for documentation
+  request_timeout = "150s"  # Default value, shown for documentation
 }
 ```
 
@@ -24,9 +24,11 @@ Or using the environment variable:
 export DOIT_REQUEST_TIMEOUT="180s"
 ```
 
-The value must be a positive Go duration string (e.g., `"30s"`, `"2m"`, `"1h"`). The HCL attribute takes precedence over the environment variable when both are set.
+The value must be a Go duration string (e.g., `"150s"`, `"4m"`) greater than `120s`. The HCL attribute takes precedence over the environment variable when both are set.
 
 -> This timeout applies to each individual HTTP request, including retries. If a single API call takes longer than this value, it will be cancelled and retried.
+
+~> **Values at or below `120s` are rejected.** The DoiT API sits behind an edge proxy that answers requests still running after 120 seconds with a `524` status. The provider treats that response as a definitive failure and does not retry it. But if `request_timeout` is at or below 120 seconds, the request is cancelled locally *before* that response can arrive — and a local cancellation is indistinguishable from a network fault, so it *is* retried. The result is that a slow call fails with an opaque `context deadline exceeded` after repeatedly re-running an expensive query, instead of reporting the `524` immediately.
 
 ## Resource Timeouts
 
@@ -42,8 +44,8 @@ resource "doit_allocation" "large_group" {
   timeouts = {
     create = "10m"  # Large allocations with many rules may need more time
     update = "10m"
-    read   = "2m"   # Default
-    delete = "2m"   # Default
+    read   = "5m"   # Default
+    delete = "5m"   # Default
   }
 }
 ```
@@ -53,9 +55,9 @@ resource "doit_allocation" "large_group" {
 | Operation | Default |
 | --------- | ------- |
 | Create    | 5 min   |
-| Read      | 2 min   |
+| Read      | 5 min   |
 | Update    | 5 min   |
-| Delete    | 2 min   |
+| Delete    | 5 min   |
 
 Only specify `timeouts` when you need to override the defaults — Terraform won't show any diff for resources without this attribute.
 
@@ -73,7 +75,7 @@ data "doit_report_query" "heavy_report" {
 }
 ```
 
-The default read timeout for data sources is **2 minutes**.
+The default read timeout for data sources is **5 minutes**.
 
 ## How Timeouts Interact
 
@@ -87,16 +89,23 @@ The **operation timeout is the outer boundary**. Retries continue until the oper
 | Layer | Controls | Example |
 | ----- | -------- | ------- |
 | **Operation timeout** (outer) | Total time for the Terraform operation, including all retries | `timeouts = { create = "10m" }` |
-| **Request timeout** (inner) | Time for a single HTTP request to the API | `request_timeout = "120s"` |
+| **Request timeout** (inner) | Time for a single HTTP request to the API | `request_timeout = "150s"` |
 
 Within a single operation (e.g., `create`), the flow is:
 
-1. **Request 1**: The provider sends an HTTP request. If the API doesn't respond within `request_timeout` (e.g., 120s), the request is cancelled.
-2. **Backoff**: The provider waits with exponential backoff before retrying.
+1. **Request 1**: The provider sends an HTTP request. If the API doesn't respond within `request_timeout` (e.g., 150s), the request is cancelled.
+2. **Backoff**: The provider waits with exponential backoff before retrying. Backoff starts at 2 seconds and doubles, up to 60 seconds, with jitter.
 3. **Request 2**: A retry is attempted. This cycle repeats.
 4. **Deadline**: Once the operation timeout (e.g., 10m) is reached, all remaining retries are cancelled and Terraform reports the error.
 
-~> **Important:** Ensure that your operation timeout is larger than your `request_timeout`. If `request_timeout` is larger than the operation timeout, a single slow request could consume the entire operation budget with no room for retries. For example, `request_timeout = "300s"` with `timeouts = { create = "2m" }` means the first request could take up to 2 minutes before being cancelled by the operation timeout — leaving zero time for retries.
+### Keep the layers ordered
+
+The defaults satisfy `operation timeout > request timeout > 120s`, and both bounds matter:
+
+- **Operation timeout above request timeout.** Otherwise a single slow request consumes the entire operation budget with no room for retries. For example, `request_timeout = "300s"` with `timeouts = { create = "2m" }` means the first request could still be running when the operation deadline cancels it — leaving zero time for a retry.
+- **Request timeout above 120s.** See the note under [Provider-Level Request Timeout](#provider-level-request-timeout): below that threshold the API's own `524` response cannot reach the provider, and slow calls degrade into retried, opaque deadline errors.
+
+If you raise `request_timeout`, raise the `timeouts {}` blocks on the affected resources and data sources to match. The provider emits a warning when `request_timeout` is not below the default operation timeout, since it cannot see the per-resource blocks — they are resolved later, per operation.
 
 ## Troubleshooting
 
@@ -122,13 +131,21 @@ This error means a timeout was exceeded. Check which level caused it:
   }
   ```
 
+### `status: 524`
+
+A `524` comes from the DoiT API's edge proxy and means the API did not finish the request within its own 120-second limit. The provider reports it immediately and **does not retry** — the query already ran for the full edge timeout, so an identical retry would only re-run expensive work that is going to time out again.
+
+Raising `request_timeout` will not help, because the limit is enforced upstream rather than locally. Reduce the amount of work in the request instead — for example, narrow a report's time range, or add filters to reduce the number of rows.
+
+Seeing `context deadline exceeded` instead of `524` on a request you expect to be slow is a sign that `request_timeout` is at or below 120 seconds.
+
 ### Large Allocations
 
 Allocation groups with many rules (100+) may require larger timeouts because the API processes all rules in a single request. Recommended settings:
 
 ```hcl
 provider "doit" {
-  request_timeout = "300s"  # 5 minutes per request
+  request_timeout = "290s"  # just under 5 minutes per request
 }
 
 resource "doit_allocation" "large_group" {
@@ -140,3 +157,5 @@ resource "doit_allocation" "large_group" {
   }
 }
 ```
+
+-> `request_timeout` is deliberately just under the 5-minute default operation timeout here. Raising it to `300s` or beyond triggers the ordering warning described above, because it would leave a default-timeout operation no room to retry.

--- a/tools/linters/timeoutcheck/analyzer.go
+++ b/tools/linters/timeoutcheck/analyzer.go
@@ -6,11 +6,13 @@
 // contain no API calls (no StatusCode() or WithResponse call), such as no-op
 // Delete methods.
 //
-// Second, the default passed to Timeouts.Create/Read/Update/Delete must be a
-// named constant from internal/provider/timeouts.go rather than a literal
-// duration. Literals had drifted into 136 call sites across 84 files, which made
-// the defaults impossible to change in one place and let the timeout ordering
-// invariant documented in timeouts.go be violated silently.
+// Second, the default passed to Timeouts.Create/Read/Update/Delete must be that
+// operation's Default<Op>Timeout constant from internal/provider/timeouts.go
+// rather than a literal duration. Literals had drifted into 136 call sites
+// across 84 files, which made the defaults impossible to change in one place and
+// let the timeout ordering invariant documented in timeouts.go be violated
+// silently. A resource with a genuine need for a different default can silence
+// this with //nolint:timeoutcheck and a comment explaining why.
 package timeoutcheck
 
 import (
@@ -68,20 +70,24 @@ func checkTimeoutDefaults(pass *analysis.Pass, insp *inspector.Inspector) {
 			return
 		}
 
-		// Accept only a reference to a declared constant. Checking for a bare
-		// identifier is not enough: a local variable holding a literal
-		// (timeout := 2*time.Minute) would slip through and defeat the point.
-		if ident, ok := call.Args[1].(*ast.Ident); ok {
+		// Accept only the operation's own default constant, by name and as a
+		// declared constant. Weaker checks leave real holes: accepting any bare
+		// identifier lets a variable holding a literal through
+		// (timeout := 2*time.Minute), and accepting any constant lets both a
+		// locally declared literal (const short = 2*time.Minute) and another
+		// operation's default (Timeouts.Read(ctx, DefaultCreateTimeout)) pass —
+		// the latter being an easy copy-paste error between CRUD methods.
+		want := "Default" + sel.Sel.Name + "Timeout"
+		if ident, ok := call.Args[1].(*ast.Ident); ok && ident.Name == want {
 			if _, isConst := pass.TypesInfo.ObjectOf(ident).(*types.Const); isConst {
 				return
 			}
 		}
 
 		pass.Reportf(call.Args[1].Pos(),
-			"Timeouts.%s must use a named default timeout constant "+
-				"(e.g. Default%sTimeout from timeouts.go), not a literal duration "+
-				"or a variable holding one",
-			sel.Sel.Name, sel.Sel.Name)
+			"Timeouts.%s must use the %s constant from timeouts.go, not a literal "+
+				"duration, a variable, or another operation's default",
+			sel.Sel.Name, want)
 	})
 }
 

--- a/tools/linters/timeoutcheck/analyzer.go
+++ b/tools/linters/timeoutcheck/analyzer.go
@@ -15,6 +15,7 @@ package timeoutcheck
 
 import (
 	"go/ast"
+	"go/types"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
@@ -67,15 +68,19 @@ func checkTimeoutDefaults(pass *analysis.Pass, insp *inspector.Inspector) {
 			return
 		}
 
-		// A named constant is a bare identifier. Anything else — a BasicLit or a
-		// BinaryExpr such as 2*time.Minute — is a literal duration.
-		if _, ok := call.Args[1].(*ast.Ident); ok {
-			return
+		// Accept only a reference to a declared constant. Checking for a bare
+		// identifier is not enough: a local variable holding a literal
+		// (timeout := 2*time.Minute) would slip through and defeat the point.
+		if ident, ok := call.Args[1].(*ast.Ident); ok {
+			if _, isConst := pass.TypesInfo.ObjectOf(ident).(*types.Const); isConst {
+				return
+			}
 		}
 
 		pass.Reportf(call.Args[1].Pos(),
 			"Timeouts.%s must use a named default timeout constant "+
-				"(e.g. Default%sTimeout from timeouts.go), not a literal duration",
+				"(e.g. Default%sTimeout from timeouts.go), not a literal duration "+
+				"or a variable holding one",
 			sel.Sel.Name, sel.Sel.Name)
 	})
 }

--- a/tools/linters/timeoutcheck/analyzer.go
+++ b/tools/linters/timeoutcheck/analyzer.go
@@ -1,9 +1,16 @@
-// Package timeoutcheck ensures that all CRUD methods on resources and Read
-// methods on data sources wrap their context with context.WithTimeout.
-// Enforces timeout support in CRUD methods.
+// Package timeoutcheck enforces two things about timeout handling in CRUD
+// methods.
 //
-// Methods are exempt if they contain no API calls (no StatusCode() or
-// WithResponse call), such as no-op Delete methods.
+// First, all CRUD methods on resources and Read methods on data sources must
+// wrap their context with context.WithTimeout. Methods are exempt if they
+// contain no API calls (no StatusCode() or WithResponse call), such as no-op
+// Delete methods.
+//
+// Second, the default passed to Timeouts.Create/Read/Update/Delete must be a
+// named constant from internal/provider/timeouts.go rather than a literal
+// duration. Literals had drifted into 136 call sites across 84 files, which made
+// the defaults impossible to change in one place and let the timeout ordering
+// invariant documented in timeouts.go be violated silently.
 package timeoutcheck
 
 import (
@@ -33,6 +40,49 @@ var crudMethods = map[string]bool{
 func run(pass *analysis.Pass) (any, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
+	checkWithTimeout(pass, insp)
+	checkTimeoutDefaults(pass, insp)
+
+	return nil, nil
+}
+
+// checkTimeoutDefaults reports literal durations passed as the default to
+// Timeouts.Create/Read/Update/Delete. The default must be a named constant so
+// that internal/provider/timeouts.go stays the single source of truth.
+func checkTimeoutDefaults(pass *analysis.Pass, insp *inspector.Inspector) {
+	nodeFilter := []ast.Node{(*ast.CallExpr)(nil)}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		// Match: <expr>.Timeouts.<Op>(ctx, <default>)
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !crudMethods[sel.Sel.Name] {
+			return
+		}
+		recv, ok := sel.X.(*ast.SelectorExpr)
+		if !ok || recv.Sel.Name != "Timeouts" {
+			return
+		}
+		if len(call.Args) != 2 {
+			return
+		}
+
+		// A named constant is a bare identifier. Anything else — a BasicLit or a
+		// BinaryExpr such as 2*time.Minute — is a literal duration.
+		if _, ok := call.Args[1].(*ast.Ident); ok {
+			return
+		}
+
+		pass.Reportf(call.Args[1].Pos(),
+			"Timeouts.%s must use a named default timeout constant "+
+				"(e.g. Default%sTimeout from timeouts.go), not a literal duration",
+			sel.Sel.Name, sel.Sel.Name)
+	})
+}
+
+// checkWithTimeout reports CRUD methods that make API calls without wrapping
+// their context with context.WithTimeout.
+func checkWithTimeout(pass *analysis.Pass, insp *inspector.Inspector) {
 	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil)}
 	insp.Preorder(nodeFilter, func(n ast.Node) {
 		fn := n.(*ast.FuncDecl)
@@ -60,8 +110,6 @@ func run(pass *analysis.Pass) (any, error) {
 				fn.Name.Name)
 		}
 	})
-
-	return nil, nil
 }
 
 // hasAPICalls checks whether the function body contains API-related calls.

--- a/tools/linters/timeoutcheck/testdata/src/timeouttest/timeouttest.go
+++ b/tools/linters/timeoutcheck/testdata/src/timeouttest/timeouttest.go
@@ -1,6 +1,9 @@
 package timeouttest
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Stubs
 type createRequest struct{}
@@ -129,4 +132,51 @@ func Create(ctx context.Context, req createRequest, resp *createResponse) {
 	if apiResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError("Error", "failed")
 	}
+}
+
+// --- Timeouts default must be a named constant ---
+
+type timeoutsValue struct{}
+
+func (t timeoutsValue) Create(ctx context.Context, d time.Duration) (time.Duration, diagList) {
+	return d, diagList{}
+}
+func (t timeoutsValue) Read(ctx context.Context, d time.Duration) (time.Duration, diagList) {
+	return d, diagList{}
+}
+func (t timeoutsValue) Update(ctx context.Context, d time.Duration) (time.Duration, diagList) {
+	return d, diagList{}
+}
+func (t timeoutsValue) Delete(ctx context.Context, d time.Duration) (time.Duration, diagList) {
+	return d, diagList{}
+}
+
+type modelWithTimeouts struct{ Timeouts timeoutsValue }
+
+const (
+	DefaultCreateTimeout = 5 * time.Minute
+	DefaultReadTimeout   = 5 * time.Minute
+	DefaultUpdateTimeout = 5 * time.Minute
+	DefaultDeleteTimeout = 5 * time.Minute
+)
+
+// BAD: literal durations as the default.
+func literalTimeoutDefaults(ctx context.Context) {
+	var data modelWithTimeouts
+
+	_, _ = data.Timeouts.Create(ctx, 5*time.Minute) // want "Timeouts.Create must use a named default timeout constant"
+	_, _ = data.Timeouts.Read(ctx, 2*time.Minute)   // want "Timeouts.Read must use a named default timeout constant"
+	_, _ = data.Timeouts.Update(ctx, 5*time.Minute) // want "Timeouts.Update must use a named default timeout constant"
+	_, _ = data.Timeouts.Delete(ctx, 2*time.Minute) // want "Timeouts.Delete must use a named default timeout constant"
+	_, _ = data.Timeouts.Read(ctx, 0)               // want "Timeouts.Read must use a named default timeout constant"
+}
+
+// GOOD: named constants as the default.
+func namedTimeoutDefaults(ctx context.Context) {
+	var data modelWithTimeouts
+
+	_, _ = data.Timeouts.Create(ctx, DefaultCreateTimeout)
+	_, _ = data.Timeouts.Read(ctx, DefaultReadTimeout)
+	_, _ = data.Timeouts.Update(ctx, DefaultUpdateTimeout)
+	_, _ = data.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 }

--- a/tools/linters/timeoutcheck/testdata/src/timeouttest/timeouttest.go
+++ b/tools/linters/timeoutcheck/testdata/src/timeouttest/timeouttest.go
@@ -180,3 +180,14 @@ func namedTimeoutDefaults(ctx context.Context) {
 	_, _ = data.Timeouts.Update(ctx, DefaultUpdateTimeout)
 	_, _ = data.Timeouts.Delete(ctx, DefaultDeleteTimeout)
 }
+
+// BAD: a variable holding a literal duration is not a named constant.
+func variableTimeoutDefaults(ctx context.Context) {
+	var data modelWithTimeouts
+
+	timeout := 2 * time.Minute
+	_, _ = data.Timeouts.Read(ctx, timeout) // want "Timeouts.Read must use a named default timeout constant"
+
+	var deadline time.Duration = 5 * time.Minute
+	_, _ = data.Timeouts.Create(ctx, deadline) // want "Timeouts.Create must use a named default timeout constant"
+}

--- a/tools/linters/timeoutcheck/testdata/src/timeouttest/timeouttest.go
+++ b/tools/linters/timeoutcheck/testdata/src/timeouttest/timeouttest.go
@@ -164,11 +164,11 @@ const (
 func literalTimeoutDefaults(ctx context.Context) {
 	var data modelWithTimeouts
 
-	_, _ = data.Timeouts.Create(ctx, 5*time.Minute) // want "Timeouts.Create must use a named default timeout constant"
-	_, _ = data.Timeouts.Read(ctx, 2*time.Minute)   // want "Timeouts.Read must use a named default timeout constant"
-	_, _ = data.Timeouts.Update(ctx, 5*time.Minute) // want "Timeouts.Update must use a named default timeout constant"
-	_, _ = data.Timeouts.Delete(ctx, 2*time.Minute) // want "Timeouts.Delete must use a named default timeout constant"
-	_, _ = data.Timeouts.Read(ctx, 0)               // want "Timeouts.Read must use a named default timeout constant"
+	_, _ = data.Timeouts.Create(ctx, 5*time.Minute) // want "Timeouts.Create must use the DefaultCreateTimeout constant"
+	_, _ = data.Timeouts.Read(ctx, 2*time.Minute)   // want "Timeouts.Read must use the DefaultReadTimeout constant"
+	_, _ = data.Timeouts.Update(ctx, 5*time.Minute) // want "Timeouts.Update must use the DefaultUpdateTimeout constant"
+	_, _ = data.Timeouts.Delete(ctx, 2*time.Minute) // want "Timeouts.Delete must use the DefaultDeleteTimeout constant"
+	_, _ = data.Timeouts.Read(ctx, 0)               // want "Timeouts.Read must use the DefaultReadTimeout constant"
 }
 
 // GOOD: named constants as the default.
@@ -186,8 +186,21 @@ func variableTimeoutDefaults(ctx context.Context) {
 	var data modelWithTimeouts
 
 	timeout := 2 * time.Minute
-	_, _ = data.Timeouts.Read(ctx, timeout) // want "Timeouts.Read must use a named default timeout constant"
+	_, _ = data.Timeouts.Read(ctx, timeout) // want "Timeouts.Read must use the DefaultReadTimeout constant"
 
 	var deadline time.Duration = 5 * time.Minute
-	_, _ = data.Timeouts.Create(ctx, deadline) // want "Timeouts.Create must use a named default timeout constant"
+	_, _ = data.Timeouts.Create(ctx, deadline) // want "Timeouts.Create must use the DefaultCreateTimeout constant"
+}
+
+// BAD: a constant that is not this operation's default.
+func mismatchedTimeoutDefaults(ctx context.Context) {
+	var data modelWithTimeouts
+
+	// A locally declared literal is still a literal.
+	const short = 2 * time.Minute
+	_, _ = data.Timeouts.Read(ctx, short) // want "Timeouts.Read must use the DefaultReadTimeout constant"
+
+	// Another operation's default — an easy copy-paste error between CRUD methods.
+	_, _ = data.Timeouts.Read(ctx, DefaultCreateTimeout) // want "Timeouts.Read must use the DefaultReadTimeout constant"
+	_, _ = data.Timeouts.Delete(ctx, DefaultReadTimeout) // want "Timeouts.Delete must use the DefaultDeleteTimeout constant"
 }


### PR DESCRIPTION
## Why

Slow reads — notably `data-source/doit_report_result` against large reports — failed with an opaque `context deadline exceeded` after repeatedly re-running an expensive query, instead of reporting the API's actual `524` response.

The chain:

1. The DoiT API's edge proxy answers requests still running after **120s** with a `524`. `DCIRetryClient` already classifies that correctly as permanent — one attempt, then a clear error.
2. But `DefaultRequestTimeout` was **also exactly 120s**, so Go's `http.Client` usually aborted the socket a moment before that response could arrive. Which of the two timers won was effectively a coin flip.
3. A local transport error is not wrapped in `backoff.Permanent` and is indistinguishable from a network fault, so it **was retried** — re-issuing an expensive query every ~120s until the operation deadline expired. This is the source of the 429 volume seen in Cloud Logging from the provider's user agent.
4. The `read`/`delete` operation defaults were *also* `2m`, matching the request timeout exactly and leaving **zero retry headroom** — the very footgun the timeouts guide warned users about.

Confirming the diagnosis: raising `request_timeout` past 120s made the `524` arrive as a real response and fail fast on the first attempt. The classification logic was right; only the defaults were wrong.

## What changed

### Defaults, defined once and ordered

`operation timeout (5m) > request timeout (150s) > edge timeout (120s)`

New `internal/provider/timeouts.go` holds all five defaults, replacing literal durations at **136 call sites across 84 files**. It documents the invariant and enforces it **at compile time** — a negative margin converted to `uint` is not representable, so a bad edit cannot build:

```go
const _ = uint(DefaultReadTimeout - DefaultRequestTimeout - minRetryHeadroom)
```

Verified by deliberately inverting a value: `constant -15000000000 overflows uint`, pointing at the offending line.

### Enforcement against user overrides

- A validator rejects `request_timeout` at or below `120s` at `terraform validate` time, before any API call.
- A resolved-value check in `Configure` applies the same rule — the only path that also covers `DOIT_REQUEST_TIMEOUT`, which a schema validator cannot see.
- A **warning** (not an error) when `request_timeout` is not below the operation defaults. Deliberately not an error: raising both is a legitimate configuration, and the provider cannot see per-resource `timeouts {}` blocks, which are resolved later per operation.

### Retry pacing and `Retry-After`

Both were exposed while investigating the above.

- The API sends **no `Retry-After` header** (confirmed against the live tenant), so the exponential policy governs nearly every retry. It started at 500ms with a 1.5x multiplier — roughly five requests in the first four seconds against an API that had just asked the client to slow down. Now 2s, doubling, 60s cap, jitter retained.
- `Retry-After: 0`, negatives, and past dates were honored literally. That schedules an immediate retry, and because the backoff library resets the exponential policy whenever a `Retry-After` is honored, a server repeatedly sending such a value would pin retries to a **flat cadence that never grew**. These now fall back to exponential backoff.
- All three RFC 7231 date formats are accepted (only IMF-fixdate was), and outsized values are capped.

### Regression guard

`timeoutcheck` now also rejects literal durations passed as a `Timeouts.*` default. Extending the existing linter avoids new `.golangci.yml` wiring. Verified against the real tree:

```
alert_data_source.go:67:48: Timeouts.Read must use a named default timeout
constant (e.g. DefaultReadTimeout from timeouts.go), not a literal duration
```

`.agents/skills/implementation-conventions/SKILL.md` is updated too — its copy-paste snippet is *why* all 136 sites were uniform, so leaving it would reintroduce literals with the next generated resource.

## Verification

End-to-end with defaults only (no overrides):

```
Still reading... [02m00s elapsed]
Error: Could not read results for report ID qEQp7...:
       non-retryable error: 524, body: error code: 524
```

Stops at **2m00s with zero retries**. That is the decisive check — with the read default now at 5m, a retry loop would have continued to 3m/4m/5m and ended in a deadline error.

Also confirmed manually: `request_timeout = "60s"` errors at validate time; `"10m"` warns.

Automated: `go build`, `make test` (0 failures), `make lint` (0 issues), `tools/linters` tests, and `tfplugindocs validate` all pass.

New unit coverage for the `429`, `524`, `404`, and `500` paths and for `Retry-After` parsing — **none of which was previously tested**. The `524` test was checked for vacuity by temporarily making 524 retryable, which fails it as expected. Two pre-existing tests were converted to an injected backoff: at a 2s initial interval their jitter windows straddled their context deadlines, making them ~5% flaky. Net effect is ~13s *less* wall-clock in the package.

## Reviewer notes

- **One potentially breaking change:** `request_timeout` at or below `120s` is now rejected, so an existing config with e.g. `"60s"` will fail validation. Marked BREAKING in the changelog. This is the only change that can break someone on upgrade and is worth a deliberate look before release.
- **The `newBackOff` field must stay a factory, not a `backoff.BackOff` value.** `ExponentialBackOff` is not thread-safe, `backoff.Retry` calls `Reset()` on entry, and one client is shared across concurrent Terraform operations. An instance field would pass every test here while corrupting intervals in production.
- **Read `internal/provider/timeouts.go` first** — it carries the rationale for the whole change. The 84-file diff is a mechanical substitution; `git diff` shows only timeout-line swaps plus 61 now-unused `"time"` import removals.
- **Diagnostics and docs spell durations as `150s`/`120s`, not `Duration.String()`'s `2m30s`/`2m0s`**, which matches nothing a user types.
- Making `524` retryable was considered and rejected: failing fast on a permanent edge timeout is the desired behavior, and the storm came from the 120s collision, not the classification.
- Not run here: the 429-storm reproduction (re-creates real backend load) and acceptance tests.

## Out of scope

Genuinely slow reports would be better served by an async submit/poll pattern than by one long synchronous request. Worth raising with the API team separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)