### PR TITLE
feat: add name_contains filter to alerts, allocations, budgets, labels, and reports data sources

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -335,6 +335,13 @@
 						}
 					},
 					{
+						"name": "name_contains",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics."
+						}
+					},
+					{
 						"name": "alerts",
 						"list_nested": {
 							"computed_optional_required": "computed",
@@ -868,6 +875,13 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "An expression for filtering the results.\nValid fields: **type**, **owner**, **name**, **folderId**."
+						}
+					},
+					{
+						"name": "name_contains",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics."
 						}
 					},
 					{
@@ -2652,7 +2666,14 @@
 						"name": "filter",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "An expression for filtering the results of the request. The syntax is \"key:[\u003cvalue\u003e]\".\nAvailable keys: owner, lastModified in ms (\u003elasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\"."
+							"description": "An expression for filtering the results of the request. The syntax is \"key:[\u003cvalue\u003e]\".\nAvailable keys: owner, budgetName, lastModified in ms (\u003elasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\"."
+						}
+					},
+					{
+						"name": "name_contains",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics."
 						}
 					},
 					{
@@ -9746,6 +9767,13 @@
 						}
 					},
 					{
+						"name": "name_contains",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics."
+						}
+					},
+					{
 						"name": "sort_by",
 						"string": {
 							"computed_optional_required": "computed_optional",
@@ -11985,6 +12013,13 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "An expression for filtering the results.\nThe syntax is `key:[\u003cvalue\u003e]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nPossible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**"
+						}
+					},
+					{
+						"name": "name_contains",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics."
 						}
 					},
 					{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -118,6 +118,7 @@ paths:
           example: "name:test"
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
       responses:
         "200":
           description: >-
@@ -292,6 +293,7 @@ paths:
           example: type:custom
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: sortBy
           in: query
           description: A field by which the results will be sorted.
@@ -703,6 +705,7 @@ paths:
           example: name:budget
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: sortBy
           in: query
           description: A field by which the results will be sorted.
@@ -1181,9 +1184,11 @@ paths:
           in: query
           description: |-
             An expression for filtering the results of the request. The syntax is "key:[<value>]".
-            Available keys: owner, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+            Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+          example: "budgetName:My Monthly Budget"
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: minCreationTime
           in: query
           description: Min value for reports creation time, in milliseconds since the
@@ -1792,6 +1797,7 @@ paths:
           example: "reportName:This Month vs. Last"
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: minCreationTime
           in: query
           description: Min value for reports creation time, in milliseconds since the
@@ -16071,6 +16077,14 @@ components:
       name: pageToken
       in: query
       description: Page token, returned by a previous call, to request the next page of results
+      schema:
+        type: string
+    nameContains:
+      name: nameContains
+      in: query
+      description: >-
+        Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
+      example: monthly spend
       schema:
         type: string
     includeRevoked:

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -117,6 +117,7 @@ paths:
           example: "name:test"
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
       responses:
         "200":
           description: >-
@@ -291,6 +292,7 @@ paths:
           example: type:custom
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: sortBy
           in: query
           description: A field by which the results will be sorted.
@@ -680,6 +682,7 @@ paths:
           example: name:budget
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: sortBy
           in: query
           description: A field by which the results will be sorted.
@@ -1150,9 +1153,11 @@ paths:
           in: query
           description: |-
             An expression for filtering the results of the request. The syntax is "key:[<value>]".
-            Available keys: owner, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+            Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+          example: "budgetName:My Monthly Budget"
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: minCreationTime
           in: query
           description: Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
@@ -1632,6 +1637,7 @@ paths:
           example: "reportName:This Month vs. Last"
           schema:
             type: string
+        - $ref: "#/components/parameters/nameContains"
         - name: minCreationTime
           in: query
           description: Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
@@ -11222,6 +11228,14 @@ components:
       name: pageToken
       in: query
       description: Page token, returned by a previous call, to request the next page of results
+      schema:
+        type: string
+    nameContains:
+      name: nameContains
+      in: query
+      description: >-
+        Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
+      example: monthly spend
       schema:
         type: string
     includeRevoked:

--- a/docs/data-sources/alerts.md
+++ b/docs/data-sources/alerts.md
@@ -20,6 +20,11 @@ data "doit_alerts" "aws_alerts" {
   filter = "name:[AWS]"
 }
 
+# Filter alerts by name substring
+data "doit_alerts" "production" {
+  name_contains = "production"
+}
+
 # Sort by last triggered time
 data "doit_alerts" "recent" {
   sort_by    = "lastAlerted"
@@ -56,6 +61,7 @@ output "alert_details" {
 - `filter` (String) An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 Available filter keys: **owner**, **name**
 - `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `name_contains` (String) Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `name`, `createTime`, `updateTime`, `lastAlerted`

--- a/docs/data-sources/allocations.md
+++ b/docs/data-sources/allocations.md
@@ -20,6 +20,11 @@ data "doit_allocations" "groups" {
   filter = "allocationType:[group]"
 }
 
+# Filter by name substring
+data "doit_allocations" "production" {
+  name_contains = "production"
+}
+
 # Output allocation names
 output "total_allocations" {
   value = data.doit_allocations.all.row_count
@@ -40,6 +45,7 @@ output "allocation_names" {
 - `filter` (String) An expression for filtering the results.
 Valid fields: **type**, **owner**, **name**, **folderId**.
 - `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `name_contains` (String) Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `id`, `name`, `owner`, `description`, `type`, `createTime`, `updateTime`

--- a/docs/data-sources/budgets.md
+++ b/docs/data-sources/budgets.md
@@ -15,6 +15,11 @@ Track actual cloud spend against planned spend.
 # List all budgets
 data "doit_budgets" "all" {}
 
+# Filter budgets by name substring
+data "doit_budgets" "production" {
+  name_contains = "production"
+}
+
 # Output total number of budgets
 output "total_budgets" {
   value = data.doit_budgets.all.row_count
@@ -34,10 +39,11 @@ output "budget_names" {
 ### Optional
 
 - `filter` (String) An expression for filtering the results of the request. The syntax is "key:[<value>]".
-Available keys: owner, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
 - `max_creation_time` (String) Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.
 - `max_results` (Number) The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
 - `min_creation_time` (String) Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
+- `name_contains` (String) Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/docs/data-sources/labels.md
+++ b/docs/data-sources/labels.md
@@ -15,6 +15,11 @@ Create and manage labels to organize and categorize your cloud resources.
 # Retrieve all labels
 data "doit_labels" "all" {}
 
+# Filter labels by name substring
+data "doit_labels" "environment" {
+  name_contains = "env"
+}
+
 # Sort by name
 data "doit_labels" "sorted" {
   sort_by    = "name"
@@ -41,6 +46,7 @@ output "label_names" {
 - `filter` (String) An expression for filtering the results.
 Valid fields: **name**, **type**.
 - `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
+- `name_contains` (String) Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `sort_by` (String) A field by which the results will be sorted.
 Possible values: `id`, `name`, `type`, `createTime`, `updateTime`

--- a/docs/data-sources/reports.md
+++ b/docs/data-sources/reports.md
@@ -15,6 +15,11 @@ Manage Cloud Analytics reports and get reports data in JSON format.
 # Retrieve all reports
 data "doit_reports" "all" {}
 
+# Filter reports by name substring
+data "doit_reports" "production" {
+  name_contains = "production"
+}
+
 # Use doit_current_user to filter reports owned by the current user
 data "doit_current_user" "me" {}
 
@@ -63,6 +68,7 @@ Possible filter keys: **reportName**, **owner**, **type**, **updateTime**, **fol
 - `max_creation_time` (String) Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.
 - `max_results` (Number) The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.
 - `min_creation_time` (String) Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
+- `name_contains` (String) Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/examples/data-sources/doit_alerts/data-source.tf
+++ b/examples/data-sources/doit_alerts/data-source.tf
@@ -6,6 +6,11 @@ data "doit_alerts" "aws_alerts" {
   filter = "name:[AWS]"
 }
 
+# Filter alerts by name substring
+data "doit_alerts" "production" {
+  name_contains = "production"
+}
+
 # Sort by last triggered time
 data "doit_alerts" "recent" {
   sort_by    = "lastAlerted"

--- a/examples/data-sources/doit_allocations/data-source.tf
+++ b/examples/data-sources/doit_allocations/data-source.tf
@@ -6,6 +6,11 @@ data "doit_allocations" "groups" {
   filter = "allocationType:[group]"
 }
 
+# Filter by name substring
+data "doit_allocations" "production" {
+  name_contains = "production"
+}
+
 # Output allocation names
 output "total_allocations" {
   value = data.doit_allocations.all.row_count

--- a/examples/data-sources/doit_budgets/data-source.tf
+++ b/examples/data-sources/doit_budgets/data-source.tf
@@ -1,6 +1,11 @@
 # List all budgets
 data "doit_budgets" "all" {}
 
+# Filter budgets by name substring
+data "doit_budgets" "production" {
+  name_contains = "production"
+}
+
 # Output total number of budgets
 output "total_budgets" {
   value = data.doit_budgets.all.row_count

--- a/examples/data-sources/doit_labels/data-source.tf
+++ b/examples/data-sources/doit_labels/data-source.tf
@@ -1,6 +1,11 @@
 # Retrieve all labels
 data "doit_labels" "all" {}
 
+# Filter labels by name substring
+data "doit_labels" "environment" {
+  name_contains = "env"
+}
+
 # Sort by name
 data "doit_labels" "sorted" {
   sort_by    = "name"

--- a/examples/data-sources/doit_reports/data-source.tf
+++ b/examples/data-sources/doit_reports/data-source.tf
@@ -1,6 +1,11 @@
 # Retrieve all reports
 data "doit_reports" "all" {}
 
+# Filter reports by name substring
+data "doit_reports" "production" {
+  name_contains = "production"
+}
+
 # Use doit_current_user to filter reports owned by the current user
 data "doit_current_user" "me" {}
 

--- a/internal/provider/alerts_data_source.go
+++ b/internal/provider/alerts_data_source.go
@@ -75,7 +75,7 @@ func (d *alertsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	defer cancel()
 
 	// If any filter/pagination input is unknown, return unknown list
-	if data.Filter.IsUnknown() || data.SortBy.IsUnknown() || data.SortOrder.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
+	if data.Filter.IsUnknown() || data.NameContains.IsUnknown() || data.SortBy.IsUnknown() || data.SortOrder.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
 		data.Alerts = types.ListUnknown(datasource_alerts.AlertsValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -84,6 +84,9 @@ func (d *alertsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	params := &models.ListAlertsParams{}
 	if !data.Filter.IsNull() {
 		params.Filter = new(data.Filter.ValueString())
+	}
+	if !data.NameContains.IsNull() {
+		params.NameContains = new(data.NameContains.ValueString())
 	}
 	if !data.SortBy.IsNull() {
 		params.SortBy = new(models.ListAlertsParamsSortBy(data.SortBy.ValueString()))

--- a/internal/provider/alerts_data_source_test.go
+++ b/internal/provider/alerts_data_source_test.go
@@ -179,6 +179,58 @@ data "doit_alerts" "test" {
 `
 }
 
+// TestAccAlertsDataSource_NameContains tests filtering alerts with name_contains
+// against both an existing alert (via chained data source) and a non-existent name.
+func TestAccAlertsDataSource_NameContains(t *testing.T) {
+	alertCount := getAlertCount(t)
+	if alertCount < 1 {
+		t.Skipf("Need at least 1 alert to test name_contains, got %d", alertCount)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertsDataSourceNameContainsConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_alerts.first", "alerts.0.name"),
+					resource.TestCheckResourceAttrSet("data.doit_alerts.filtered", "alerts.0.id"),
+					resource.TestCheckResourceAttrSet("data.doit_alerts.filtered", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_alerts.empty", "alerts.#", "0"),
+					resource.TestCheckResourceAttr("data.doit_alerts.empty", "row_count", "0"),
+				),
+			},
+			// Drift verification: re-apply the same config should produce an empty plan
+			{
+				Config: testAccAlertsDataSourceNameContainsConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAlertsDataSourceNameContainsConfig() string {
+	return `
+data "doit_alerts" "first" {
+  max_results = "1"
+}
+
+data "doit_alerts" "filtered" {
+  name_contains = data.doit_alerts.first.alerts.0.name
+}
+
+data "doit_alerts" "empty" {
+  name_contains = "nonexistent-alert-xyz-99999"
+}
+`
+}
+
 // Helper functions
 
 var (

--- a/internal/provider/allocations_data_source.go
+++ b/internal/provider/allocations_data_source.go
@@ -74,7 +74,7 @@ func (d *allocationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 	defer cancel()
 
 	// If any filter/pagination input is unknown, return unknown list
-	if data.Filter.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
+	if data.Filter.IsUnknown() || data.NameContains.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
 		data.Allocations = types.ListUnknown(datasource_allocations.AllocationsValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -83,6 +83,9 @@ func (d *allocationsDataSource) Read(ctx context.Context, req datasource.ReadReq
 	params := &models.ListAllocationsParams{}
 	if !data.Filter.IsNull() {
 		params.Filter = new(data.Filter.ValueString())
+	}
+	if !data.NameContains.IsNull() {
+		params.NameContains = new(data.NameContains.ValueString())
 	}
 
 	// Smart pagination: honor user-provided values, otherwise auto-paginate

--- a/internal/provider/allocations_data_source_test.go
+++ b/internal/provider/allocations_data_source_test.go
@@ -163,6 +163,58 @@ data "doit_allocations" "test" {
 `
 }
 
+// TestAccAllocationsDataSource_NameContains tests filtering allocations with name_contains
+// against both an existing allocation (via chained data source) and a non-existent name.
+func TestAccAllocationsDataSource_NameContains(t *testing.T) {
+	allocationCount := getAllocationCount(t)
+	if allocationCount < 1 {
+		t.Skipf("Need at least 1 allocation to test name_contains, got %d", allocationCount)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAllocationsDataSourceNameContainsConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_allocations.first", "allocations.0.name"),
+					resource.TestCheckResourceAttrSet("data.doit_allocations.filtered", "allocations.0.id"),
+					resource.TestCheckResourceAttrSet("data.doit_allocations.filtered", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_allocations.empty", "allocations.#", "0"),
+					resource.TestCheckResourceAttr("data.doit_allocations.empty", "row_count", "0"),
+				),
+			},
+			// Drift verification: re-apply the same config should produce an empty plan
+			{
+				Config: testAccAllocationsDataSourceNameContainsConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAllocationsDataSourceNameContainsConfig() string {
+	return `
+data "doit_allocations" "first" {
+  max_results = "1"
+}
+
+data "doit_allocations" "filtered" {
+  name_contains = data.doit_allocations.first.allocations.0.name
+}
+
+data "doit_allocations" "empty" {
+  name_contains = "nonexistent-allocation-xyz-99999"
+}
+`
+}
+
 // Helper functions
 
 var (

--- a/internal/provider/budgets_data_source.go
+++ b/internal/provider/budgets_data_source.go
@@ -75,7 +75,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	defer cancel()
 
 	// If any filter/pagination input is unknown, return unknown list
-	if data.Filter.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
+	if data.Filter.IsUnknown() || data.NameContains.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
 		data.Budgets = types.ListUnknown(datasource_budgets.BudgetsValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -84,6 +84,9 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	params := &models.ListBudgetsParams{}
 	if !data.Filter.IsNull() {
 		params.Filter = new(data.Filter.ValueString())
+	}
+	if !data.NameContains.IsNull() {
+		params.NameContains = new(data.NameContains.ValueString())
 	}
 	if !data.MinCreationTime.IsNull() {
 		params.MinCreationTime = new(data.MinCreationTime.ValueString())

--- a/internal/provider/budgets_data_source_test.go
+++ b/internal/provider/budgets_data_source_test.go
@@ -164,6 +164,58 @@ func TestAccBudgetsDataSource_AutoPagination(t *testing.T) {
 	})
 }
 
+// TestAccBudgetsDataSource_NameContains tests filtering budgets with name_contains
+// against both an existing budget (via chained data source) and a non-existent name.
+func TestAccBudgetsDataSource_NameContains(t *testing.T) {
+	budgetCount := getBudgetCount(t)
+	if budgetCount < 1 {
+		t.Skipf("Need at least 1 budget to test name_contains, got %d", budgetCount)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetsDataSourceNameContainsConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_budgets.first", "budgets.0.budget_name"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.filtered", "budgets.0.id"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.filtered", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_budgets.empty", "budgets.#", "0"),
+					resource.TestCheckResourceAttr("data.doit_budgets.empty", "row_count", "0"),
+				),
+			},
+			// Drift verification: re-apply the same config should produce an empty plan
+			{
+				Config: testAccBudgetsDataSourceNameContainsConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetsDataSourceNameContainsConfig() string {
+	return `
+data "doit_budgets" "first" {
+  max_results = "1"
+}
+
+data "doit_budgets" "filtered" {
+  name_contains = data.doit_budgets.first.budgets.0.budget_name
+}
+
+data "doit_budgets" "empty" {
+  name_contains = "nonexistent-budget-xyz-99999"
+}
+`
+}
+
 // Helper functions
 
 var (

--- a/internal/provider/datasource_alerts/alerts_data_source_gen.go
+++ b/internal/provider/datasource_alerts/alerts_data_source_gen.go
@@ -206,6 +206,12 @@ func AlertsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
 				MarkdownDescription: "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
 			},
+			"name_contains": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+				MarkdownDescription: "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+			},
 			"page_token": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -250,13 +256,14 @@ func AlertsDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type AlertsModel struct {
-	Alerts     types.List   `tfsdk:"alerts"`
-	Filter     types.String `tfsdk:"filter"`
-	MaxResults types.Int64  `tfsdk:"max_results"`
-	PageToken  types.String `tfsdk:"page_token"`
-	RowCount   types.Int64  `tfsdk:"row_count"`
-	SortBy     types.String `tfsdk:"sort_by"`
-	SortOrder  types.String `tfsdk:"sort_order"`
+	Alerts       types.List   `tfsdk:"alerts"`
+	Filter       types.String `tfsdk:"filter"`
+	MaxResults   types.Int64  `tfsdk:"max_results"`
+	NameContains types.String `tfsdk:"name_contains"`
+	PageToken    types.String `tfsdk:"page_token"`
+	RowCount     types.Int64  `tfsdk:"row_count"`
+	SortBy       types.String `tfsdk:"sort_by"`
+	SortOrder    types.String `tfsdk:"sort_order"`
 }
 
 var _ basetypes.ObjectTypable = AlertsType{}

--- a/internal/provider/datasource_allocations/allocations_data_source_gen.go
+++ b/internal/provider/datasource_allocations/allocations_data_source_gen.go
@@ -99,6 +99,12 @@ func AllocationsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
 				MarkdownDescription: "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
 			},
+			"name_contains": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+				MarkdownDescription: "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+			},
 			"page_token": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -146,13 +152,14 @@ func AllocationsDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type AllocationsModel struct {
-	Allocations types.List   `tfsdk:"allocations"`
-	Filter      types.String `tfsdk:"filter"`
-	MaxResults  types.Int64  `tfsdk:"max_results"`
-	PageToken   types.String `tfsdk:"page_token"`
-	RowCount    types.Int64  `tfsdk:"row_count"`
-	SortBy      types.String `tfsdk:"sort_by"`
-	SortOrder   types.String `tfsdk:"sort_order"`
+	Allocations  types.List   `tfsdk:"allocations"`
+	Filter       types.String `tfsdk:"filter"`
+	MaxResults   types.Int64  `tfsdk:"max_results"`
+	NameContains types.String `tfsdk:"name_contains"`
+	PageToken    types.String `tfsdk:"page_token"`
+	RowCount     types.Int64  `tfsdk:"row_count"`
+	SortBy       types.String `tfsdk:"sort_by"`
+	SortOrder    types.String `tfsdk:"sort_order"`
 }
 
 var _ basetypes.ObjectTypable = AllocationsType{}

--- a/internal/provider/datasource_budgets/budgets_data_source_gen.go
+++ b/internal/provider/datasource_budgets/budgets_data_source_gen.go
@@ -149,8 +149,8 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 			"filter": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\".",
-				MarkdownDescription: "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\".",
+				Description:         "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\".",
+				MarkdownDescription: "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\".",
 			},
 			"max_creation_time": schema.StringAttribute{
 				Optional:            true,
@@ -169,6 +169,12 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.",
 				MarkdownDescription: "Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.",
+			},
+			"name_contains": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+				MarkdownDescription: "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
 			},
 			"page_token": schema.StringAttribute{
 				Optional:            true,
@@ -193,6 +199,7 @@ type BudgetsModel struct {
 	MaxCreationTime types.String `tfsdk:"max_creation_time"`
 	MaxResults      types.Int64  `tfsdk:"max_results"`
 	MinCreationTime types.String `tfsdk:"min_creation_time"`
+	NameContains    types.String `tfsdk:"name_contains"`
 	PageToken       types.String `tfsdk:"page_token"`
 	RowCount        types.Int64  `tfsdk:"row_count"`
 }

--- a/internal/provider/datasource_labels/labels_data_source_gen.go
+++ b/internal/provider/datasource_labels/labels_data_source_gen.go
@@ -74,6 +74,12 @@ func LabelsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
 				MarkdownDescription: "The maximum number of results to return in a single page. Use the page tokens to iterate through the entire collection.",
 			},
+			"name_contains": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+				MarkdownDescription: "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+			},
 			"page_token": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -119,13 +125,14 @@ func LabelsDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type LabelsModel struct {
-	Filter     types.String `tfsdk:"filter"`
-	Labels     types.List   `tfsdk:"labels"`
-	MaxResults types.Int64  `tfsdk:"max_results"`
-	PageToken  types.String `tfsdk:"page_token"`
-	RowCount   types.Int64  `tfsdk:"row_count"`
-	SortBy     types.String `tfsdk:"sort_by"`
-	SortOrder  types.String `tfsdk:"sort_order"`
+	Filter       types.String `tfsdk:"filter"`
+	Labels       types.List   `tfsdk:"labels"`
+	MaxResults   types.Int64  `tfsdk:"max_results"`
+	NameContains types.String `tfsdk:"name_contains"`
+	PageToken    types.String `tfsdk:"page_token"`
+	RowCount     types.Int64  `tfsdk:"row_count"`
+	SortBy       types.String `tfsdk:"sort_by"`
+	SortOrder    types.String `tfsdk:"sort_order"`
 }
 
 var _ basetypes.ObjectTypable = LabelsType{}

--- a/internal/provider/datasource_reports/reports_data_source_gen.go
+++ b/internal/provider/datasource_reports/reports_data_source_gen.go
@@ -42,6 +42,12 @@ func ReportsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.",
 				MarkdownDescription: "Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.",
 			},
+			"name_contains": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+				MarkdownDescription: "Case-insensitive substring match against the resource name. Combined with the \"filter\" parameter using AND semantics.",
+			},
 			"page_token": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -133,6 +139,7 @@ type ReportsModel struct {
 	MaxCreationTime types.String `tfsdk:"max_creation_time"`
 	MaxResults      types.Int64  `tfsdk:"max_results"`
 	MinCreationTime types.String `tfsdk:"min_creation_time"`
+	NameContains    types.String `tfsdk:"name_contains"`
 	PageToken       types.String `tfsdk:"page_token"`
 	Reports         types.List   `tfsdk:"reports"`
 	RowCount        types.Int64  `tfsdk:"row_count"`

--- a/internal/provider/labels_data_source.go
+++ b/internal/provider/labels_data_source.go
@@ -74,7 +74,7 @@ func (d *labelsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	defer cancel()
 
 	// If any filter/pagination input is unknown, return unknown list
-	if data.Filter.IsUnknown() || data.SortBy.IsUnknown() || data.SortOrder.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
+	if data.Filter.IsUnknown() || data.NameContains.IsUnknown() || data.SortBy.IsUnknown() || data.SortOrder.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
 		data.Labels = types.ListUnknown(datasource_labels.LabelsValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -83,6 +83,9 @@ func (d *labelsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	params := &models.ListLabelsParams{}
 	if !data.Filter.IsNull() {
 		params.Filter = new(data.Filter.ValueString())
+	}
+	if !data.NameContains.IsNull() {
+		params.NameContains = new(data.NameContains.ValueString())
 	}
 	if !data.SortBy.IsNull() {
 		params.SortBy = new(models.ListLabelsParamsSortBy(data.SortBy.ValueString()))

--- a/internal/provider/labels_data_source_test.go
+++ b/internal/provider/labels_data_source_test.go
@@ -159,6 +159,58 @@ data "doit_labels" "test" {
 `
 }
 
+// TestAccLabelsDataSource_NameContains tests filtering labels with name_contains
+// against both an existing label (via chained data source) and a non-existent name.
+func TestAccLabelsDataSource_NameContains(t *testing.T) {
+	labelCount := getLabelCount(t)
+	if labelCount < 1 {
+		t.Skipf("Need at least 1 label to test name_contains, got %d", labelCount)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLabelsDataSourceNameContainsConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_labels.first", "labels.0.name"),
+					resource.TestCheckResourceAttrSet("data.doit_labels.filtered", "labels.0.id"),
+					resource.TestCheckResourceAttrSet("data.doit_labels.filtered", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_labels.empty", "labels.#", "0"),
+					resource.TestCheckResourceAttr("data.doit_labels.empty", "row_count", "0"),
+				),
+			},
+			// Drift verification: re-apply the same config should produce an empty plan
+			{
+				Config: testAccLabelsDataSourceNameContainsConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccLabelsDataSourceNameContainsConfig() string {
+	return `
+data "doit_labels" "first" {
+  max_results = "1"
+}
+
+data "doit_labels" "filtered" {
+  name_contains = data.doit_labels.first.labels.0.name
+}
+
+data "doit_labels" "empty" {
+  name_contains = "nonexistent-label-xyz-99999"
+}
+`
+}
+
 // Helper functions
 
 var (

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -8865,6 +8865,9 @@ type ManagementAccountId = string
 // MaxResults defines model for maxResults.
 type MaxResults = int64
 
+// NameContains defines model for nameContains.
+type NameContains = string
+
 // PageToken defines model for pageToken.
 type PageToken = string
 
@@ -8951,6 +8954,9 @@ type ListAlertsParams struct {
 	// Filter An expression for filtering the results. The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 	// Available filter keys: **owner**, **name**
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
+
+	// NameContains Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
+	NameContains *NameContains `form:"nameContains,omitempty" json:"nameContains,omitempty"`
 }
 
 // ListAlertsParamsSortBy defines parameters for ListAlerts.
@@ -8970,6 +8976,9 @@ type ListAllocationsParams struct {
 	// Filter An expression for filtering the results.
 	// Valid fields: **type**, **owner**, **name**, **folderId**.
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
+
+	// NameContains Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
+	NameContains *NameContains `form:"nameContains,omitempty" json:"nameContains,omitempty"`
 
 	// SortBy A field by which the results will be sorted.
 	SortBy *ListAllocationsParamsSortBy `form:"sortBy,omitempty" json:"sortBy,omitempty"`
@@ -9018,8 +9027,11 @@ type ListBudgetsParams struct {
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 
 	// Filter An expression for filtering the results of the request. The syntax is "key:[<value>]".
-	// Available keys: owner, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+	// Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
+
+	// NameContains Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
+	NameContains *NameContains `form:"nameContains,omitempty" json:"nameContains,omitempty"`
 
 	// MinCreationTime Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
 	MinCreationTime *string `form:"minCreationTime,omitempty" json:"minCreationTime,omitempty"`
@@ -9108,6 +9120,9 @@ type ListLabelsParams struct {
 	// Valid fields: **name**, **type**.
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
 
+	// NameContains Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
+	NameContains *NameContains `form:"nameContains,omitempty" json:"nameContains,omitempty"`
+
 	// SortBy A field by which the results will be sorted.
 	SortBy *ListLabelsParamsSortBy `form:"sortBy,omitempty" json:"sortBy,omitempty"`
 
@@ -9133,6 +9148,9 @@ type ListReportsParams struct {
 	// The syntax is `key:[<value>]`. Multiple filters can be connected using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
 	// Possible filter keys: **reportName**, **owner**, **type**, **updateTime**, **folderId**
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
+
+	// NameContains Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
+	NameContains *NameContains `form:"nameContains,omitempty" json:"nameContains,omitempty"`
 
 	// MinCreationTime Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
 	MinCreationTime *string `form:"minCreationTime,omitempty" json:"minCreationTime,omitempty"`
@@ -14273,6 +14291,18 @@ func NewListAlertsRequest(server string, params *ListAlertsParams) (*http.Reques
 
 		}
 
+		if params.NameContains != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "nameContains", *params.NameContains, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if encoded := queryValues.Encode(); encoded != "" {
 			rawQueryFragments = append(rawQueryFragments, encoded)
 		}
@@ -14497,6 +14527,18 @@ func NewListAllocationsRequest(server string, params *ListAllocationsParams) (*h
 		if params.Filter != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "filter", *params.Filter, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.NameContains != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "nameContains", *params.NameContains, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -15038,6 +15080,18 @@ func NewListBudgetsRequest(server string, params *ListBudgetsParams) (*http.Requ
 		if params.Filter != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "filter", *params.Filter, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.NameContains != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "nameContains", *params.NameContains, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -15821,6 +15875,18 @@ func NewListLabelsRequest(server string, params *ListLabelsParams) (*http.Reques
 
 		}
 
+		if params.NameContains != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "nameContains", *params.NameContains, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if params.SortBy != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "sortBy", *params.SortBy, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
@@ -16150,6 +16216,18 @@ func NewListReportsRequest(server string, params *ListReportsParams) (*http.Requ
 		if params.Filter != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "filter", *params.Filter, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.NameContains != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "nameContains", *params.NameContains, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/internal/provider/reports_data_source.go
+++ b/internal/provider/reports_data_source.go
@@ -75,7 +75,7 @@ func (d *reportsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	defer cancel()
 
 	// If any filter/pagination input is unknown, return unknown list
-	if data.Filter.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
+	if data.Filter.IsUnknown() || data.NameContains.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
 		data.Reports = types.ListUnknown(datasource_reports.ReportsValue{}.Type(ctx))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
@@ -84,6 +84,9 @@ func (d *reportsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	params := &models.ListReportsParams{}
 	if !data.Filter.IsNull() {
 		params.Filter = new(data.Filter.ValueString())
+	}
+	if !data.NameContains.IsNull() {
+		params.NameContains = new(data.NameContains.ValueString())
 	}
 	if !data.MinCreationTime.IsNull() {
 		params.MinCreationTime = new(data.MinCreationTime.ValueString())

--- a/internal/provider/reports_data_source_test.go
+++ b/internal/provider/reports_data_source_test.go
@@ -159,6 +159,58 @@ data "doit_reports" "test" {
 `
 }
 
+// TestAccReportsDataSource_NameContains tests filtering reports with name_contains
+// against both an existing report (via chained data source) and a non-existent name.
+func TestAccReportsDataSource_NameContains(t *testing.T) {
+	reportCount := getReportCount(t)
+	if reportCount < 1 {
+		t.Skipf("Need at least 1 report to test name_contains, got %d", reportCount)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportsDataSourceNameContainsConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_reports.first", "reports.0.report_name"),
+					resource.TestCheckResourceAttrSet("data.doit_reports.filtered", "reports.0.id"),
+					resource.TestCheckResourceAttrSet("data.doit_reports.filtered", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_reports.empty", "reports.#", "0"),
+					resource.TestCheckResourceAttr("data.doit_reports.empty", "row_count", "0"),
+				),
+			},
+			// Drift verification: re-apply the same config should produce an empty plan
+			{
+				Config: testAccReportsDataSourceNameContainsConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccReportsDataSourceNameContainsConfig() string {
+	return `
+data "doit_reports" "first" {
+  max_results = "1"
+}
+
+data "doit_reports" "filtered" {
+  name_contains = data.doit_reports.first.reports.0.report_name
+}
+
+data "doit_reports" "empty" {
+  name_contains = "nonexistent-report-xyz-99999"
+}
+`
+}
+
 // Helper functions
 
 var (


### PR DESCRIPTION
## Description

Adds support and acceptance test coverage for the new `name_contains` query parameter across 5 data sources:
- `doit_alerts`
- `doit_allocations`
- `doit_budgets`
- `doit_labels`
- `doit_reports`

## Changes
- **Provider Wiring**: Added `data.NameContains.IsUnknown()` check (satisfying the `unknownguard` custom linter) and mapped `params.NameContains` into the API request parameters for each data source.
- **Acceptance Tests**: Added `TestAcc<Resource>DataSource_NameContains` with chained data sources to verify `name_contains` filtering against existing resources, non-existent substrings (returning 0 records), and drift checks (`plancheck.ExpectEmptyPlan()`).
- **Examples & Documentation**: Updated Terraform example configurations and regenerated documentation with `make docs`.

## Validation
- `make testacc-run TEST=DataSource_NameContains` — 5/5 acceptance tests passed.
- `make test` — full unit test suite passed.
- `./custom-gcl run` — 0 linter issues.
- `tfplugindocs validate` — PASSED.
- `make fmt` — clean.