### PR TITLE
feat: add sorting, creation time filters, and summary attributes to anomalies data source

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -1261,30 +1261,68 @@
 				"attributes": [
 					{
 						"name": "min_creation_time",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
-							"description": "Min value for the anomaly detection time"
+							"description": "Inclusive lower bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created."
 						}
 					},
 					{
 						"name": "max_creation_time",
-						"string": {
+						"int64": {
 							"computed_optional_required": "computed_optional",
-							"description": "Max value for the anomaly detection time"
+							"description": "Inclusive upper bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created."
 						}
 					},
 					{
 						"name": "filter",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "An expression for filtering the results of the request"
+							"description": "An expression for filtering the results. The syntax is `key:value`. Multiple criteria can be combined using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nAvailable filter keys: **serviceName**, **billingAccount**, **platform**, **severityLevel**. `severityLevel` values must be lowercase: `information`, `warning`, `critical`. An unrecognised key, or a segment that is not `key:value`, is rejected with `400` rather than ignored."
+						}
+					},
+					{
+						"name": "sort_by",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "A field by which the results will be sorted. Defaults to `startTime`.",
+							"validators": [
+								{
+									"custom": {
+										"imports": [
+											{
+												"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+											}
+										],
+										"schema_definition": "stringvalidator.OneOf(\n\"startTime\",\n\"severityLevel\",\n\"costOfAnomaly\",\n)"
+									}
+								}
+							]
+						}
+					},
+					{
+						"name": "sort_order",
+						"string": {
+							"computed_optional_required": "computed_optional",
+							"description": "Sort order can be ascending or descending.",
+							"validators": [
+								{
+									"custom": {
+										"imports": [
+											{
+												"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+											}
+										],
+										"schema_definition": "stringvalidator.OneOf(\n\"asc\",\n\"desc\",\n)"
+									}
+								}
+							]
 						}
 					},
 					{
 						"name": "max_results",
 						"int64": {
 							"computed_optional_required": "computed_optional",
-							"description": "The maximum number of results to return in a single page"
+							"description": "The maximum number of results to return in a single page. If omitted, all anomalies matching the filters and time window are returned in a single page."
 						}
 					},
 					{
@@ -1501,7 +1539,7 @@
 										"name": "severity_level",
 										"string": {
 											"computed_optional_required": "computed",
-											"description": "Severity level: Information, Warning or Critical"
+											"description": "Severity level: `information`, `warning`, or `critical`."
 										}
 									},
 									{
@@ -1548,13 +1586,79 @@
 										}
 									}
 								]
-							}
+							},
+							"description": "Anomalies in this page. Always an array; empty (`[]`) when there are no matching anomalies."
+						}
+					},
+					{
+						"name": "anomaly_summary",
+						"single_nested": {
+							"computed_optional_required": "computed",
+							"attributes": [
+								{
+									"name": "count_by_severity",
+									"single_nested": {
+										"computed_optional_required": "computed",
+										"attributes": [
+											{
+												"name": "critical",
+												"int64": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "information",
+												"int64": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "warning",
+												"int64": {
+													"computed_optional_required": "computed"
+												}
+											}
+										],
+										"description": "Count of matching anomalies per severity level. All three keys are always present, with zero counts included."
+									}
+								},
+								{
+									"name": "total_cost_of_anomaly",
+									"float64": {
+										"computed_optional_required": "computed",
+										"description": "Sum of `costOfAnomaly` across all matching anomalies, in USD, rounded to cents."
+									}
+								}
+							],
+							"description": "Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence."
 						}
 					},
 					{
 						"name": "row_count",
 						"int64": {
-							"computed_optional_required": "computed"
+							"computed_optional_required": "computed",
+							"description": "Number of items in this page (`anomalies.length`). This is not the total count across all pages; the total across the full filtered result set is `totalCount`."
+						}
+					},
+					{
+						"name": "total_count",
+						"int64": {
+							"computed_optional_required": "computed",
+							"description": "Total number of anomalies matching the filters and time window, across all pages. This is a per-request snapshot: under concurrent writes, the value can differ between pages fetched during the same pagination sequence."
+						}
+					},
+					{
+						"name": "total_count_exact",
+						"bool": {
+							"computed_optional_required": "computed",
+							"description": "Whether `totalCount` is exact. Always `true` for this operation, because `totalCount` is computed over the fully materialised filtered result set."
+						}
+					},
+					{
+						"name": "truncated",
+						"bool": {
+							"computed_optional_required": "computed",
+							"description": "`true` when filtered anomalies remain beyond this page. Derived from the same \"rows remain after the last returned row\" check as `pageToken`, so the two are never contradictory: `pageToken` is present if and only if `truncated` is `true`."
 						}
 					}
 				],
@@ -1761,7 +1865,7 @@
 						"name": "severity_level",
 						"string": {
 							"computed_optional_required": "computed",
-							"description": "Severity level: Information, Warning or Critical"
+							"description": "Severity level: `information`, `warning`, or `critical`."
 						}
 					},
 					{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -2398,28 +2398,60 @@ paths:
       summary: List anomalies
       description: |-
         Returns a list of detected anomalies.
-        Anomalies are returned in reverse chronological order by default.
+        Anomalies can be sorted by `startTime`, `severityLevel`, or `costOfAnomaly` using `sortBy` and `sortOrder`. By default they are sorted by `startTime` in descending order (most recent first).
+        The sort order is total and reproducible: ties on the selected field are broken by `startTime` descending and then by anomaly `id` ascending, so the same result set always paginates in the same order.
         The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
+        **Pagination stability**: `sortBy`, `sortOrder`, `filter`, `minCreationTime`, and `maxCreationTime` must be held constant across a pagination sequence. A `pageToken` presented with any of them changed is rejected with `400`.
       operationId: listAnomalies
       parameters:
         - name: minCreationTime
           in: query
-          description: Min value for the anomaly detection time
+          description: >-
+            Inclusive lower bound on the anomaly's usage start time, in milliseconds since the POSIX
+            epoch. Despite the name, this filters the anomaly's usage start time, not the time the
+            anomaly document was created.
           schema:
-            type: string
+            type: integer
+            format: int64
         - name: maxCreationTime
           in: query
-          description: Max value for the anomaly detection time
+          description: >-
+            Inclusive upper bound on the anomaly's usage start time, in milliseconds since the POSIX
+            epoch. Despite the name, this filters the anomaly's usage start time, not the time the
+            anomaly document was created.
           schema:
-            type: string
+            type: integer
+            format: int64
         - name: filter
           in: query
-          description: An expression for filtering the results of the request
+          description: >-
+            An expression for filtering the results. The syntax is `key:value`. Multiple criteria
+            can be combined using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
+
+            Available filter keys: **serviceName**, **billingAccount**, **platform**,
+            **severityLevel**. `severityLevel` values must be lowercase: `information`, `warning`,
+            `critical`. An unrecognised key, or a segment that is not `key:value`, is rejected with
+            `400` rather than ignored.
+          example: "severityLevel:critical"
           schema:
             type: string
+        - name: sortBy
+          in: query
+          description: >-
+            A field by which the results will be sorted. Defaults to `startTime`.
+          schema:
+            type: string
+            enum:
+              - startTime
+              - severityLevel
+              - costOfAnomaly
+            default: startTime
+        - $ref: "#/components/parameters/sortOrder"
         - name: maxResults
           in: query
-          description: The maximum number of results to return in a single page
+          description: >-
+            The maximum number of results to return in a single page. If omitted, all anomalies
+            matching the filters and time window are returned in a single page.
           schema:
             type: integer
             format: int64
@@ -2510,7 +2542,7 @@ paths:
                     description: Service name
                   severityLevel:
                     type: string
-                    description: "Severity level: Information, Warning or Critical"
+                    description: "Severity level: `information`, `warning`, or `critical`."
                   startTime:
                     type: integer
                     description: Usage start time of the anomaly
@@ -9015,16 +9047,86 @@ components:
     AnomaliesResponse:
       type: object
       description: List of detected cloud cost anomalies.
+      required:
+        - anomalies
+        - rowCount
+        - truncated
+        - totalCount
+        - totalCountExact
+        - anomalySummary
       properties:
         anomalies:
           type: array
+          description: >-
+            Anomalies in this page. Always an array; empty (`[]`) when there are no matching
+            anomalies.
           items:
             $ref: "#/components/schemas/AnomalyItem"
         pageToken:
           type: string
+          description: Opaque token for the next page. Omitted when there is no next page.
         rowCount:
           type: integer
           format: int64
+          description: >-
+            Number of items in this page (`anomalies.length`). This is not the total count across
+            all pages; the total across the full filtered result set is `totalCount`.
+        truncated:
+          type: boolean
+          description: >-
+            `true` when filtered anomalies remain beyond this page. Derived from the same "rows
+            remain after the last returned row" check as `pageToken`, so the two are never
+            contradictory: `pageToken` is present if and only if `truncated` is `true`.
+        totalCount:
+          type: integer
+          format: int64
+          description: >-
+            Total number of anomalies matching the filters and time window, across all pages. This
+            is a per-request snapshot: under concurrent writes, the value can differ between pages
+            fetched during the same pagination sequence.
+        totalCountExact:
+          type: boolean
+          description: >-
+            Whether `totalCount` is exact. Always `true` for this operation, because `totalCount`
+            is computed over the fully materialised filtered result set.
+        anomalySummary:
+          type: object
+          description: >-
+            Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete
+            filtered result set across all pages, not the returned page. Anomalies whose severity
+            cannot be determined (legacy documents) are counted in `totalCount` and
+            `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so
+            the three values can sum to less than `totalCount`. Computed as of this request; under
+            concurrent writes, values may differ between pages fetched during the same pagination
+            sequence.
+          required:
+            - countBySeverity
+            - totalCostOfAnomaly
+          properties:
+            countBySeverity:
+              type: object
+              description: >-
+                Count of matching anomalies per severity level. All three keys are always present,
+                with zero counts included.
+              required:
+                - information
+                - warning
+                - critical
+              properties:
+                information:
+                  type: integer
+                  format: int64
+                warning:
+                  type: integer
+                  format: int64
+                critical:
+                  type: integer
+                  format: int64
+            totalCostOfAnomaly:
+              type: number
+              format: double
+              description: >-
+                Sum of `costOfAnomaly` across all matching anomalies, in USD, rounded to cents.
     AnomalyItem:
       required:
         - attribution
@@ -9076,7 +9178,7 @@ components:
           description: Service name.
         severityLevel:
           type: string
-          description: "Severity level: Information, Warning or Critical"
+          description: "Severity level: `information`, `warning`, or `critical`."
         startTime:
           type: integer
           description: Usage start time of the anomaly.
@@ -15874,7 +15976,7 @@ components:
                 description: Service name
               severityLevel:
                 type: string
-                description: "Severity level: Information, Warning or Critical"
+                description: "Severity level: `information`, `warning`, or `critical`."
               startTime:
                 type: integer
                 description: Usage start time of the anomaly

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -1986,28 +1986,51 @@ paths:
       summary: List anomalies
       description: |-
         Returns a list of detected anomalies.
-        Anomalies are returned in reverse chronological order by default.
+        Anomalies can be sorted by `startTime`, `severityLevel`, or `costOfAnomaly` using `sortBy` and `sortOrder`. By default they are sorted by `startTime` in descending order (most recent first).
+        The sort order is total and reproducible: ties on the selected field are broken by `startTime` descending and then by anomaly `id` ascending, so the same result set always paginates in the same order.
         The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
+        **Pagination stability**: `sortBy`, `sortOrder`, `filter`, `minCreationTime`, and `maxCreationTime` must be held constant across a pagination sequence. A `pageToken` presented with any of them changed is rejected with `400`.
       operationId: listAnomalies
       parameters:
         - name: minCreationTime
           in: query
-          description: Min value for the anomaly detection time
+          description: >-
+            Inclusive lower bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.
           schema:
-            type: string
+            type: integer
+            format: int64
         - name: maxCreationTime
           in: query
-          description: Max value for the anomaly detection time
+          description: >-
+            Inclusive upper bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.
           schema:
-            type: string
+            type: integer
+            format: int64
         - name: filter
           in: query
-          description: An expression for filtering the results of the request
+          description: >-
+            An expression for filtering the results. The syntax is `key:value`. Multiple criteria can be combined using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
+
+            Available filter keys: **serviceName**, **billingAccount**, **platform**, **severityLevel**. `severityLevel` values must be lowercase: `information`, `warning`, `critical`. An unrecognised key, or a segment that is not `key:value`, is rejected with `400` rather than ignored.
+          example: "severityLevel:critical"
           schema:
             type: string
+        - name: sortBy
+          in: query
+          description: >-
+            A field by which the results will be sorted. Defaults to `startTime`.
+          schema:
+            type: string
+            enum:
+              - startTime
+              - severityLevel
+              - costOfAnomaly
+            default: startTime
+        - $ref: "#/components/parameters/sortOrder"
         - name: maxResults
           in: query
-          description: The maximum number of results to return in a single page
+          description: >-
+            The maximum number of results to return in a single page. If omitted, all anomalies matching the filters and time window are returned in a single page.
           schema:
             type: integer
             format: int64
@@ -4801,14 +4824,80 @@ components:
     AnomaliesResponse:
       type: object
       description: List of detected cloud cost anomalies.
+      required:
+        - anomalies
+        - rowCount
+        - truncated
+        - totalCount
+        - totalCountExact
+        - anomalySummary
       properties:
         anomalies:
           type: array
+          description: >-
+            Anomalies in this page. Always an array; empty (`[]`) when there are no matching anomalies.
           items:
             $ref: "#/components/schemas/AnomalyItem"
         pageToken:
           type: string
+          description: Opaque token for the next page. Omitted when there is no next page.
         rowCount:
+          type: integer
+          format: int64
+          description: >-
+            Number of items in this page (`anomalies.length`). This is not the total count across all pages; the total across the full filtered result set is `totalCount`.
+        truncated:
+          type: boolean
+          description: >-
+            `true` when filtered anomalies remain beyond this page. Derived from the same "rows remain after the last returned row" check as `pageToken`, so the two are never contradictory: `pageToken` is present if and only if `truncated` is `true`.
+        totalCount:
+          type: integer
+          format: int64
+          description: >-
+            Total number of anomalies matching the filters and time window, across all pages. This is a per-request snapshot: under concurrent writes, the value can differ between pages fetched during the same pagination sequence.
+        totalCountExact:
+          type: boolean
+          description: >-
+            Whether `totalCount` is exact. Always `true` for this operation, because `totalCount` is computed over the fully materialised filtered result set.
+        anomalySummary:
+          description: >-
+            Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence.
+          allOf:
+            - $ref: '#/components/schemas/AnomaliesResponseAnomalySummary'
+    AnomaliesResponseAnomalySummary:
+      type: object
+      description: >-
+        Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence.
+      required:
+        - countBySeverity
+        - totalCostOfAnomaly
+      properties:
+        countBySeverity:
+          description: >-
+            Count of matching anomalies per severity level. All three keys are always present, with zero counts included.
+          allOf:
+            - $ref: '#/components/schemas/AnomaliesResponseAnomalySummaryCountBySeverity'
+        totalCostOfAnomaly:
+          type: number
+          format: double
+          description: >-
+            Sum of `costOfAnomaly` across all matching anomalies, in USD, rounded to cents.
+    AnomaliesResponseAnomalySummaryCountBySeverity:
+      type: object
+      description: >-
+        Count of matching anomalies per severity level. All three keys are always present, with zero counts included.
+      required:
+        - information
+        - warning
+        - critical
+      properties:
+        information:
+          type: integer
+          format: int64
+        warning:
+          type: integer
+          format: int64
+        critical:
           type: integer
           format: int64
     AnomalyItem:
@@ -4861,7 +4950,7 @@ components:
           description: Service name.
         severityLevel:
           type: string
-          description: "Severity level: Information, Warning or Critical"
+          description: "Severity level: `information`, `warning`, or `critical`."
         startTime:
           type: integer
           description: Usage start time of the anomaly.
@@ -8606,7 +8695,7 @@ components:
           description: Service name
         severityLevel:
           type: string
-          description: "Severity level: Information, Warning or Critical"
+          description: "Severity level: `information`, `warning`, or `critical`."
         startTime:
           type: integer
           description: Usage start time of the anomaly

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -22,7 +22,7 @@ data "doit_anomalies" "critical_by_cost" {
   sort_order = "desc"
 }
 
-# Filter by creation time window (epoch milliseconds)
+# Filter by usage start time window (epoch milliseconds)
 data "doit_anomalies" "recent" {
   min_creation_time = 1704067200000 # 2024-01-01T00:00:00Z
   max_creation_time = 1735689600000 # 2025-01-01T00:00:00Z

--- a/docs/data-sources/anomalies.md
+++ b/docs/data-sources/anomalies.md
@@ -15,9 +15,17 @@ Monitor cost spikes in your cloud environment.
 # Retrieve all anomalies
 data "doit_anomalies" "all" {}
 
-# Filter by severity
-data "doit_anomalies" "critical" {
-  filter = "severityLevel:critical"
+# Filter by severity and sort by cost descending
+data "doit_anomalies" "critical_by_cost" {
+  filter     = "severityLevel:critical"
+  sort_by    = "costOfAnomaly"
+  sort_order = "desc"
+}
+
+# Filter by creation time window (epoch milliseconds)
+data "doit_anomalies" "recent" {
+  min_creation_time = 1704067200000 # 2024-01-01T00:00:00Z
+  max_creation_time = 1735689600000 # 2025-01-01T00:00:00Z
 }
 
 # Include notification events for each anomaly
@@ -37,9 +45,22 @@ output "notification_audit" {
   }]
 }
 
-# Output anomaly details
+# Output anomaly counts and aggregate summary
 output "total_anomalies" {
   value = data.doit_anomalies.all.row_count
+}
+
+output "total_count" {
+  value = data.doit_anomalies.all.total_count
+}
+
+output "anomaly_summary_metrics" {
+  value = {
+    total_cost        = data.doit_anomalies.all.anomaly_summary.total_cost_of_anomaly
+    critical_count    = data.doit_anomalies.all.anomaly_summary.count_by_severity.critical
+    warning_count     = data.doit_anomalies.all.anomaly_summary.count_by_severity.warning
+    information_count = data.doit_anomalies.all.anomaly_summary.count_by_severity.information
+  }
 }
 
 output "anomaly_summary" {
@@ -258,18 +279,27 @@ output "acknowledgment_audit" {
 
 ### Optional
 
-- `filter` (String) An expression for filtering the results of the request
+- `filter` (String) An expression for filtering the results. The syntax is `key:value`. Multiple criteria can be combined using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
+Available filter keys: **serviceName**, **billingAccount**, **platform**, **severityLevel**. `severityLevel` values must be lowercase: `information`, `warning`, `critical`. An unrecognised key, or a segment that is not `key:value`, is rejected with `400` rather than ignored.
 - `include_notifications` (Boolean) Include anomaly notifications from the subcollection. Defaults to false.
-- `max_creation_time` (String) Max value for the anomaly detection time
-- `max_results` (Number) The maximum number of results to return in a single page
-- `min_creation_time` (String) Min value for the anomaly detection time
+- `max_creation_time` (Number) Inclusive upper bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.
+- `max_results` (Number) The maximum number of results to return in a single page. If omitted, all anomalies matching the filters and time window are returned in a single page.
+- `min_creation_time` (Number) Inclusive lower bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.
 - `page_token` (String) Page token, returned by a previous call, to request the next page of results
+- `sort_by` (String) A field by which the results will be sorted. Defaults to `startTime`.
+Possible values: `startTime`, `severityLevel`, `costOfAnomaly`
+- `sort_order` (String) Sort order can be ascending or descending.
+Possible values: `asc`, `desc`
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
 
-- `anomalies` (Attributes List) (see [below for nested schema](#nestedatt--anomalies))
-- `row_count` (Number)
+- `anomalies` (Attributes List) Anomalies in this page. Always an array; empty (`[]`) when there are no matching anomalies. (see [below for nested schema](#nestedatt--anomalies))
+- `anomaly_summary` (Attributes) Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence. (see [below for nested schema](#nestedatt--anomaly_summary))
+- `row_count` (Number) Number of items in this page (`anomalies.length`). This is not the total count across all pages; the total across the full filtered result set is `totalCount`.
+- `total_count` (Number) Total number of anomalies matching the filters and time window, across all pages. This is a per-request snapshot: under concurrent writes, the value can differ between pages fetched during the same pagination sequence.
+- `total_count_exact` (Boolean) Whether `totalCount` is exact. Always `true` for this operation, because `totalCount` is computed over the fully materialised filtered result set.
+- `truncated` (Boolean) `true` when filtered anomalies remain beyond this page. Derived from the same "rows remain after the last returned row" check as `pageToken`, so the two are never contradictory: `pageToken` is present if and only if `truncated` is `true`.
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`
@@ -300,7 +330,7 @@ Read-Only:
 - `resource_data` (Attributes List) Array of resources contributing to an anomaly. (see [below for nested schema](#nestedatt--anomalies--resource_data))
 - `scope` (String) Scope: Project or Account
 - `service_name` (String) Service name.
-- `severity_level` (String) Severity level: Information, Warning or Critical
+- `severity_level` (String) Severity level: `information`, `warning`, or `critical`.
 - `start_time` (Number) Usage start time of the anomaly.
 - `status` (String)
 - `time_frame` (String) Timeframe: Daily or Hourly
@@ -345,3 +375,22 @@ Read-Only:
 
 - `cost` (Number)
 - `name` (String)
+
+
+
+<a id="nestedatt--anomaly_summary"></a>
+### Nested Schema for `anomaly_summary`
+
+Read-Only:
+
+- `count_by_severity` (Attributes) Count of matching anomalies per severity level. All three keys are always present, with zero counts included. (see [below for nested schema](#nestedatt--anomaly_summary--count_by_severity))
+- `total_cost_of_anomaly` (Number) Sum of `costOfAnomaly` across all matching anomalies, in USD, rounded to cents.
+
+<a id="nestedatt--anomaly_summary--count_by_severity"></a>
+### Nested Schema for `anomaly_summary.count_by_severity`
+
+Read-Only:
+
+- `critical` (Number)
+- `information` (Number)
+- `warning` (Number)

--- a/docs/data-sources/anomaly.md
+++ b/docs/data-sources/anomaly.md
@@ -88,7 +88,7 @@ output "anomaly_deactivation_reason" {
 - `resource_data` (Attributes List) Array of resources contributing to an anomaly. (see [below for nested schema](#nestedatt--resource_data))
 - `scope` (String) Scope: Project or Account
 - `service_name` (String) Service name
-- `severity_level` (String) Severity level: Information, Warning or Critical
+- `severity_level` (String) Severity level: `information`, `warning`, or `critical`.
 - `start_time` (Number) Usage start time of the anomaly
 - `status` (String)
 - `time_frame` (String) Timeframe: Daily or Hourly

--- a/examples/data-sources/doit_anomalies/data-source.tf
+++ b/examples/data-sources/doit_anomalies/data-source.tf
@@ -8,7 +8,7 @@ data "doit_anomalies" "critical_by_cost" {
   sort_order = "desc"
 }
 
-# Filter by creation time window (epoch milliseconds)
+# Filter by usage start time window (epoch milliseconds)
 data "doit_anomalies" "recent" {
   min_creation_time = 1704067200000 # 2024-01-01T00:00:00Z
   max_creation_time = 1735689600000 # 2025-01-01T00:00:00Z

--- a/examples/data-sources/doit_anomalies/data-source.tf
+++ b/examples/data-sources/doit_anomalies/data-source.tf
@@ -1,9 +1,17 @@
 # Retrieve all anomalies
 data "doit_anomalies" "all" {}
 
-# Filter by severity
-data "doit_anomalies" "critical" {
-  filter = "severityLevel:critical"
+# Filter by severity and sort by cost descending
+data "doit_anomalies" "critical_by_cost" {
+  filter     = "severityLevel:critical"
+  sort_by    = "costOfAnomaly"
+  sort_order = "desc"
+}
+
+# Filter by creation time window (epoch milliseconds)
+data "doit_anomalies" "recent" {
+  min_creation_time = 1704067200000 # 2024-01-01T00:00:00Z
+  max_creation_time = 1735689600000 # 2025-01-01T00:00:00Z
 }
 
 # Include notification events for each anomaly
@@ -23,9 +31,22 @@ output "notification_audit" {
   }]
 }
 
-# Output anomaly details
+# Output anomaly counts and aggregate summary
 output "total_anomalies" {
   value = data.doit_anomalies.all.row_count
+}
+
+output "total_count" {
+  value = data.doit_anomalies.all.total_count
+}
+
+output "anomaly_summary_metrics" {
+  value = {
+    total_cost        = data.doit_anomalies.all.anomaly_summary.total_cost_of_anomaly
+    critical_count    = data.doit_anomalies.all.anomaly_summary.count_by_severity.critical
+    warning_count     = data.doit_anomalies.all.anomaly_summary.count_by_severity.warning
+    information_count = data.doit_anomalies.all.anomaly_summary.count_by_severity.information
+  }
 }
 
 output "anomaly_summary" {

--- a/internal/provider/anomalies_data_source.go
+++ b/internal/provider/anomalies_data_source.go
@@ -83,6 +83,7 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 		data.TotalCount = types.Int64Unknown()
 		data.TotalCountExact = types.BoolUnknown()
 		data.Truncated = types.BoolUnknown()
+		data.PageToken = types.StringUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
@@ -163,6 +164,7 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 		if !data.PageToken.IsNull() {
 			params.PageToken = new(data.PageToken.ValueString())
 		}
+		firstPage := true
 		for {
 			apiResp, err := d.client.ListAnomaliesWithResponse(ctx, params)
 			if err != nil {
@@ -183,9 +185,12 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 			result := apiResp.JSON200
 			allAnomalies = append(allAnomalies, result.Anomalies...)
-			finalSummary = result.AnomalySummary
-			totalCount = result.TotalCount
-			totalCountExact = result.TotalCountExact
+			if firstPage {
+				finalSummary = result.AnomalySummary
+				totalCount = result.TotalCount
+				totalCountExact = result.TotalCountExact
+				firstPage = false
+			}
 			// In auto mode, by definition all matching pages are fetched
 			truncated = false
 

--- a/internal/provider/anomalies_data_source.go
+++ b/internal/provider/anomalies_data_source.go
@@ -75,9 +75,14 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 	ctx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	// If any filter/pagination input is unknown, return unknown list
-	if data.Filter.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() || data.IncludeNotifications.IsUnknown() {
+	// If any filter/pagination input is unknown, return unknown list and unknown computed attributes
+	if data.Filter.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() || data.IncludeNotifications.IsUnknown() || data.SortBy.IsUnknown() || data.SortOrder.IsUnknown() {
 		data.Anomalies = types.ListUnknown(datasource_anomalies.AnomaliesValue{}.Type(ctx))
+		data.AnomalySummary = datasource_anomalies.NewAnomalySummaryValueUnknown()
+		data.RowCount = types.Int64Unknown()
+		data.TotalCount = types.Int64Unknown()
+		data.TotalCountExact = types.BoolUnknown()
+		data.Truncated = types.BoolUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
@@ -87,19 +92,29 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 		params.Filter = new(data.Filter.ValueString())
 	}
 	if !data.MinCreationTime.IsNull() {
-		params.MinCreationTime = new(data.MinCreationTime.ValueString())
+		params.MinCreationTime = new(data.MinCreationTime.ValueInt64())
 	}
 	if !data.MaxCreationTime.IsNull() {
-		params.MaxCreationTime = new(data.MaxCreationTime.ValueString())
+		params.MaxCreationTime = new(data.MaxCreationTime.ValueInt64())
 	}
 	if !data.IncludeNotifications.IsNull() {
 		params.IncludeNotifications = data.IncludeNotifications.ValueBoolPointer()
+	}
+	if !data.SortBy.IsNull() {
+		params.SortBy = new(models.ListAnomaliesParamsSortBy(data.SortBy.ValueString()))
+	}
+	if !data.SortOrder.IsNull() {
+		params.SortOrder = new(models.ListAnomaliesParamsSortOrder(data.SortOrder.ValueString()))
 	}
 
 	// Smart pagination: honor user-provided values, otherwise auto-paginate
 	userControlsPagination := !data.MaxResults.IsNull()
 
 	var allAnomalies []models.AnomalyItem
+	var finalSummary models.AnomaliesResponseAnomalySummary
+	var totalCount int64
+	var totalCountExact bool
+	var truncated bool
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
@@ -126,17 +141,22 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 		}
 
 		result := apiResp.JSON200
-		if result.Anomalies != nil {
-			allAnomalies = *result.Anomalies
-		}
+		allAnomalies = result.Anomalies
+		finalSummary = result.AnomalySummary
+		totalCount = result.TotalCount
+		totalCountExact = result.TotalCountExact
+		truncated = result.Truncated
 
 		// Preserve API's page_token for user to fetch next page
-		data.PageToken = types.StringPointerValue(result.PageToken)
-		if result.RowCount != nil {
-			data.RowCount = types.Int64Value(*result.RowCount)
+		if result.PageToken != nil && *result.PageToken != "" {
+			data.PageToken = types.StringValue(*result.PageToken)
 		} else {
-			data.RowCount = types.Int64Value(int64(len(allAnomalies)))
+			data.PageToken = types.StringNull()
 		}
+		data.RowCount = types.Int64Value(result.RowCount)
+		data.TotalCount = types.Int64Value(totalCount)
+		data.TotalCountExact = types.BoolValue(totalCountExact)
+		data.Truncated = types.BoolValue(truncated)
 		// max_results is already set by user, no change needed
 	} else {
 		// Auto mode: fetch all pages, honoring user-provided page_token as starting point
@@ -162,9 +182,12 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 			}
 
 			result := apiResp.JSON200
-			if result.Anomalies != nil {
-				allAnomalies = append(allAnomalies, *result.Anomalies...)
-			}
+			allAnomalies = append(allAnomalies, result.Anomalies...)
+			finalSummary = result.AnomalySummary
+			totalCount = result.TotalCount
+			totalCountExact = result.TotalCountExact
+			// In auto mode, by definition all matching pages are fetched
+			truncated = false
 
 			if result.PageToken == nil || *result.PageToken == "" {
 				break
@@ -175,8 +198,13 @@ func (d *anomaliesDataSource) Read(ctx context.Context, req datasource.ReadReque
 		// Auto mode: set counts based on what we fetched
 		data.RowCount = types.Int64Value(int64(len(allAnomalies)))
 		data.PageToken = types.StringNull()
+		data.TotalCount = types.Int64Value(totalCount)
+		data.TotalCountExact = types.BoolValue(totalCountExact)
+		data.Truncated = types.BoolValue(truncated)
 		// max_results was not set; preserve null
 	}
+
+	data.AnomalySummary = mapAnomalySummary(ctx, finalSummary, &resp.Diagnostics)
 
 	// Map anomalies list
 	if len(allAnomalies) > 0 {
@@ -374,4 +402,28 @@ func mapAnomalyNotifications(ctx context.Context, notifications []models.Notific
 	list, diags := types.ListValueFrom(ctx, datasource_anomalies.NotificationsValue{}.Type(ctx), vals)
 	diagnostics.Append(diags...)
 	return list
+}
+
+// mapAnomalySummary maps API AnomaliesResponseAnomalySummary to Terraform AnomalySummaryValue.
+func mapAnomalySummary(ctx context.Context, summary models.AnomaliesResponseAnomalySummary, diagnostics *diag.Diagnostics) datasource_anomalies.AnomalySummaryValue {
+	countBySeverityVal, diags := datasource_anomalies.NewCountBySeverityValue(
+		datasource_anomalies.CountBySeverityValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"critical":    types.Int64Value(summary.CountBySeverity.Critical),
+			"information": types.Int64Value(summary.CountBySeverity.Information),
+			"warning":     types.Int64Value(summary.CountBySeverity.Warning),
+		},
+	)
+	diagnostics.Append(diags...)
+
+	summaryVal, diags := datasource_anomalies.NewAnomalySummaryValue(
+		datasource_anomalies.AnomalySummaryValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"count_by_severity":     countBySeverityVal,
+			"total_cost_of_anomaly": types.Float64Value(summary.TotalCostOfAnomaly),
+		},
+	)
+	diagnostics.Append(diags...)
+
+	return summaryVal
 }

--- a/internal/provider/anomalies_data_source_internal_test.go
+++ b/internal/provider/anomalies_data_source_internal_test.go
@@ -1,0 +1,271 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/doitintl/terraform-provider-doit/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// readAnomaliesHelper builds an anomaliesDataSource backed by a client pointed at
+// serverURL, invokes Read with the given config overrides, and returns the resulting state and diagnostics.
+func readAnomaliesHelper(t *testing.T, serverURL string, overrides map[string]tftypes.Value) (anomaliesDataSourceModel, tfsdk.State) {
+	t.Helper()
+
+	client, err := models.NewClientWithResponses(serverURL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	ds := &anomaliesDataSource{client: client}
+	ctx := context.Background()
+
+	schemaResp := &datasource.SchemaResponse{}
+	ds.Schema(ctx, datasource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("failed to get schema: %v", schemaResp.Diagnostics)
+	}
+
+	configValues := map[string]tftypes.Value{}
+	attrTypes := map[string]tftypes.Type{}
+	for name, attr := range schemaResp.Schema.Attributes {
+		tfType := attr.GetType().TerraformType(ctx)
+		attrTypes[name] = tfType
+		if override, ok := overrides[name]; ok {
+			configValues[name] = override
+			continue
+		}
+		configValues[name] = tftypes.NewValue(tfType, nil)
+	}
+
+	configVal := tftypes.NewValue(tftypes.Object{AttributeTypes: attrTypes}, configValues)
+	config := tfsdk.Config{
+		Schema: schemaResp.Schema,
+		Raw:    configVal,
+	}
+
+	readResp := &datasource.ReadResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+	ds.Read(ctx, datasource.ReadRequest{Config: config}, readResp)
+
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("Read() returned diagnostics: %v", readResp.Diagnostics)
+	}
+
+	var data anomaliesDataSourceModel
+	if diags := readResp.State.Get(ctx, &data); diags.HasError() {
+		t.Fatalf("failed to read state: %v", diags)
+	}
+
+	return data, readResp.State
+}
+
+func TestAnomaliesDataSource_UnknownInputs(t *testing.T) {
+	t.Parallel()
+
+	unknownCases := []struct {
+		name      string
+		overrides map[string]tftypes.Value
+	}{
+		{
+			name: "unknown filter",
+			overrides: map[string]tftypes.Value{
+				"filter": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			},
+		},
+		{
+			name: "unknown min_creation_time",
+			overrides: map[string]tftypes.Value{
+				"min_creation_time": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+		{
+			name: "unknown max_creation_time",
+			overrides: map[string]tftypes.Value{
+				"max_creation_time": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+		{
+			name: "unknown sort_by",
+			overrides: map[string]tftypes.Value{
+				"sort_by": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			},
+		},
+		{
+			name: "unknown sort_order",
+			overrides: map[string]tftypes.Value{
+				"sort_order": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			},
+		},
+		{
+			name: "unknown max_results",
+			overrides: map[string]tftypes.Value{
+				"max_results": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+		{
+			name: "unknown page_token",
+			overrides: map[string]tftypes.Value{
+				"page_token": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			},
+		},
+		{
+			name: "unknown include_notifications",
+			overrides: map[string]tftypes.Value{
+				"include_notifications": tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+			},
+		},
+	}
+
+	for _, tc := range unknownCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			data, _ := readAnomaliesHelper(t, server.URL, tc.overrides)
+
+			if reqs := requestCount.Load(); reqs != 0 {
+				t.Errorf("expected 0 API requests when inputs are unknown, got %d", reqs)
+			}
+
+			if !data.Anomalies.IsUnknown() {
+				t.Errorf("expected Anomalies to be unknown, got %v", data.Anomalies)
+			}
+			if !data.AnomalySummary.IsUnknown() {
+				t.Errorf("expected AnomalySummary to be unknown, got %v", data.AnomalySummary)
+			}
+			if !data.RowCount.IsUnknown() {
+				t.Errorf("expected RowCount to be unknown, got %v", data.RowCount)
+			}
+			if !data.TotalCount.IsUnknown() {
+				t.Errorf("expected TotalCount to be unknown, got %v", data.TotalCount)
+			}
+			if !data.TotalCountExact.IsUnknown() {
+				t.Errorf("expected TotalCountExact to be unknown, got %v", data.TotalCountExact)
+			}
+			if !data.Truncated.IsUnknown() {
+				t.Errorf("expected Truncated to be unknown, got %v", data.Truncated)
+			}
+			if !data.PageToken.IsUnknown() {
+				t.Errorf("expected PageToken to be unknown, got %v", data.PageToken)
+			}
+		})
+	}
+}
+
+func TestAnomaliesDataSource_AutoPaginationMetadataFromFirstPage(t *testing.T) {
+	t.Parallel()
+
+	var pageRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqNum := pageRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if reqNum == 1 {
+			// Page 1: contains initial snapshot metadata
+			_, _ = fmt.Fprint(w, `{
+				"anomalies": [
+					{
+						"id": "anomaly-1",
+						"serviceName": "AmazonEC2",
+						"costOfAnomaly": 10.5,
+						"startTime": 1704067200000,
+						"severityLevel": "critical"
+					}
+				],
+				"pageToken": "page-2-token",
+				"rowCount": 1,
+				"totalCount": 2,
+				"totalCountExact": true,
+				"truncated": false,
+				"anomalySummary": {
+					"countBySeverity": {
+						"critical": 1,
+						"warning": 0,
+						"information": 0
+					},
+					"totalCostOfAnomaly": 10.5
+				}
+			}`)
+			return
+		}
+
+		// Page 2: backend returns shifted snapshot due to concurrent write
+		_, _ = fmt.Fprint(w, `{
+			"anomalies": [
+				{
+					"id": "anomaly-2",
+					"serviceName": "CloudStorage",
+					"costOfAnomaly": 20.0,
+					"startTime": 1704070800000,
+					"severityLevel": "warning"
+				}
+			],
+			"pageToken": null,
+			"rowCount": 1,
+			"totalCount": 999,
+			"totalCountExact": true,
+			"truncated": false,
+			"anomalySummary": {
+				"countBySeverity": {
+					"critical": 50,
+					"warning": 50,
+					"information": 0
+				},
+				"totalCostOfAnomaly": 9999.99
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	// Zero overrides = auto-pagination mode
+	data, _ := readAnomaliesHelper(t, server.URL, map[string]tftypes.Value{})
+
+	if reqs := pageRequests.Load(); reqs != 2 {
+		t.Fatalf("expected 2 API requests in auto-pagination mode, got %d", reqs)
+	}
+
+	// Collected anomalies from both pages
+	if got := len(data.Anomalies.Elements()); got != 2 {
+		t.Errorf("anomalies count = %d, want 2", got)
+	}
+	if got := data.RowCount.ValueInt64(); got != 2 {
+		t.Errorf("row_count = %d, want 2 (accumulated)", got)
+	}
+	if !data.PageToken.IsNull() {
+		t.Errorf("page_token in auto mode should be null, got %v", data.PageToken)
+	}
+	if got := data.Truncated.ValueBool(); got != false {
+		t.Errorf("truncated in auto mode should be false, got %v", got)
+	}
+
+	// Metadata MUST be captured from Page 1 (initial query snapshot), NOT Page 2
+	if got := data.TotalCount.ValueInt64(); got != 2 {
+		t.Errorf("total_count = %d, want 2 (from page 1 snapshot)", got)
+	}
+
+	summaryVal, diags := data.AnomalySummary.ToObjectValue(context.Background())
+	if diags.HasError() {
+		t.Fatalf("failed to convert summary to object: %v", diags)
+	}
+	totalCostVal := summaryVal.Attributes()["total_cost_of_anomaly"].(types.Float64)
+	if got := totalCostVal.ValueFloat64(); got != 10.5 {
+		t.Errorf("total_cost_of_anomaly = %f, want 10.5 (from page 1 snapshot)", got)
+	}
+}

--- a/internal/provider/anomalies_data_source_internal_test.go
+++ b/internal/provider/anomalies_data_source_internal_test.go
@@ -269,3 +269,46 @@ func TestAnomaliesDataSource_AutoPaginationMetadataFromFirstPage(t *testing.T) {
 		t.Errorf("total_cost_of_anomaly = %f, want 10.5 (from page 1 snapshot)", got)
 	}
 }
+
+func TestAnomaliesDataSource_EmptyAnomaliesList(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{
+			"anomalies": [],
+			"rowCount": 0,
+			"totalCount": 0,
+			"totalCountExact": true,
+			"truncated": false,
+			"anomalySummary": {
+				"countBySeverity": {
+					"critical": 0,
+					"warning": 0,
+					"information": 0
+				},
+				"totalCostOfAnomaly": 0.0
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	data, _ := readAnomaliesHelper(t, server.URL, map[string]tftypes.Value{})
+
+	if data.Anomalies.IsNull() {
+		t.Errorf("expected Anomalies to not be null")
+	}
+	if data.Anomalies.IsUnknown() {
+		t.Errorf("expected Anomalies to not be unknown")
+	}
+	if got := len(data.Anomalies.Elements()); got != 0 {
+		t.Errorf("expected 0 anomalies in list, got %d", got)
+	}
+	if got := data.RowCount.ValueInt64(); got != 0 {
+		t.Errorf("expected row_count to be 0, got %d", got)
+	}
+	if got := data.TotalCount.ValueInt64(); got != 0 {
+		t.Errorf("expected total_count to be 0, got %d", got)
+	}
+}

--- a/internal/provider/anomalies_data_source_test.go
+++ b/internal/provider/anomalies_data_source_test.go
@@ -30,6 +30,13 @@ func TestAccAnomaliesDataSource_MaxResultsOnly(t *testing.T) {
 					resource.TestCheckResourceAttr("data.doit_anomalies.limited", "anomalies.#", "1"),
 					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "page_token"),
 					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "anomalies.0.notifications.#"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "total_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.limited", "total_count_exact", "true"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.limited", "truncated", "true"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "anomaly_summary.count_by_severity.critical"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "anomaly_summary.count_by_severity.warning"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "anomaly_summary.count_by_severity.information"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.limited", "anomaly_summary.total_cost_of_anomaly"),
 				),
 			},
 			{
@@ -144,6 +151,13 @@ func TestAccAnomaliesDataSource_AutoPagination(t *testing.T) {
 					// Don't check specific values since parallel tests may change the count
 					resource.TestCheckResourceAttrSet("data.doit_anomalies.test", "row_count"),
 					resource.TestCheckNoResourceAttr("data.doit_anomalies.test", "page_token"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.test", "total_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.test", "total_count_exact", "true"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.test", "truncated", "false"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.test", "anomaly_summary.count_by_severity.critical"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.test", "anomaly_summary.count_by_severity.warning"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.test", "anomaly_summary.count_by_severity.information"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.test", "anomaly_summary.total_cost_of_anomaly"),
 				),
 			},
 		},
@@ -424,6 +438,204 @@ output "anomaly_expected_max_cost" {
 `
 }
 
+// TestAccAnomaliesDataSource_SortByAndSortOrder verifies that the sort_by and
+// sort_order parameters work without drift across different sort configurations.
+func TestAccAnomaliesDataSource_SortByAndSortOrder(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomaliesDataSourceSortConfig("startTime", "desc"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.sorted", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.sorted", "sort_by", "startTime"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.sorted", "sort_order", "desc"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceSortConfig("startTime", "desc"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccAnomaliesDataSourceSortConfig("costOfAnomaly", "asc"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.sorted", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.sorted", "sort_by", "costOfAnomaly"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.sorted", "sort_order", "asc"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceSortConfig("costOfAnomaly", "asc"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAnomaliesDataSourceSortConfig(sortBy, sortOrder string) string {
+	return fmt.Sprintf(`
+data "doit_anomalies" "sorted" {
+  max_results = 1
+  sort_by     = %[1]q
+  sort_order  = %[2]q
+}
+`, sortBy, sortOrder)
+}
+
+// TestAccAnomaliesDataSource_MinMaxCreationTime verifies that min_creation_time
+// and max_creation_time integer filters work without drift.
+func TestAccAnomaliesDataSource_MinMaxCreationTime(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomaliesDataSourceMinMaxTimeConfig(0, 4102444800000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.timed", "row_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.timed", "min_creation_time", "0"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.timed", "max_creation_time", "4102444800000"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceMinMaxTimeConfig(0, 4102444800000),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAnomaliesDataSourceMinMaxTimeConfig(minTime, maxTime int64) string {
+	return fmt.Sprintf(`
+data "doit_anomalies" "timed" {
+  max_results       = 1
+  min_creation_time = %d
+  max_creation_time = %d
+}
+`, minTime, maxTime)
+}
+
+// TestAccAnomaliesDataSource_AnomalySummary verifies that the anomaly_summary
+// nested object (count_by_severity and total_cost_of_anomaly) is accessible.
+func TestAccAnomaliesDataSource_AnomalySummary(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomaliesDataSourceSummaryConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.summary_test", "anomaly_summary.count_by_severity.critical"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.summary_test", "anomaly_summary.count_by_severity.warning"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.summary_test", "anomaly_summary.count_by_severity.information"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.summary_test", "anomaly_summary.total_cost_of_anomaly"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceSummaryConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAnomaliesDataSourceSummaryConfig() string {
+	return `
+data "doit_anomalies" "summary_test" {
+  max_results = 1
+}
+
+output "critical_count" {
+  value = data.doit_anomalies.summary_test.anomaly_summary.count_by_severity.critical
+}
+
+output "warning_count" {
+  value = data.doit_anomalies.summary_test.anomaly_summary.count_by_severity.warning
+}
+
+output "info_count" {
+  value = data.doit_anomalies.summary_test.anomaly_summary.count_by_severity.information
+}
+
+output "total_cost" {
+  value = data.doit_anomalies.summary_test.anomaly_summary.total_cost_of_anomaly
+}
+`
+}
+
+// TestAccAnomaliesDataSource_TotalCountAndTruncated verifies that total_count,
+// total_count_exact, and truncated attributes are mapped correctly.
+func TestAccAnomaliesDataSource_TotalCountAndTruncated(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnomaliesDataSourceTotalCountConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.total_count_test", "total_count"),
+					resource.TestCheckResourceAttr("data.doit_anomalies.total_count_test", "total_count_exact", "true"),
+					resource.TestCheckResourceAttrSet("data.doit_anomalies.total_count_test", "truncated"),
+				),
+			},
+			// Drift verification
+			{
+				Config: testAccAnomaliesDataSourceTotalCountConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccAnomaliesDataSourceTotalCountConfig() string {
+	return `
+data "doit_anomalies" "total_count_test" {
+  max_results = 1
+}
+
+output "total_count" {
+  value = data.doit_anomalies.total_count_test.total_count
+}
+
+output "total_count_exact" {
+  value = data.doit_anomalies.total_count_test.total_count_exact
+}
+
+output "truncated" {
+  value = data.doit_anomalies.total_count_test.truncated
+}
+`
+}
+
 // Helper functions
 
 var (
@@ -452,10 +664,10 @@ func computeAnomalyCount(t *testing.T) int {
 		if err != nil {
 			t.Fatalf("Failed to list anomalies: %v", err)
 		}
-		if resp.JSON200 == nil || resp.JSON200.Anomalies == nil {
+		if resp.JSON200 == nil {
 			break
 		}
-		total += len(*resp.JSON200.Anomalies)
+		total += len(resp.JSON200.Anomalies)
 
 		if resp.JSON200.PageToken == nil || *resp.JSON200.PageToken == "" {
 			break

--- a/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
+++ b/internal/provider/datasource_anomalies/anomalies_data_source_gen.go
@@ -5,8 +5,10 @@ package datasource_anomalies
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -172,8 +174,8 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 						},
 						"severity_level": schema.StringAttribute{
 							Computed:            true,
-							Description:         "Severity level: Information, Warning or Critical",
-							MarkdownDescription: "Severity level: Information, Warning or Critical",
+							Description:         "Severity level: `information`, `warning`, or `critical`.",
+							MarkdownDescription: "Severity level: `information`, `warning`, or `critical`.",
 						},
 						"start_time": schema.Int64Attribute{
 							Computed:            true,
@@ -215,13 +217,53 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 						},
 					},
 				},
-				Computed: true,
+				Computed:            true,
+				Description:         "Anomalies in this page. Always an array; empty (`[]`) when there are no matching anomalies.",
+				MarkdownDescription: "Anomalies in this page. Always an array; empty (`[]`) when there are no matching anomalies.",
+			},
+			"anomaly_summary": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"count_by_severity": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"critical": schema.Int64Attribute{
+								Computed: true,
+							},
+							"information": schema.Int64Attribute{
+								Computed: true,
+							},
+							"warning": schema.Int64Attribute{
+								Computed: true,
+							},
+						},
+						CustomType: CountBySeverityType{
+							ObjectType: types.ObjectType{
+								AttrTypes: CountBySeverityValue{}.AttributeTypes(ctx),
+							},
+						},
+						Computed:            true,
+						Description:         "Count of matching anomalies per severity level. All three keys are always present, with zero counts included.",
+						MarkdownDescription: "Count of matching anomalies per severity level. All three keys are always present, with zero counts included.",
+					},
+					"total_cost_of_anomaly": schema.Float64Attribute{
+						Computed:            true,
+						Description:         "Sum of `costOfAnomaly` across all matching anomalies, in USD, rounded to cents.",
+						MarkdownDescription: "Sum of `costOfAnomaly` across all matching anomalies, in USD, rounded to cents.",
+					},
+				},
+				CustomType: AnomalySummaryType{
+					ObjectType: types.ObjectType{
+						AttrTypes: AnomalySummaryValue{}.AttributeTypes(ctx),
+					},
+				},
+				Computed:            true,
+				Description:         "Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence.",
+				MarkdownDescription: "Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence.",
 			},
 			"filter": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "An expression for filtering the results of the request",
-				MarkdownDescription: "An expression for filtering the results of the request",
+				Description:         "An expression for filtering the results. The syntax is `key:value`. Multiple criteria can be combined using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nAvailable filter keys: **serviceName**, **billingAccount**, **platform**, **severityLevel**. `severityLevel` values must be lowercase: `information`, `warning`, `critical`. An unrecognised key, or a segment that is not `key:value`, is rejected with `400` rather than ignored.",
+				MarkdownDescription: "An expression for filtering the results. The syntax is `key:value`. Multiple criteria can be combined using a pipe |. See [Filters](https://developer.doit.com/docs/filters).\nAvailable filter keys: **serviceName**, **billingAccount**, **platform**, **severityLevel**. `severityLevel` values must be lowercase: `information`, `warning`, `critical`. An unrecognised key, or a segment that is not `key:value`, is rejected with `400` rather than ignored.",
 			},
 			"include_notifications": schema.BoolAttribute{
 				Optional:            true,
@@ -229,23 +271,23 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Include anomaly notifications from the subcollection. Defaults to false.",
 				MarkdownDescription: "Include anomaly notifications from the subcollection. Defaults to false.",
 			},
-			"max_creation_time": schema.StringAttribute{
+			"max_creation_time": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Max value for the anomaly detection time",
-				MarkdownDescription: "Max value for the anomaly detection time",
+				Description:         "Inclusive upper bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.",
+				MarkdownDescription: "Inclusive upper bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.",
 			},
 			"max_results": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The maximum number of results to return in a single page",
-				MarkdownDescription: "The maximum number of results to return in a single page",
+				Description:         "The maximum number of results to return in a single page. If omitted, all anomalies matching the filters and time window are returned in a single page.",
+				MarkdownDescription: "The maximum number of results to return in a single page. If omitted, all anomalies matching the filters and time window are returned in a single page.",
 			},
-			"min_creation_time": schema.StringAttribute{
+			"min_creation_time": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Min value for the anomaly detection time",
-				MarkdownDescription: "Min value for the anomaly detection time",
+				Description:         "Inclusive lower bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.",
+				MarkdownDescription: "Inclusive lower bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.",
 			},
 			"page_token": schema.StringAttribute{
 				Optional:            true,
@@ -254,7 +296,49 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Page token, returned by a previous call, to request the next page of results",
 			},
 			"row_count": schema.Int64Attribute{
-				Computed: true,
+				Computed:            true,
+				Description:         "Number of items in this page (`anomalies.length`). This is not the total count across all pages; the total across the full filtered result set is `totalCount`.",
+				MarkdownDescription: "Number of items in this page (`anomalies.length`). This is not the total count across all pages; the total across the full filtered result set is `totalCount`.",
+			},
+			"sort_by": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "A field by which the results will be sorted. Defaults to `startTime`.\nPossible values: `startTime`, `severityLevel`, `costOfAnomaly`",
+				MarkdownDescription: "A field by which the results will be sorted. Defaults to `startTime`.\nPossible values: `startTime`, `severityLevel`, `costOfAnomaly`",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"startTime",
+						"severityLevel",
+						"costOfAnomaly",
+					),
+				},
+			},
+			"sort_order": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Sort order can be ascending or descending.\nPossible values: `asc`, `desc`",
+				MarkdownDescription: "Sort order can be ascending or descending.\nPossible values: `asc`, `desc`",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"asc",
+						"desc",
+					),
+				},
+			},
+			"total_count": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Total number of anomalies matching the filters and time window, across all pages. This is a per-request snapshot: under concurrent writes, the value can differ between pages fetched during the same pagination sequence.",
+				MarkdownDescription: "Total number of anomalies matching the filters and time window, across all pages. This is a per-request snapshot: under concurrent writes, the value can differ between pages fetched during the same pagination sequence.",
+			},
+			"total_count_exact": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "Whether `totalCount` is exact. Always `true` for this operation, because `totalCount` is computed over the fully materialised filtered result set.",
+				MarkdownDescription: "Whether `totalCount` is exact. Always `true` for this operation, because `totalCount` is computed over the fully materialised filtered result set.",
+			},
+			"truncated": schema.BoolAttribute{
+				Computed:            true,
+				Description:         "`true` when filtered anomalies remain beyond this page. Derived from the same \"rows remain after the last returned row\" check as `pageToken`, so the two are never contradictory: `pageToken` is present if and only if `truncated` is `true`.",
+				MarkdownDescription: "`true` when filtered anomalies remain beyond this page. Derived from the same \"rows remain after the last returned row\" check as `pageToken`, so the two are never contradictory: `pageToken` is present if and only if `truncated` is `true`.",
 			},
 		},
 		Description:         "Monitor cost spikes in your cloud environment.",
@@ -263,14 +347,20 @@ func AnomaliesDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type AnomaliesModel struct {
-	Anomalies            types.List   `tfsdk:"anomalies"`
-	Filter               types.String `tfsdk:"filter"`
-	IncludeNotifications types.Bool   `tfsdk:"include_notifications"`
-	MaxCreationTime      types.String `tfsdk:"max_creation_time"`
-	MaxResults           types.Int64  `tfsdk:"max_results"`
-	MinCreationTime      types.String `tfsdk:"min_creation_time"`
-	PageToken            types.String `tfsdk:"page_token"`
-	RowCount             types.Int64  `tfsdk:"row_count"`
+	Anomalies            types.List          `tfsdk:"anomalies"`
+	AnomalySummary       AnomalySummaryValue `tfsdk:"anomaly_summary"`
+	Filter               types.String        `tfsdk:"filter"`
+	IncludeNotifications types.Bool          `tfsdk:"include_notifications"`
+	MaxCreationTime      types.Int64         `tfsdk:"max_creation_time"`
+	MaxResults           types.Int64         `tfsdk:"max_results"`
+	MinCreationTime      types.Int64         `tfsdk:"min_creation_time"`
+	PageToken            types.String        `tfsdk:"page_token"`
+	RowCount             types.Int64         `tfsdk:"row_count"`
+	SortBy               types.String        `tfsdk:"sort_by"`
+	SortOrder            types.String        `tfsdk:"sort_order"`
+	TotalCount           types.Int64         `tfsdk:"total_count"`
+	TotalCountExact      types.Bool          `tfsdk:"total_count_exact"`
+	Truncated            types.Bool          `tfsdk:"truncated"`
 }
 
 var _ basetypes.ObjectTypable = AnomaliesType{}
@@ -3518,5 +3608,878 @@ func (v Top3skusValue) AttributeTypes(ctx context.Context) map[string]attr.Type 
 	return map[string]attr.Type{
 		"cost": basetypes.Float64Type{},
 		"name": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = AnomalySummaryType{}
+
+type AnomalySummaryType struct {
+	basetypes.ObjectType
+}
+
+func (t AnomalySummaryType) Equal(o attr.Type) bool {
+	other, ok := o.(AnomalySummaryType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t AnomalySummaryType) String() string {
+	return "AnomalySummaryType"
+}
+
+func (t AnomalySummaryType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewAnomalySummaryValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewAnomalySummaryValueUnknown(), diags
+	}
+
+	attributes := in.Attributes()
+
+	countBySeverityAttribute, ok := attributes["count_by_severity"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`count_by_severity is missing from object`)
+
+		return nil, diags
+	}
+
+	countBySeverityValuable, ok := countBySeverityAttribute.(basetypes.ObjectValuable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`count_by_severity expected to be basetypes.ObjectValuable, was: %T`, countBySeverityAttribute))
+
+		return nil, diags
+	}
+
+	countBySeverityObjVal, countBySeverityObjValDiags := countBySeverityValuable.ToObjectValue(ctx)
+	diags.Append(countBySeverityObjValDiags...)
+
+	countBySeverityTypable, ok := t.AttrTypes["count_by_severity"].(basetypes.ObjectTypable)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`count_by_severity expected type to be basetypes.ObjectTypable, was: %T`, t.AttrTypes["count_by_severity"]))
+
+		return nil, diags
+	}
+
+	countBySeverityConverted, countBySeverityConvertedDiags := countBySeverityTypable.ValueFromObject(ctx, countBySeverityObjVal)
+	diags.Append(countBySeverityConvertedDiags...)
+
+	countBySeverityVal, ok := countBySeverityConverted.(CountBySeverityValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`count_by_severity expected to be CountBySeverityValue, was: %T`, countBySeverityConverted))
+	}
+
+	totalCostOfAnomalyAttribute, ok := attributes["total_cost_of_anomaly"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`total_cost_of_anomaly is missing from object`)
+
+		return nil, diags
+	}
+
+	totalCostOfAnomalyVal, ok := totalCostOfAnomalyAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`total_cost_of_anomaly expected to be basetypes.Float64Value, was: %T`, totalCostOfAnomalyAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return AnomalySummaryValue{
+		CountBySeverity:    countBySeverityVal,
+		TotalCostOfAnomaly: totalCostOfAnomalyVal,
+		state:              attr.ValueStateKnown,
+	}, diags
+}
+
+func NewAnomalySummaryValueNull() AnomalySummaryValue {
+	return AnomalySummaryValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewAnomalySummaryValueUnknown() AnomalySummaryValue {
+	return AnomalySummaryValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewAnomalySummaryValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (AnomalySummaryValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing AnomalySummaryValue Attribute Value",
+				"While creating a AnomalySummaryValue value, a missing attribute value was detected. "+
+					"A AnomalySummaryValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("AnomalySummaryValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid AnomalySummaryValue Attribute Type",
+				"While creating a AnomalySummaryValue value, an invalid attribute value was detected. "+
+					"A AnomalySummaryValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("AnomalySummaryValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("AnomalySummaryValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra AnomalySummaryValue Attribute Value",
+				"While creating a AnomalySummaryValue value, an extra attribute value was detected. "+
+					"A AnomalySummaryValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra AnomalySummaryValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewAnomalySummaryValueUnknown(), diags
+	}
+
+	countBySeverityAttribute, ok := attributes["count_by_severity"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`count_by_severity is missing from object`)
+
+		return NewAnomalySummaryValueUnknown(), diags
+	}
+
+	countBySeverityVal, ok := countBySeverityAttribute.(CountBySeverityValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`count_by_severity expected to be CountBySeverityValue, was: %T`, countBySeverityAttribute))
+	}
+
+	totalCostOfAnomalyAttribute, ok := attributes["total_cost_of_anomaly"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`total_cost_of_anomaly is missing from object`)
+
+		return NewAnomalySummaryValueUnknown(), diags
+	}
+
+	totalCostOfAnomalyVal, ok := totalCostOfAnomalyAttribute.(basetypes.Float64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`total_cost_of_anomaly expected to be basetypes.Float64Value, was: %T`, totalCostOfAnomalyAttribute))
+	}
+
+	if diags.HasError() {
+		return NewAnomalySummaryValueUnknown(), diags
+	}
+
+	return AnomalySummaryValue{
+		CountBySeverity:    countBySeverityVal,
+		TotalCostOfAnomaly: totalCostOfAnomalyVal,
+		state:              attr.ValueStateKnown,
+	}, diags
+}
+
+func NewAnomalySummaryValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) AnomalySummaryValue {
+	object, diags := NewAnomalySummaryValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewAnomalySummaryValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t AnomalySummaryType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewAnomalySummaryValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewAnomalySummaryValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewAnomalySummaryValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewAnomalySummaryValueMust(AnomalySummaryValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t AnomalySummaryType) ValueType(ctx context.Context) attr.Value {
+	return AnomalySummaryValue{}
+}
+
+var _ basetypes.ObjectValuable = AnomalySummaryValue{}
+
+type AnomalySummaryValue struct {
+	CountBySeverity    CountBySeverityValue   `tfsdk:"count_by_severity"`
+	TotalCostOfAnomaly basetypes.Float64Value `tfsdk:"total_cost_of_anomaly"`
+	state              attr.ValueState
+}
+
+func (v AnomalySummaryValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["count_by_severity"] = CountBySeverityType{
+		basetypes.ObjectType{
+			AttrTypes: CountBySeverityValue{}.AttributeTypes(ctx),
+		},
+	}.TerraformType(ctx)
+	attrTypes["total_cost_of_anomaly"] = basetypes.Float64Type{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.CountBySeverity.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["count_by_severity"] = val
+
+		val, err = v.TotalCostOfAnomaly.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["total_cost_of_anomaly"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v AnomalySummaryValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v AnomalySummaryValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v AnomalySummaryValue) String() string {
+	return "AnomalySummaryValue"
+}
+
+func (v AnomalySummaryValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var countBySeverity attr.Value
+
+	{
+		countBySeverity = v.CountBySeverity
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"count_by_severity": CountBySeverityType{
+			basetypes.ObjectType{
+				AttrTypes: CountBySeverityValue{}.AttributeTypes(ctx),
+			},
+		},
+		"total_cost_of_anomaly": basetypes.Float64Type{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"count_by_severity":     countBySeverity,
+			"total_cost_of_anomaly": v.TotalCostOfAnomaly,
+		})
+
+	return objVal, diags
+}
+
+func (v AnomalySummaryValue) Equal(o attr.Value) bool {
+	other, ok := o.(AnomalySummaryValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.CountBySeverity.Equal(other.CountBySeverity) {
+		return false
+	}
+
+	if !v.TotalCostOfAnomaly.Equal(other.TotalCostOfAnomaly) {
+		return false
+	}
+
+	return true
+}
+
+func (v AnomalySummaryValue) Type(ctx context.Context) attr.Type {
+	return AnomalySummaryType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v AnomalySummaryValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"count_by_severity": CountBySeverityType{
+			basetypes.ObjectType{
+				AttrTypes: CountBySeverityValue{}.AttributeTypes(ctx),
+			},
+		},
+		"total_cost_of_anomaly": basetypes.Float64Type{},
+	}
+}
+
+var _ basetypes.ObjectTypable = CountBySeverityType{}
+
+type CountBySeverityType struct {
+	basetypes.ObjectType
+}
+
+func (t CountBySeverityType) Equal(o attr.Type) bool {
+	other, ok := o.(CountBySeverityType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CountBySeverityType) String() string {
+	return "CountBySeverityType"
+}
+
+func (t CountBySeverityType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewCountBySeverityValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewCountBySeverityValueUnknown(), diags
+	}
+
+	attributes := in.Attributes()
+
+	criticalAttribute, ok := attributes["critical"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`critical is missing from object`)
+
+		return nil, diags
+	}
+
+	criticalVal, ok := criticalAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`critical expected to be basetypes.Int64Value, was: %T`, criticalAttribute))
+	}
+
+	informationAttribute, ok := attributes["information"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`information is missing from object`)
+
+		return nil, diags
+	}
+
+	informationVal, ok := informationAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`information expected to be basetypes.Int64Value, was: %T`, informationAttribute))
+	}
+
+	warningAttribute, ok := attributes["warning"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`warning is missing from object`)
+
+		return nil, diags
+	}
+
+	warningVal, ok := warningAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`warning expected to be basetypes.Int64Value, was: %T`, warningAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CountBySeverityValue{
+		Critical:    criticalVal,
+		Information: informationVal,
+		Warning:     warningVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCountBySeverityValueNull() CountBySeverityValue {
+	return CountBySeverityValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCountBySeverityValueUnknown() CountBySeverityValue {
+	return CountBySeverityValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCountBySeverityValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CountBySeverityValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CountBySeverityValue Attribute Value",
+				"While creating a CountBySeverityValue value, a missing attribute value was detected. "+
+					"A CountBySeverityValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CountBySeverityValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CountBySeverityValue Attribute Type",
+				"While creating a CountBySeverityValue value, an invalid attribute value was detected. "+
+					"A CountBySeverityValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CountBySeverityValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CountBySeverityValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CountBySeverityValue Attribute Value",
+				"While creating a CountBySeverityValue value, an extra attribute value was detected. "+
+					"A CountBySeverityValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CountBySeverityValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCountBySeverityValueUnknown(), diags
+	}
+
+	criticalAttribute, ok := attributes["critical"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`critical is missing from object`)
+
+		return NewCountBySeverityValueUnknown(), diags
+	}
+
+	criticalVal, ok := criticalAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`critical expected to be basetypes.Int64Value, was: %T`, criticalAttribute))
+	}
+
+	informationAttribute, ok := attributes["information"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`information is missing from object`)
+
+		return NewCountBySeverityValueUnknown(), diags
+	}
+
+	informationVal, ok := informationAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`information expected to be basetypes.Int64Value, was: %T`, informationAttribute))
+	}
+
+	warningAttribute, ok := attributes["warning"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`warning is missing from object`)
+
+		return NewCountBySeverityValueUnknown(), diags
+	}
+
+	warningVal, ok := warningAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`warning expected to be basetypes.Int64Value, was: %T`, warningAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCountBySeverityValueUnknown(), diags
+	}
+
+	return CountBySeverityValue{
+		Critical:    criticalVal,
+		Information: informationVal,
+		Warning:     warningVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCountBySeverityValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CountBySeverityValue {
+	object, diags := NewCountBySeverityValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCountBySeverityValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CountBySeverityType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCountBySeverityValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCountBySeverityValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCountBySeverityValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCountBySeverityValueMust(CountBySeverityValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CountBySeverityType) ValueType(ctx context.Context) attr.Value {
+	return CountBySeverityValue{}
+}
+
+var _ basetypes.ObjectValuable = CountBySeverityValue{}
+
+type CountBySeverityValue struct {
+	Critical    basetypes.Int64Value `tfsdk:"critical"`
+	Information basetypes.Int64Value `tfsdk:"information"`
+	Warning     basetypes.Int64Value `tfsdk:"warning"`
+	state       attr.ValueState
+}
+
+func (v CountBySeverityValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["critical"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["information"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["warning"] = basetypes.Int64Type{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Critical.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["critical"] = val
+
+		val, err = v.Information.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["information"] = val
+
+		val, err = v.Warning.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["warning"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CountBySeverityValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CountBySeverityValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CountBySeverityValue) String() string {
+	return "CountBySeverityValue"
+}
+
+func (v CountBySeverityValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"critical":    basetypes.Int64Type{},
+		"information": basetypes.Int64Type{},
+		"warning":     basetypes.Int64Type{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"critical":    v.Critical,
+			"information": v.Information,
+			"warning":     v.Warning,
+		})
+
+	return objVal, diags
+}
+
+func (v CountBySeverityValue) Equal(o attr.Value) bool {
+	other, ok := o.(CountBySeverityValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Critical.Equal(other.Critical) {
+		return false
+	}
+
+	if !v.Information.Equal(other.Information) {
+		return false
+	}
+
+	if !v.Warning.Equal(other.Warning) {
+		return false
+	}
+
+	return true
+}
+
+func (v CountBySeverityValue) Type(ctx context.Context) attr.Type {
+	return CountBySeverityType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CountBySeverityValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"critical":    basetypes.Int64Type{},
+		"information": basetypes.Int64Type{},
+		"warning":     basetypes.Int64Type{},
 	}
 }

--- a/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
+++ b/internal/provider/datasource_anomaly/anomaly_data_source_gen.go
@@ -171,8 +171,8 @@ func AnomalyDataSourceSchema(ctx context.Context) schema.Schema {
 			},
 			"severity_level": schema.StringAttribute{
 				Computed:            true,
-				Description:         "Severity level: Information, Warning or Critical",
-				MarkdownDescription: "Severity level: Information, Warning or Critical",
+				Description:         "Severity level: `information`, `warning`, or `critical`.",
+				MarkdownDescription: "Severity level: `information`, `warning`, or `critical`.",
 			},
 			"start_time": schema.Int64Attribute{
 				Computed:            true,

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -3607,6 +3607,45 @@ func (e ListLabelsParamsSortOrder) Valid() bool {
 	}
 }
 
+// Defines values for ListAnomaliesParamsSortBy.
+const (
+	CostOfAnomaly ListAnomaliesParamsSortBy = "costOfAnomaly"
+	SeverityLevel ListAnomaliesParamsSortBy = "severityLevel"
+	StartTime     ListAnomaliesParamsSortBy = "startTime"
+)
+
+// Valid indicates whether the value is a known member of the ListAnomaliesParamsSortBy enum.
+func (e ListAnomaliesParamsSortBy) Valid() bool {
+	switch e {
+	case CostOfAnomaly:
+		return true
+	case SeverityLevel:
+		return true
+	case StartTime:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListAnomaliesParamsSortOrder.
+const (
+	ListAnomaliesParamsSortOrderAsc  ListAnomaliesParamsSortOrder = "asc"
+	ListAnomaliesParamsSortOrderDesc ListAnomaliesParamsSortOrder = "desc"
+)
+
+// Valid indicates whether the value is a known member of the ListAnomaliesParamsSortOrder enum.
+func (e ListAnomaliesParamsSortOrder) Valid() bool {
+	switch e {
+	case ListAnomaliesParamsSortOrderAsc:
+		return true
+	case ListAnomaliesParamsSortOrderDesc:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GetCloudDiagramComponentsParamsType.
 const (
 	GetCloudDiagramComponentsParamsTypeApplication    GetCloudDiagramComponentsParamsType = "application"
@@ -4264,9 +4303,42 @@ type AnnotationListItem struct {
 
 // AnomaliesResponse List of detected cloud cost anomalies.
 type AnomaliesResponse struct {
-	Anomalies *[]AnomalyItem `json:"anomalies,omitempty"`
-	PageToken *string        `json:"pageToken,omitempty"`
-	RowCount  *int64         `json:"rowCount,omitempty"`
+	// Anomalies Anomalies in this page. Always an array; empty (`[]`) when there are no matching anomalies.
+	Anomalies []AnomalyItem `json:"anomalies"`
+
+	// AnomalySummary Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence.
+	AnomalySummary AnomaliesResponseAnomalySummary `json:"anomalySummary"`
+
+	// PageToken Opaque token for the next page. Omitted when there is no next page.
+	PageToken *string `json:"pageToken,omitempty"`
+
+	// RowCount Number of items in this page (`anomalies.length`). This is not the total count across all pages; the total across the full filtered result set is `totalCount`.
+	RowCount int64 `json:"rowCount"`
+
+	// TotalCount Total number of anomalies matching the filters and time window, across all pages. This is a per-request snapshot: under concurrent writes, the value can differ between pages fetched during the same pagination sequence.
+	TotalCount int64 `json:"totalCount"`
+
+	// TotalCountExact Whether `totalCount` is exact. Always `true` for this operation, because `totalCount` is computed over the fully materialised filtered result set.
+	TotalCountExact bool `json:"totalCountExact"`
+
+	// Truncated `true` when filtered anomalies remain beyond this page. Derived from the same "rows remain after the last returned row" check as `pageToken`, so the two are never contradictory: `pageToken` is present if and only if `truncated` is `true`.
+	Truncated bool `json:"truncated"`
+}
+
+// AnomaliesResponseAnomalySummary Anomaly-specific summary. `countBySeverity` and `totalCostOfAnomaly` cover the complete filtered result set across all pages, not the returned page. Anomalies whose severity cannot be determined (legacy documents) are counted in `totalCount` and `totalCostOfAnomaly` but in none of the three severity buckets in `countBySeverity`, so the three values can sum to less than `totalCount`. Computed as of this request; under concurrent writes, values may differ between pages fetched during the same pagination sequence.
+type AnomaliesResponseAnomalySummary struct {
+	// CountBySeverity Count of matching anomalies per severity level. All three keys are always present, with zero counts included.
+	CountBySeverity AnomaliesResponseAnomalySummaryCountBySeverity `json:"countBySeverity"`
+
+	// TotalCostOfAnomaly Sum of `costOfAnomaly` across all matching anomalies, in USD, rounded to cents.
+	TotalCostOfAnomaly float64 `json:"totalCostOfAnomaly"`
+}
+
+// AnomaliesResponseAnomalySummaryCountBySeverity Count of matching anomalies per severity level. All three keys are always present, with zero counts included.
+type AnomaliesResponseAnomalySummaryCountBySeverity struct {
+	Critical    int64 `json:"critical"`
+	Information int64 `json:"information"`
+	Warning     int64 `json:"warning"`
 }
 
 // AnomalyItem Detailed information about a detected anomaly. The `notifications` array is always present; list responses return an empty array unless `includeNotifications=true` is requested.
@@ -4317,7 +4389,7 @@ type AnomalyItem struct {
 	// ServiceName Service name.
 	ServiceName string `json:"serviceName"`
 
-	// SeverityLevel Severity level: Information, Warning or Critical
+	// SeverityLevel Severity level: `information`, `warning`, or `critical`.
 	SeverityLevel string `json:"severityLevel"`
 
 	// StartTime Usage start time of the anomaly.
@@ -6980,7 +7052,7 @@ type GetAnomaly200Response struct {
 	// ServiceName Service name
 	ServiceName string `json:"serviceName"`
 
-	// SeverityLevel Severity level: Information, Warning or Critical
+	// SeverityLevel Severity level: `information`, `warning`, or `critical`.
 	SeverityLevel string `json:"severityLevel"`
 
 	// StartTime Usage start time of the anomaly
@@ -9173,16 +9245,23 @@ type GetReportParams struct {
 
 // ListAnomaliesParams defines parameters for ListAnomalies.
 type ListAnomaliesParams struct {
-	// MinCreationTime Min value for the anomaly detection time
-	MinCreationTime *string `form:"minCreationTime,omitempty" json:"minCreationTime,omitempty"`
+	// MinCreationTime Inclusive lower bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.
+	MinCreationTime *int64 `form:"minCreationTime,omitempty" json:"minCreationTime,omitempty"`
 
-	// MaxCreationTime Max value for the anomaly detection time
-	MaxCreationTime *string `form:"maxCreationTime,omitempty" json:"maxCreationTime,omitempty"`
+	// MaxCreationTime Inclusive upper bound on the anomaly's usage start time, in milliseconds since the POSIX epoch. Despite the name, this filters the anomaly's usage start time, not the time the anomaly document was created.
+	MaxCreationTime *int64 `form:"maxCreationTime,omitempty" json:"maxCreationTime,omitempty"`
 
-	// Filter An expression for filtering the results of the request
+	// Filter An expression for filtering the results. The syntax is `key:value`. Multiple criteria can be combined using a pipe |. See [Filters](https://developer.doit.com/docs/filters).
+	// Available filter keys: **serviceName**, **billingAccount**, **platform**, **severityLevel**. `severityLevel` values must be lowercase: `information`, `warning`, `critical`. An unrecognised key, or a segment that is not `key:value`, is rejected with `400` rather than ignored.
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
 
-	// MaxResults The maximum number of results to return in a single page
+	// SortBy A field by which the results will be sorted. Defaults to `startTime`.
+	SortBy *ListAnomaliesParamsSortBy `form:"sortBy,omitempty" json:"sortBy,omitempty"`
+
+	// SortOrder Sort order can be ascending or descending.
+	SortOrder *ListAnomaliesParamsSortOrder `form:"sortOrder,omitempty" json:"sortOrder,omitempty"`
+
+	// MaxResults The maximum number of results to return in a single page. If omitted, all anomalies matching the filters and time window are returned in a single page.
 	MaxResults *int64 `form:"maxResults,omitempty" json:"maxResults,omitempty"`
 
 	// PageToken Page token, returned by a previous call, to request the next page of results
@@ -9191,6 +9270,12 @@ type ListAnomaliesParams struct {
 	// IncludeNotifications Include anomaly notifications from the subcollection. Defaults to false.
 	IncludeNotifications *bool `form:"includeNotifications,omitempty" json:"includeNotifications,omitempty"`
 }
+
+// ListAnomaliesParamsSortBy defines parameters for ListAnomalies.
+type ListAnomaliesParamsSortBy string
+
+// ListAnomaliesParamsSortOrder defines parameters for ListAnomalies.
+type ListAnomaliesParamsSortOrder string
 
 // IdOfAssetsParams defines parameters for IdOfAssets.
 type IdOfAssetsParams struct {
@@ -10752,8 +10837,10 @@ type ClientInterface interface {
 	// ListAnomalies List anomalies
 	//
 	// Returns a list of detected anomalies.
-	// Anomalies are returned in reverse chronological order by default.
+	// Anomalies can be sorted by `startTime`, `severityLevel`, or `costOfAnomaly` using `sortBy` and `sortOrder`. By default they are sorted by `startTime` in descending order (most recent first).
+	// The sort order is total and reproducible: ties on the selected field are broken by `startTime` descending and then by anomaly `id` ascending, so the same result set always paginates in the same order.
 	// The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
+	// **Pagination stability**: `sortBy`, `sortOrder`, `filter`, `minCreationTime`, and `maxCreationTime` must be held constant across a pagination sequence. A `pageToken` presented with any of them changed is rejected with `400`.
 	//
 	// Corresponds with GET /anomalies/v1 (the `ListAnomalies` operationId).
 	ListAnomalies(ctx context.Context, params *ListAnomaliesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -12753,8 +12840,10 @@ func (c *Client) UpdateCustomTheme(ctx context.Context, id string, body UpdateCu
 // ListAnomalies List anomalies
 //
 // Returns a list of detected anomalies.
-// Anomalies are returned in reverse chronological order by default.
+// Anomalies can be sorted by `startTime`, `severityLevel`, or `costOfAnomaly` using `sortBy` and `sortOrder`. By default they are sorted by `startTime` in descending order (most recent first).
+// The sort order is total and reproducible: ties on the selected field are broken by `startTime` descending and then by anomaly `id` ascending, so the same result set always paginates in the same order.
 // The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
+// **Pagination stability**: `sortBy`, `sortOrder`, `filter`, `minCreationTime`, and `maxCreationTime` must be held constant across a pagination sequence. A `pageToken` presented with any of them changed is rejected with `400`.
 //
 // Corresponds with GET /anomalies/v1 (the `ListAnomalies` operationId).
 func (c *Client) ListAnomalies(ctx context.Context, params *ListAnomaliesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -16834,7 +16923,7 @@ func NewListAnomaliesRequest(server string, params *ListAnomaliesParams) (*http.
 
 		if params.MinCreationTime != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "minCreationTime", *params.MinCreationTime, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "minCreationTime", *params.MinCreationTime, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -16846,7 +16935,7 @@ func NewListAnomaliesRequest(server string, params *ListAnomaliesParams) (*http.
 
 		if params.MaxCreationTime != nil {
 
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxCreationTime", *params.MaxCreationTime, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "maxCreationTime", *params.MaxCreationTime, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -16859,6 +16948,30 @@ func NewListAnomaliesRequest(server string, params *ListAnomaliesParams) (*http.
 		if params.Filter != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "filter", *params.Filter, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.SortBy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "sortBy", *params.SortBy, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.SortOrder != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "sortOrder", *params.SortOrder, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -20864,8 +20977,10 @@ type ClientWithResponsesInterface interface {
 	// ListAnomaliesWithResponse List anomalies
 	//
 	// Returns a list of detected anomalies.
-	// Anomalies are returned in reverse chronological order by default.
+	// Anomalies can be sorted by `startTime`, `severityLevel`, or `costOfAnomaly` using `sortBy` and `sortOrder`. By default they are sorted by `startTime` in descending order (most recent first).
+	// The sort order is total and reproducible: ties on the selected field are broken by `startTime` descending and then by anomaly `id` ascending, so the same result set always paginates in the same order.
 	// The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
+	// **Pagination stability**: `sortBy`, `sortOrder`, `filter`, `minCreationTime`, and `maxCreationTime` must be held constant across a pagination sequence. A `pageToken` presented with any of them changed is rejected with `400`.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -30346,8 +30461,10 @@ func (c *ClientWithResponses) UpdateCustomThemeWithResponse(ctx context.Context,
 // ListAnomaliesWithResponse List anomalies
 //
 // Returns a list of detected anomalies.
-// Anomalies are returned in reverse chronological order by default.
+// Anomalies can be sorted by `startTime`, `severityLevel`, or `costOfAnomaly` using `sortBy` and `sortOrder`. By default they are sorted by `startTime` in descending order (most recent first).
+// The sort order is total and reproducible: ties on the selected field are broken by `startTime` descending and then by anomaly `id` ascending, so the same result set always paginates in the same order.
 // The `notifications` array is always present on each anomaly item; it is empty unless `includeNotifications=true` is supplied.
+// **Pagination stability**: `sortBy`, `sortOrder`, `filter`, `minCreationTime`, and `maxCreationTime` must be held constant across a pagination sequence. A `pageToken` presented with any of them changed is rejected with `400`.
 //
 // Returns a wrapper object for the known response body format(s).
 //


### PR DESCRIPTION
## Summary
- Upstream added support for new query parameters (`sort_by`, `sort_order`, `min_creation_time`, `max_creation_time`) and response attributes (`total_count`, `total_count_exact`, `truncated`, `anomaly_summary`) to the anomalies API.
- Fixed type errors caused by upstream changes where `Anomalies` changed from pointer slice to non-pointer slice (`[]AnomalyItem`).
- Wired the new query parameters and response attributes in `doit_anomalies` data source:
  - Mapped `sort_by` and `sort_order` enums and `min_creation_time` and `max_creation_time` epoch timestamp parameters.
  - Mapped response fields `total_count`, `total_count_exact`, `truncated` (and enforced `truncated = false` for auto-paginated results).
  - Implemented `mapAnomalySummary()` to populate `anomaly_summary` (including `count_by_severity` and `total_cost_of_anomaly`).
  - Updated the unknown input guard to check all inputs and return unknown outputs.
- Updated documentation and examples in `examples/data-sources/doit_anomalies/data-source.tf` and regenerated `docs/data-sources/anomalies.md`.
- Added acceptance test coverage for all new attributes with empty-plan drift checks:
  - `TestAccAnomaliesDataSource_SortByAndSortOrder`
  - `TestAccAnomaliesDataSource_MinMaxCreationTime`
  - `TestAccAnomaliesDataSource_AnomalySummary`
  - `TestAccAnomaliesDataSource_TotalCountAndTruncated`
  - Updated existing tests to verify the new attributes.

## Test plan
- [x] `make test` — all unit tests pass
- [x] `make lint` (`./custom-gcl run`) — 0 issues
- [x] `make docs` / `make validate-examples` — all 85 examples validate cleanly
- [x] `make testacc-run TEST=TestAccAnomaliesDataSource` — 14/14 acceptance tests pass with drift verification