### PR TITLE
feat: add risk_status and risk_aggregations to doit_budgets data source

### DIFF
--- a/OpenAPI/2_tfplugingen-framework/output_datasources.json
+++ b/OpenAPI/2_tfplugingen-framework/output_datasources.json
@@ -4232,7 +4232,7 @@
 						"name": "filter",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "An expression for filtering the results of the request. The syntax is \"key:[\u003cvalue\u003e]\".\nAvailable keys: owner, budgetName, lastModified in ms (\u003elasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\"."
+							"description": "An expression for filtering the results of the request. The syntax is \"key:[\u003cvalue\u003e]\".\nAvailable keys: owner, budgetName, lastModified in ms (\u003elasModified), riskStatus (one of \"atRisk\", \"onTrack\", \"unknown\"). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\" (except riskStatus, where only the first occurrence is honored).\nA budget is \"atRisk\" when it has already exceeded its configured amount, or its forecast projects it will exceed the configured amount before the current period ends. Budgets with no forecast data yet, a fixed budget whose period has already expired, or that are invalid/draft are classified \"unknown\". Filtering to riskStatus:atRisk sorts results by earliest projected breach date (day granularity) ascending instead of the default order; budgets that tie on breach day, including every already-breached budget, resolve to a fixed, repeatable order across requests rather than an arbitrary one.\nBecause riskStatus is computed from live, periodically-refreshed budget data, paginated results filtered by riskStatus may shift between page requests if budget data refreshes mid-pagination."
 						}
 					},
 					{
@@ -4339,6 +4339,13 @@
 										}
 									},
 									{
+										"name": "risk_status",
+										"string": {
+											"computed_optional_required": "computed",
+											"description": "Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.\n\"atRisk\" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.\n\"onTrack\" - the budget has forecast data and is neither over budget nor projected to breach.\n\"unknown\" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft."
+										}
+									},
+									{
 										"name": "scope",
 										"list": {
 											"computed_optional_required": "computed",
@@ -4439,6 +4446,39 @@
 								]
 							},
 							"description": "Array of Budgets"
+						}
+					},
+					{
+						"name": "risk_aggregations",
+						"single_nested": {
+							"computed_optional_required": "computed",
+							"attributes": [
+								{
+									"name": "at_risk",
+									"int64": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "on_track",
+									"int64": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "total",
+									"int64": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "unknown",
+									"int64": {
+										"computed_optional_required": "computed"
+									}
+								}
+							],
+							"description": "Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page."
 						}
 					},
 					{

--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -1174,6 +1174,7 @@ paths:
       summary: List budgets
       description: |-
         Returns a list of budgets that your account has access to. Budgets are listed in reverse chronological order by default.
+        Each budget includes a server-computed `riskStatus` (`atRisk`, `onTrack`, or `unknown`), and the response includes a `riskAggregations` summary of risk counts across the full filtered result set (all pages, not just the current page).
       operationId: listBudgets
       parameters:
         - name: maxResults
@@ -1188,8 +1189,10 @@ paths:
           in: query
           description: |-
             An expression for filtering the results of the request. The syntax is "key:[<value>]".
-            Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
-          example: "budgetName:My Monthly Budget"
+            Available keys: owner, budgetName, lastModified in ms (>lasModified), riskStatus (one of "atRisk", "onTrack", "unknown"). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR" (except riskStatus, where only the first occurrence is honored).
+            A budget is "atRisk" when it has already exceeded its configured amount, or its forecast projects it will exceed the configured amount before the current period ends. Budgets with no forecast data yet, a fixed budget whose period has already expired, or that are invalid/draft are classified "unknown". Filtering to riskStatus:atRisk sorts results by earliest projected breach date (day granularity) ascending instead of the default order; budgets that tie on breach day, including every already-breached budget, resolve to a fixed, repeatable order across requests rather than an arbitrary one.
+            Because riskStatus is computed from live, periodically-refreshed budget data, paginated results filtered by riskStatus may shift between page requests if budget data refreshes mid-pagination.
+          example: "riskStatus:atRisk"
           schema:
             type: string
         - $ref: "#/components/parameters/nameContains"
@@ -1228,6 +1231,8 @@ paths:
                     type: integer
                     description: Budgets rows count
                     format: int64
+                  riskAggregations:
+                    $ref: "#/components/schemas/RiskAggregations"
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -10206,6 +10211,14 @@ components:
           type: string
         owner:
           type: string
+        riskStatus:
+          type: string
+          description: |-
+            Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.
+            "atRisk" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.
+            "onTrack" - the budget has forecast data and is neither over budget nor projected to breach.
+            "unknown" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft.
+          enum: ["atRisk", "onTrack", "unknown"]
         scope:
           type: array
           description: List of allocations that define the budget scope.
@@ -10227,6 +10240,27 @@ components:
           format: int64
         url:
           type: string
+    RiskAggregations:
+      type: object
+      description: Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page.
+      required:
+        - total
+        - atRisk
+        - onTrack
+        - unknown
+      properties:
+        total:
+          type: integer
+          format: int64
+        atRisk:
+          type: integer
+          format: int64
+        onTrack:
+          type: integer
+          format: int64
+        unknown:
+          type: integer
+          format: int64
     BudgetCreateUpdateAlert:
       type: object
       description: Threshold settings for budget alerts.

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -1143,6 +1143,7 @@ paths:
       summary: List budgets
       description: |-
         Returns a list of budgets that your account has access to. Budgets are listed in reverse chronological order by default.
+        Each budget includes a server-computed `riskStatus` (`atRisk`, `onTrack`, or `unknown`), and the response includes a `riskAggregations` summary of risk counts across the full filtered result set (all pages, not just the current page).
       operationId: listBudgets
       parameters:
         - name: maxResults
@@ -1157,8 +1158,10 @@ paths:
           in: query
           description: |-
             An expression for filtering the results of the request. The syntax is "key:[<value>]".
-            Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
-          example: "budgetName:My Monthly Budget"
+            Available keys: owner, budgetName, lastModified in ms (>lasModified), riskStatus (one of "atRisk", "onTrack", "unknown"). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR" (except riskStatus, where only the first occurrence is honored).
+            A budget is "atRisk" when it has already exceeded its configured amount, or its forecast projects it will exceed the configured amount before the current period ends. Budgets with no forecast data yet, a fixed budget whose period has already expired, or that are invalid/draft are classified "unknown". Filtering to riskStatus:atRisk sorts results by earliest projected breach date (day granularity) ascending instead of the default order; budgets that tie on breach day, including every already-breached budget, resolve to a fixed, repeatable order across requests rather than an arbitrary one.
+            Because riskStatus is computed from live, periodically-refreshed budget data, paginated results filtered by riskStatus may shift between page requests if budget data refreshes mid-pagination.
+          example: "riskStatus:atRisk"
           schema:
             type: string
         - $ref: "#/components/parameters/nameContains"
@@ -6022,6 +6025,14 @@ components:
           type: string
         owner:
           type: string
+        riskStatus:
+          type: string
+          description: |-
+            Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.
+            "atRisk" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.
+            "onTrack" - the budget has forecast data and is neither over budget nor projected to breach.
+            "unknown" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft.
+          enum: ["atRisk", "onTrack", "unknown"]
         scope:
           type: array
           description: List of allocations that define the budget scope.
@@ -9863,6 +9874,8 @@ components:
           type: integer
           description: Budgets rows count
           format: int64
+        riskAggregations:
+          $ref: "#/components/schemas/RiskAggregations"
     ListCustomThemes200Response:
       type: object
       properties:
@@ -10505,6 +10518,27 @@ components:
             $ref: "#/components/schemas/InsightResponse"
         pagination:
           $ref: "#/components/schemas/Pagination"
+    RiskAggregations:
+      type: object
+      description: Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page.
+      required:
+        - total
+        - atRisk
+        - onTrack
+        - unknown
+      properties:
+        total:
+          type: integer
+          format: int64
+        atRisk:
+          type: integer
+          format: int64
+        onTrack:
+          type: integer
+          format: int64
+        unknown:
+          type: integer
+          format: int64
     Role:
       type: object
       description: Definition and permissions assigned to a role.

--- a/docs/data-sources/budgets.md
+++ b/docs/data-sources/budgets.md
@@ -20,14 +20,26 @@ data "doit_budgets" "production" {
   name_contains = "production"
 }
 
+# Filter budgets by risk status (atRisk, onTrack, unknown)
+data "doit_budgets" "at_risk" {
+  filter = "riskStatus:atRisk"
+}
+
 # Output total number of budgets
 output "total_budgets" {
   value = data.doit_budgets.all.row_count
 }
 
-# Output budget names
-output "budget_names" {
-  value = [for b in data.doit_budgets.all.budgets : b.budget_name]
+# Output risk aggregations across all budgets
+output "risk_summary" {
+  value = data.doit_budgets.all.risk_aggregations
+}
+
+# Output budget names and risk status
+output "budget_risks" {
+  value = {
+    for b in data.doit_budgets.all.budgets : b.budget_name => b.risk_status
+  }
 }
 ```
 
@@ -39,7 +51,9 @@ output "budget_names" {
 ### Optional
 
 - `filter` (String) An expression for filtering the results of the request. The syntax is "key:[<value>]".
-Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+Available keys: owner, budgetName, lastModified in ms (>lasModified), riskStatus (one of "atRisk", "onTrack", "unknown"). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR" (except riskStatus, where only the first occurrence is honored).
+A budget is "atRisk" when it has already exceeded its configured amount, or its forecast projects it will exceed the configured amount before the current period ends. Budgets with no forecast data yet, a fixed budget whose period has already expired, or that are invalid/draft are classified "unknown". Filtering to riskStatus:atRisk sorts results by earliest projected breach date (day granularity) ascending instead of the default order; budgets that tie on breach day, including every already-breached budget, resolve to a fixed, repeatable order across requests rather than an arbitrary one.
+Because riskStatus is computed from live, periodically-refreshed budget data, paginated results filtered by riskStatus may shift between page requests if budget data refreshes mid-pagination.
 - `max_creation_time` (String) Max value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created before or at this timestamp are returned.
 - `max_results` (Number) The maximum number of results to return in a single page. Leverage the page tokens to iterate through the entire collection.
 - `min_creation_time` (String) Min value for reports creation time, in milliseconds since the POSIX epoch. If set, only reports created after or at this timestamp are returned.
@@ -50,6 +64,7 @@ Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple f
 ### Read-Only
 
 - `budgets` (Attributes List) Array of Budgets (see [below for nested schema](#nestedatt--budgets))
+- `risk_aggregations` (Attributes) Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page. (see [below for nested schema](#nestedatt--risk_aggregations))
 - `row_count` (Number) Budgets rows count
 
 <a id="nestedatt--timeouts"></a>
@@ -75,6 +90,10 @@ Read-Only:
 - `forecasted_utilization_date` (Number)
 - `id` (String)
 - `owner` (String)
+- `risk_status` (String) Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.
+"atRisk" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.
+"onTrack" - the budget has forecast data and is neither over budget nor projected to breach.
+"unknown" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft.
 - `scope` (List of String, Deprecated) List of allocations that define the budget scope.
 - `scopes` (Attributes List) The filters selected define the scope of the budget. (see [below for nested schema](#nestedatt--budgets--scopes))
 - `start_period` (Number)
@@ -103,3 +122,15 @@ Read-Only:
 - `mode` (String) Controls how the dimension’s `values` are matched when the alert query runs. If mode is omitted, behavior defaults to is.
 - `type` (String) Dimension filter type. Always pair `type` with `id` on scope filters. Discover valid `id` + `type` pairs for your account with `GET /analytics/v1/dimensions`. `allocation_rule` replaces `attribution`; `allocation` replaces `attribution_group`.
 - `values` (List of String) List of values to include or exclude. Must match exact strings from your billing or DataHub data for the dimension (for example, `Amazon Simple Storage Service` for AWS S3 on `service_description`). For `allocation_rule`, use allocation rule IDs.
+
+
+
+<a id="nestedatt--risk_aggregations"></a>
+### Nested Schema for `risk_aggregations`
+
+Read-Only:
+
+- `at_risk` (Number)
+- `on_track` (Number)
+- `total` (Number)
+- `unknown` (Number)

--- a/examples/data-sources/doit_budgets/data-source.tf
+++ b/examples/data-sources/doit_budgets/data-source.tf
@@ -6,12 +6,24 @@ data "doit_budgets" "production" {
   name_contains = "production"
 }
 
+# Filter budgets by risk status (atRisk, onTrack, unknown)
+data "doit_budgets" "at_risk" {
+  filter = "riskStatus:atRisk"
+}
+
 # Output total number of budgets
 output "total_budgets" {
   value = data.doit_budgets.all.row_count
 }
 
-# Output budget names
-output "budget_names" {
-  value = [for b in data.doit_budgets.all.budgets : b.budget_name]
+# Output risk aggregations across all budgets
+output "risk_summary" {
+  value = data.doit_budgets.all.risk_aggregations
+}
+
+# Output budget names and risk status
+output "budget_risks" {
+  value = {
+    for b in data.doit_budgets.all.budgets : b.budget_name => b.risk_status
+  }
 }

--- a/internal/provider/budgets_data_source.go
+++ b/internal/provider/budgets_data_source.go
@@ -77,6 +77,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	// If any filter/pagination input is unknown, return unknown list
 	if data.Filter.IsUnknown() || data.NameContains.IsUnknown() || data.MinCreationTime.IsUnknown() || data.MaxCreationTime.IsUnknown() || data.MaxResults.IsUnknown() || data.PageToken.IsUnknown() {
 		data.Budgets = types.ListUnknown(datasource_budgets.BudgetsValue{}.Type(ctx))
+		data.RiskAggregations = datasource_budgets.NewRiskAggregationsValueUnknown()
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
@@ -99,6 +100,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	userControlsPagination := !data.MaxResults.IsNull()
 
 	var allBudgets []models.BudgetListItem
+	var riskAggregations *models.RiskAggregations
 
 	if userControlsPagination {
 		// Manual mode: single API call with user's params
@@ -128,6 +130,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		if result.Budgets != nil {
 			allBudgets = *result.Budgets
 		}
+		riskAggregations = result.RiskAggregations
 
 		// Preserve API's page_token for user to fetch next page
 		data.PageToken = types.StringPointerValue(result.PageToken)
@@ -164,6 +167,9 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 			if result.Budgets != nil {
 				allBudgets = append(allBudgets, *result.Budgets...)
 			}
+			if result.RiskAggregations != nil {
+				riskAggregations = result.RiskAggregations
+			}
 
 			if result.PageToken == nil || *result.PageToken == "" {
 				break
@@ -177,6 +183,10 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		// max_results was not set by user; normalize to null
 		data.MaxResults = types.Int64Null()
 	}
+
+	riskAggVal, diags := mapRiskAggregations(ctx, riskAggregations)
+	resp.Diagnostics.Append(diags...)
+	data.RiskAggregations = riskAggVal
 
 	// Map budgets list
 	if len(allBudgets) > 0 {
@@ -221,6 +231,7 @@ func (d *budgetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 					"end_period":                  types.Int64PointerValue(budget.EndPeriod),
 					"time_interval":               types.StringPointerValue(budget.TimeInterval),
 					"url":                         types.StringPointerValue(budget.Url),
+					"risk_status":                 types.StringPointerValue((*string)(budget.RiskStatus)),
 					"alert_thresholds":            alertThresholdsList,
 					"scopes":                      scopesList,
 					"scope":                       scopeList,
@@ -315,4 +326,20 @@ func mapBudgetScopes(ctx context.Context, scopes *[]models.ExternalConfigFilter)
 	}
 
 	return types.ListValueFrom(ctx, datasource_budgets.ScopesValue{}.Type(ctx), vals)
+}
+
+func mapRiskAggregations(ctx context.Context, riskAgg *models.RiskAggregations) (datasource_budgets.RiskAggregationsValue, diag.Diagnostics) {
+	if riskAgg == nil {
+		return datasource_budgets.NewRiskAggregationsValueNull(), nil
+	}
+
+	return datasource_budgets.NewRiskAggregationsValue(
+		datasource_budgets.RiskAggregationsValue{}.AttributeTypes(ctx),
+		map[string]attr.Value{
+			"at_risk":  types.Int64Value(riskAgg.AtRisk),
+			"on_track": types.Int64Value(riskAgg.OnTrack),
+			"total":    types.Int64Value(riskAgg.Total),
+			"unknown":  types.Int64Value(riskAgg.Unknown),
+		},
+	)
 }

--- a/internal/provider/budgets_data_source_test.go
+++ b/internal/provider/budgets_data_source_test.go
@@ -39,6 +39,9 @@ func TestAccBudgetsDataSource_MaxResultsOnly(t *testing.T) {
 					resource.TestCheckResourceAttr("data.doit_budgets.limited", "budgets.#", "2"),
 					// Verify page_token is returned (more pages exist)
 					resource.TestCheckResourceAttrSet("data.doit_budgets.limited", "page_token"),
+					// Verify risk attributes
+					resource.TestCheckResourceAttrSet("data.doit_budgets.limited", "budgets.0.risk_status"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.limited", "risk_aggregations.total"),
 				),
 			},
 			// Second apply should produce no diff (max_results preserved in state)
@@ -158,10 +161,52 @@ func TestAccBudgetsDataSource_AutoPagination(t *testing.T) {
 					// Don't check specific values since parallel tests may change the count
 					resource.TestCheckResourceAttrSet("data.doit_budgets.test", "row_count"),
 					resource.TestCheckNoResourceAttr("data.doit_budgets.test", "page_token"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.test", "risk_aggregations.total"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.test", "risk_aggregations.at_risk"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.test", "risk_aggregations.on_track"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.test", "risk_aggregations.unknown"),
 				),
 			},
 		},
 	})
+}
+
+// TestAccBudgetsDataSource_FilterByRiskStatus tests filtering budgets with the riskStatus filter key.
+func TestAccBudgetsDataSource_FilterByRiskStatus(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetsDataSourceFilterRiskStatusConfig("riskStatus:atRisk"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "row_count"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.total"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.at_risk"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.on_track"),
+					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.unknown"),
+				),
+			},
+			// Drift verification: re-apply the same config should produce an empty plan
+			{
+				Config: testAccBudgetsDataSourceFilterRiskStatusConfig("riskStatus:atRisk"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccBudgetsDataSourceFilterRiskStatusConfig(filter string) string {
+	return fmt.Sprintf(`
+data "doit_budgets" "risk_filtered" {
+  filter = "%s"
+}
+`, filter)
 }
 
 // TestAccBudgetsDataSource_NameContains tests filtering budgets with name_contains

--- a/internal/provider/budgets_data_source_test.go
+++ b/internal/provider/budgets_data_source_test.go
@@ -182,8 +182,12 @@ func TestAccBudgetsDataSource_FilterByRiskStatus(t *testing.T) {
 				Config: testAccBudgetsDataSourceFilterRiskStatusConfig("riskStatus:atRisk"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "row_count"),
+					// When filtering by riskStatus:atRisk, the filtered row_count matches the at_risk aggregate count
+					resource.TestCheckResourceAttrPair("data.doit_budgets.risk_filtered", "row_count", "data.doit_budgets.risk_filtered", "risk_aggregations.at_risk"),
+					// Returned budgets must have risk_status = "atRisk"
+					resource.TestCheckResourceAttr("data.doit_budgets.risk_filtered", "budgets.0.risk_status", "atRisk"),
+					// Risk aggregations breakdown is populated
 					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.total"),
-					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.at_risk"),
 					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.on_track"),
 					resource.TestCheckResourceAttrSet("data.doit_budgets.risk_filtered", "risk_aggregations.unknown"),
 				),

--- a/internal/provider/datasource_budgets/budgets_data_source_gen.go
+++ b/internal/provider/datasource_budgets/budgets_data_source_gen.go
@@ -66,6 +66,11 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 						"owner": schema.StringAttribute{
 							Computed: true,
 						},
+						"risk_status": schema.StringAttribute{
+							Computed:            true,
+							Description:         "Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.\n\"atRisk\" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.\n\"onTrack\" - the budget has forecast data and is neither over budget nor projected to breach.\n\"unknown\" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft.",
+							MarkdownDescription: "Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.\n\"atRisk\" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.\n\"onTrack\" - the budget has forecast data and is neither over budget nor projected to breach.\n\"unknown\" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft.",
+						},
 						"scope": schema.ListAttribute{
 							ElementType:         types.StringType,
 							Computed:            true,
@@ -149,8 +154,8 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 			"filter": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\".",
-				MarkdownDescription: "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\".",
+				Description:         "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, budgetName, lastModified in ms (>lasModified), riskStatus (one of \"atRisk\", \"onTrack\", \"unknown\"). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\" (except riskStatus, where only the first occurrence is honored).\nA budget is \"atRisk\" when it has already exceeded its configured amount, or its forecast projects it will exceed the configured amount before the current period ends. Budgets with no forecast data yet, a fixed budget whose period has already expired, or that are invalid/draft are classified \"unknown\". Filtering to riskStatus:atRisk sorts results by earliest projected breach date (day granularity) ascending instead of the default order; budgets that tie on breach day, including every already-breached budget, resolve to a fixed, repeatable order across requests rather than an arbitrary one.\nBecause riskStatus is computed from live, periodically-refreshed budget data, paginated results filtered by riskStatus may shift between page requests if budget data refreshes mid-pagination.",
+				MarkdownDescription: "An expression for filtering the results of the request. The syntax is \"key:[<value>]\".\nAvailable keys: owner, budgetName, lastModified in ms (>lasModified), riskStatus (one of \"atRisk\", \"onTrack\", \"unknown\"). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in \"AND,\" while using the same key multiple times in the same filter results in \"OR\" (except riskStatus, where only the first occurrence is honored).\nA budget is \"atRisk\" when it has already exceeded its configured amount, or its forecast projects it will exceed the configured amount before the current period ends. Budgets with no forecast data yet, a fixed budget whose period has already expired, or that are invalid/draft are classified \"unknown\". Filtering to riskStatus:atRisk sorts results by earliest projected breach date (day granularity) ascending instead of the default order; budgets that tie on breach day, including every already-breached budget, resolve to a fixed, repeatable order across requests rather than an arbitrary one.\nBecause riskStatus is computed from live, periodically-refreshed budget data, paginated results filtered by riskStatus may shift between page requests if budget data refreshes mid-pagination.",
 			},
 			"max_creation_time": schema.StringAttribute{
 				Optional:            true,
@@ -182,6 +187,30 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Page token, returned by a previous call, to request the next page of results",
 				MarkdownDescription: "Page token, returned by a previous call, to request the next page of results",
 			},
+			"risk_aggregations": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"at_risk": schema.Int64Attribute{
+						Computed: true,
+					},
+					"on_track": schema.Int64Attribute{
+						Computed: true,
+					},
+					"total": schema.Int64Attribute{
+						Computed: true,
+					},
+					"unknown": schema.Int64Attribute{
+						Computed: true,
+					},
+				},
+				CustomType: RiskAggregationsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: RiskAggregationsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Computed:            true,
+				Description:         "Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page.",
+				MarkdownDescription: "Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page.",
+			},
 			"row_count": schema.Int64Attribute{
 				Computed:            true,
 				Description:         "Budgets rows count",
@@ -194,14 +223,15 @@ func BudgetsDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type BudgetsModel struct {
-	Budgets         types.List   `tfsdk:"budgets"`
-	Filter          types.String `tfsdk:"filter"`
-	MaxCreationTime types.String `tfsdk:"max_creation_time"`
-	MaxResults      types.Int64  `tfsdk:"max_results"`
-	MinCreationTime types.String `tfsdk:"min_creation_time"`
-	NameContains    types.String `tfsdk:"name_contains"`
-	PageToken       types.String `tfsdk:"page_token"`
-	RowCount        types.Int64  `tfsdk:"row_count"`
+	Budgets          types.List            `tfsdk:"budgets"`
+	Filter           types.String          `tfsdk:"filter"`
+	MaxCreationTime  types.String          `tfsdk:"max_creation_time"`
+	MaxResults       types.Int64           `tfsdk:"max_results"`
+	MinCreationTime  types.String          `tfsdk:"min_creation_time"`
+	NameContains     types.String          `tfsdk:"name_contains"`
+	PageToken        types.String          `tfsdk:"page_token"`
+	RiskAggregations RiskAggregationsValue `tfsdk:"risk_aggregations"`
+	RowCount         types.Int64           `tfsdk:"row_count"`
 }
 
 var _ basetypes.ObjectTypable = BudgetsType{}
@@ -417,6 +447,24 @@ func (t BudgetsType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 			fmt.Sprintf(`owner expected to be basetypes.StringValue, was: %T`, ownerAttribute))
 	}
 
+	riskStatusAttribute, ok := attributes["risk_status"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`risk_status is missing from object`)
+
+		return nil, diags
+	}
+
+	riskStatusVal, ok := riskStatusAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`risk_status expected to be basetypes.StringValue, was: %T`, riskStatusAttribute))
+	}
+
 	scopeAttribute, ok := attributes["scope"]
 
 	if !ok {
@@ -540,6 +588,7 @@ func (t BudgetsType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 		ForecastedUtilizationDate: forecastedUtilizationDateVal,
 		Id:                        idVal,
 		Owner:                     ownerVal,
+		RiskStatus:                riskStatusVal,
 		Scope:                     scopeVal,
 		Scopes:                    scopesVal,
 		StartPeriod:               startPeriodVal,
@@ -793,6 +842,24 @@ func NewBudgetsValue(attributeTypes map[string]attr.Type, attributes map[string]
 			fmt.Sprintf(`owner expected to be basetypes.StringValue, was: %T`, ownerAttribute))
 	}
 
+	riskStatusAttribute, ok := attributes["risk_status"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`risk_status is missing from object`)
+
+		return NewBudgetsValueUnknown(), diags
+	}
+
+	riskStatusVal, ok := riskStatusAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`risk_status expected to be basetypes.StringValue, was: %T`, riskStatusAttribute))
+	}
+
 	scopeAttribute, ok := attributes["scope"]
 
 	if !ok {
@@ -916,6 +983,7 @@ func NewBudgetsValue(attributeTypes map[string]attr.Type, attributes map[string]
 		ForecastedUtilizationDate: forecastedUtilizationDateVal,
 		Id:                        idVal,
 		Owner:                     ownerVal,
+		RiskStatus:                riskStatusVal,
 		Scope:                     scopeVal,
 		Scopes:                    scopesVal,
 		StartPeriod:               startPeriodVal,
@@ -1004,6 +1072,7 @@ type BudgetsValue struct {
 	ForecastedUtilizationDate basetypes.Int64Value   `tfsdk:"forecasted_utilization_date"`
 	Id                        basetypes.StringValue  `tfsdk:"id"`
 	Owner                     basetypes.StringValue  `tfsdk:"owner"`
+	RiskStatus                basetypes.StringValue  `tfsdk:"risk_status"`
 	Scope                     basetypes.ListValue    `tfsdk:"scope"`
 	Scopes                    basetypes.ListValue    `tfsdk:"scopes"`
 	StartPeriod               basetypes.Int64Value   `tfsdk:"start_period"`
@@ -1014,7 +1083,7 @@ type BudgetsValue struct {
 }
 
 func (v BudgetsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 16)
+	attrTypes := make(map[string]tftypes.Type, 17)
 
 	var val tftypes.Value
 	var err error
@@ -1031,6 +1100,7 @@ func (v BudgetsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 	attrTypes["forecasted_utilization_date"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["owner"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["risk_status"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["scope"] = basetypes.ListType{
 		ElemType: types.StringType,
 	}.TerraformType(ctx)
@@ -1046,7 +1116,7 @@ func (v BudgetsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 16)
+		vals := make(map[string]tftypes.Value, 17)
 
 		val, err = v.AlertThresholds.ToTerraformValue(ctx)
 
@@ -1127,6 +1197,14 @@ func (v BudgetsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		}
 
 		vals["owner"] = val
+
+		val, err = v.RiskStatus.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["risk_status"] = val
 
 		val, err = v.Scope.ToTerraformValue(ctx)
 
@@ -1243,6 +1321,7 @@ func (v BudgetsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 			"forecasted_utilization_date": basetypes.Int64Type{},
 			"id":                          basetypes.StringType{},
 			"owner":                       basetypes.StringType{},
+			"risk_status":                 basetypes.StringType{},
 			"scope": basetypes.ListType{
 				ElemType: types.StringType,
 			},
@@ -1269,6 +1348,7 @@ func (v BudgetsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 		"forecasted_utilization_date": basetypes.Int64Type{},
 		"id":                          basetypes.StringType{},
 		"owner":                       basetypes.StringType{},
+		"risk_status":                 basetypes.StringType{},
 		"scope": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -1302,6 +1382,7 @@ func (v BudgetsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 			"forecasted_utilization_date": v.ForecastedUtilizationDate,
 			"id":                          v.Id,
 			"owner":                       v.Owner,
+			"risk_status":                 v.RiskStatus,
 			"scope":                       scopeVal,
 			"scopes":                      scopes,
 			"start_period":                v.StartPeriod,
@@ -1368,6 +1449,10 @@ func (v BudgetsValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.RiskStatus.Equal(other.RiskStatus) {
+		return false
+	}
+
 	if !v.Scope.Equal(other.Scope) {
 		return false
 	}
@@ -1417,6 +1502,7 @@ func (v BudgetsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"forecasted_utilization_date": basetypes.Int64Type{},
 		"id":                          basetypes.StringType{},
 		"owner":                       basetypes.StringType{},
+		"risk_status":                 basetypes.StringType{},
 		"scope": basetypes.ListType{
 			ElemType: types.StringType,
 		},
@@ -2508,5 +2594,502 @@ func (v ScopesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"values": basetypes.ListType{
 			ElemType: types.StringType,
 		},
+	}
+}
+
+var _ basetypes.ObjectTypable = RiskAggregationsType{}
+
+type RiskAggregationsType struct {
+	basetypes.ObjectType
+}
+
+func (t RiskAggregationsType) Equal(o attr.Type) bool {
+	other, ok := o.(RiskAggregationsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t RiskAggregationsType) String() string {
+	return "RiskAggregationsType"
+}
+
+func (t RiskAggregationsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewRiskAggregationsValueNull(), diags
+	}
+
+	if in.IsUnknown() {
+		return NewRiskAggregationsValueUnknown(), diags
+	}
+
+	attributes := in.Attributes()
+
+	atRiskAttribute, ok := attributes["at_risk"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`at_risk is missing from object`)
+
+		return nil, diags
+	}
+
+	atRiskVal, ok := atRiskAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`at_risk expected to be basetypes.Int64Value, was: %T`, atRiskAttribute))
+	}
+
+	onTrackAttribute, ok := attributes["on_track"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`on_track is missing from object`)
+
+		return nil, diags
+	}
+
+	onTrackVal, ok := onTrackAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`on_track expected to be basetypes.Int64Value, was: %T`, onTrackAttribute))
+	}
+
+	totalAttribute, ok := attributes["total"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`total is missing from object`)
+
+		return nil, diags
+	}
+
+	totalVal, ok := totalAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`total expected to be basetypes.Int64Value, was: %T`, totalAttribute))
+	}
+
+	unknownAttribute, ok := attributes["unknown"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`unknown is missing from object`)
+
+		return nil, diags
+	}
+
+	unknownVal, ok := unknownAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`unknown expected to be basetypes.Int64Value, was: %T`, unknownAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return RiskAggregationsValue{
+		AtRisk:  atRiskVal,
+		OnTrack: onTrackVal,
+		Total:   totalVal,
+		Unknown: unknownVal,
+		state:   attr.ValueStateKnown,
+	}, diags
+}
+
+func NewRiskAggregationsValueNull() RiskAggregationsValue {
+	return RiskAggregationsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewRiskAggregationsValueUnknown() RiskAggregationsValue {
+	return RiskAggregationsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewRiskAggregationsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (RiskAggregationsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing RiskAggregationsValue Attribute Value",
+				"While creating a RiskAggregationsValue value, a missing attribute value was detected. "+
+					"A RiskAggregationsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("RiskAggregationsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid RiskAggregationsValue Attribute Type",
+				"While creating a RiskAggregationsValue value, an invalid attribute value was detected. "+
+					"A RiskAggregationsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("RiskAggregationsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("RiskAggregationsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra RiskAggregationsValue Attribute Value",
+				"While creating a RiskAggregationsValue value, an extra attribute value was detected. "+
+					"A RiskAggregationsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra RiskAggregationsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewRiskAggregationsValueUnknown(), diags
+	}
+
+	atRiskAttribute, ok := attributes["at_risk"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`at_risk is missing from object`)
+
+		return NewRiskAggregationsValueUnknown(), diags
+	}
+
+	atRiskVal, ok := atRiskAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`at_risk expected to be basetypes.Int64Value, was: %T`, atRiskAttribute))
+	}
+
+	onTrackAttribute, ok := attributes["on_track"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`on_track is missing from object`)
+
+		return NewRiskAggregationsValueUnknown(), diags
+	}
+
+	onTrackVal, ok := onTrackAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`on_track expected to be basetypes.Int64Value, was: %T`, onTrackAttribute))
+	}
+
+	totalAttribute, ok := attributes["total"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`total is missing from object`)
+
+		return NewRiskAggregationsValueUnknown(), diags
+	}
+
+	totalVal, ok := totalAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`total expected to be basetypes.Int64Value, was: %T`, totalAttribute))
+	}
+
+	unknownAttribute, ok := attributes["unknown"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`unknown is missing from object`)
+
+		return NewRiskAggregationsValueUnknown(), diags
+	}
+
+	unknownVal, ok := unknownAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`unknown expected to be basetypes.Int64Value, was: %T`, unknownAttribute))
+	}
+
+	if diags.HasError() {
+		return NewRiskAggregationsValueUnknown(), diags
+	}
+
+	return RiskAggregationsValue{
+		AtRisk:  atRiskVal,
+		OnTrack: onTrackVal,
+		Total:   totalVal,
+		Unknown: unknownVal,
+		state:   attr.ValueStateKnown,
+	}, diags
+}
+
+func NewRiskAggregationsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) RiskAggregationsValue {
+	object, diags := NewRiskAggregationsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewRiskAggregationsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t RiskAggregationsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewRiskAggregationsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewRiskAggregationsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewRiskAggregationsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewRiskAggregationsValueMust(RiskAggregationsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t RiskAggregationsType) ValueType(ctx context.Context) attr.Value {
+	return RiskAggregationsValue{}
+}
+
+var _ basetypes.ObjectValuable = RiskAggregationsValue{}
+
+type RiskAggregationsValue struct {
+	AtRisk  basetypes.Int64Value `tfsdk:"at_risk"`
+	OnTrack basetypes.Int64Value `tfsdk:"on_track"`
+	Total   basetypes.Int64Value `tfsdk:"total"`
+	Unknown basetypes.Int64Value `tfsdk:"unknown"`
+	state   attr.ValueState
+}
+
+func (v RiskAggregationsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 4)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["at_risk"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["on_track"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["total"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["unknown"] = basetypes.Int64Type{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 4)
+
+		val, err = v.AtRisk.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["at_risk"] = val
+
+		val, err = v.OnTrack.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["on_track"] = val
+
+		val, err = v.Total.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["total"] = val
+
+		val, err = v.Unknown.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["unknown"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v RiskAggregationsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v RiskAggregationsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v RiskAggregationsValue) String() string {
+	return "RiskAggregationsValue"
+}
+
+func (v RiskAggregationsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"at_risk":  basetypes.Int64Type{},
+		"on_track": basetypes.Int64Type{},
+		"total":    basetypes.Int64Type{},
+		"unknown":  basetypes.Int64Type{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"at_risk":  v.AtRisk,
+			"on_track": v.OnTrack,
+			"total":    v.Total,
+			"unknown":  v.Unknown,
+		})
+
+	return objVal, diags
+}
+
+func (v RiskAggregationsValue) Equal(o attr.Value) bool {
+	other, ok := o.(RiskAggregationsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AtRisk.Equal(other.AtRisk) {
+		return false
+	}
+
+	if !v.OnTrack.Equal(other.OnTrack) {
+		return false
+	}
+
+	if !v.Total.Equal(other.Total) {
+		return false
+	}
+
+	if !v.Unknown.Equal(other.Unknown) {
+		return false
+	}
+
+	return true
+}
+
+func (v RiskAggregationsValue) Type(ctx context.Context) attr.Type {
+	return RiskAggregationsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v RiskAggregationsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"at_risk":  basetypes.Int64Type{},
+		"on_track": basetypes.Int64Type{},
+		"total":    basetypes.Int64Type{},
+		"unknown":  basetypes.Int64Type{},
 	}
 }

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -310,6 +310,27 @@ func (e BudgetCreateUpdateRequestPublic) Valid() bool {
 	}
 }
 
+// Defines values for BudgetListItemRiskStatus.
+const (
+	BudgetListItemRiskStatusAtRisk  BudgetListItemRiskStatus = "atRisk"
+	BudgetListItemRiskStatusOnTrack BudgetListItemRiskStatus = "onTrack"
+	BudgetListItemRiskStatusUnknown BudgetListItemRiskStatus = "unknown"
+)
+
+// Valid indicates whether the value is a known member of the BudgetListItemRiskStatus enum.
+func (e BudgetListItemRiskStatus) Valid() bool {
+	switch e {
+	case BudgetListItemRiskStatusAtRisk:
+		return true
+	case BudgetListItemRiskStatusOnTrack:
+		return true
+	case BudgetListItemRiskStatusUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BudgetSuggestionConfidence.
 const (
 	BudgetSuggestionConfidenceHigh   BudgetSuggestionConfidence = "high"
@@ -5055,6 +5076,12 @@ type BudgetListItem struct {
 	Id                        *string           `json:"id,omitempty"`
 	Owner                     *string           `json:"owner,omitempty"`
 
+	// RiskStatus Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.
+	// "atRisk" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.
+	// "onTrack" - the budget has forecast data and is neither over budget nor projected to breach.
+	// "unknown" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft.
+	RiskStatus *BudgetListItemRiskStatus `json:"riskStatus,omitempty"`
+
 	// Scope List of allocations that define the budget scope.
 	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	Scope *[]string `json:"scope,omitempty"`
@@ -5066,6 +5093,12 @@ type BudgetListItem struct {
 	UpdateTime   *int64                  `json:"updateTime,omitempty"`
 	Url          *string                 `json:"url,omitempty"`
 }
+
+// BudgetListItemRiskStatus Server-computed risk classification, based on current utilization and forecasted breach date relative to the configured amount and current period end.
+// "atRisk" - the budget has already exceeded its configured amount, or its forecast projects it will before the current period ends.
+// "onTrack" - the budget has forecast data and is neither over budget nor projected to breach.
+// "unknown" - no forecast data is available yet, the budget is a fixed budget whose period has already expired, or the budget is invalid/draft.
+type BudgetListItemRiskStatus string
 
 // BudgetSuggestion An AI-generated budget recommendation.
 type BudgetSuggestion struct {
@@ -7829,6 +7862,9 @@ type ListBudgets200Response struct {
 	// PageToken Page token, returned by a previous call, to request the next page of results
 	PageToken *string `json:"pageToken,omitempty"`
 
+	// RiskAggregations Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page.
+	RiskAggregations *RiskAggregations `json:"riskAggregations,omitempty"`
+
 	// RowCount Budgets rows count
 	RowCount *int64 `json:"rowCount,omitempty"`
 }
@@ -8349,6 +8385,14 @@ type ResultsBody struct {
 
 	// Results List of insight results.
 	Results *[]InsightResponse `json:"results,omitempty"`
+}
+
+// RiskAggregations Aggregate counts of risk statuses across the full filtered result set (all pages), not just the current page.
+type RiskAggregations struct {
+	AtRisk  int64 `json:"atRisk"`
+	OnTrack int64 `json:"onTrack"`
+	Total   int64 `json:"total"`
+	Unknown int64 `json:"unknown"`
 }
 
 // Role Definition and permissions assigned to a role.
@@ -9274,7 +9318,9 @@ type ListBudgetsParams struct {
 	PageToken *PageToken `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 
 	// Filter An expression for filtering the results of the request. The syntax is "key:[<value>]".
-	// Available keys: owner, budgetName, lastModified in ms (>lasModified). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR".
+	// Available keys: owner, budgetName, lastModified in ms (>lasModified), riskStatus (one of "atRisk", "onTrack", "unknown"). Multiple filters can be connected using a pipe |. Note that using different keys in the same filter results in "AND," while using the same key multiple times in the same filter results in "OR" (except riskStatus, where only the first occurrence is honored).
+	// A budget is "atRisk" when it has already exceeded its configured amount, or its forecast projects it will exceed the configured amount before the current period ends. Budgets with no forecast data yet, a fixed budget whose period has already expired, or that are invalid/draft are classified "unknown". Filtering to riskStatus:atRisk sorts results by earliest projected breach date (day granularity) ascending instead of the default order; budgets that tie on breach day, including every already-breached budget, resolve to a fixed, repeatable order across requests rather than an arbitrary one.
+	// Because riskStatus is computed from live, periodically-refreshed budget data, paginated results filtered by riskStatus may shift between page requests if budget data refreshes mid-pagination.
 	Filter *string `form:"filter,omitempty" json:"filter,omitempty"`
 
 	// NameContains Case-insensitive substring match against the resource name. Combined with the "filter" parameter using AND semantics.
@@ -10652,6 +10698,7 @@ type ClientInterface interface {
 	// ListBudgets List budgets
 	//
 	// Returns a list of budgets that your account has access to. Budgets are listed in reverse chronological order by default.
+	// Each budget includes a server-computed `riskStatus` (`atRisk`, `onTrack`, or `unknown`), and the response includes a `riskAggregations` summary of risk counts across the full filtered result set (all pages, not just the current page).
 	//
 	// Corresponds with GET /analytics/v1/budgets (the `ListBudgets` operationId).
 	ListBudgets(ctx context.Context, params *ListBudgetsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -12215,6 +12262,7 @@ func (c *Client) ListBudgetSuggestions(ctx context.Context, reqEditors ...Reques
 // ListBudgets List budgets
 //
 // Returns a list of budgets that your account has access to. Budgets are listed in reverse chronological order by default.
+// Each budget includes a server-computed `riskStatus` (`atRisk`, `onTrack`, or `unknown`), and the response includes a `riskAggregations` summary of risk counts across the full filtered result set (all pages, not just the current page).
 //
 // Corresponds with GET /analytics/v1/budgets (the `ListBudgets` operationId).
 func (c *Client) ListBudgets(ctx context.Context, params *ListBudgetsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -21014,6 +21062,7 @@ type ClientWithResponsesInterface interface {
 	// ListBudgetsWithResponse List budgets
 	//
 	// Returns a list of budgets that your account has access to. Budgets are listed in reverse chronological order by default.
+	// Each budget includes a server-computed `riskStatus` (`atRisk`, `onTrack`, or `unknown`), and the response includes a `riskAggregations` summary of risk counts across the full filtered result set (all pages, not just the current page).
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -30657,6 +30706,7 @@ func (c *ClientWithResponses) ListBudgetSuggestionsWithResponse(ctx context.Cont
 // ListBudgetsWithResponse List budgets
 //
 // Returns a list of budgets that your account has access to. Budgets are listed in reverse chronological order by default.
+// Each budget includes a server-computed `riskStatus` (`atRisk`, `onTrack`, or `unknown`), and the response includes a `riskAggregations` summary of risk counts across the full filtered result set (all pages, not just the current page).
 //
 // Returns a wrapper object for the known response body format(s).
 //


### PR DESCRIPTION
## Summary
- Upstream added support for server-computed budget risk classification (`risk_status`) and aggregate counts across all pages (`risk_aggregations`) to the budgets list API, along with support for filtering by `riskStatus:atRisk|onTrack|unknown`.
- Wired the new attributes in the `doit_budgets` data source:
  - Mapped `risk_status` for each budget item in `datasource_budgets.NewBudgetsValue`.
  - Mapped `risk_aggregations` (`at_risk`, `on_track`, `total`, `unknown`) across both manual pagination and auto-pagination flows using `mapRiskAggregations()`.
  - Updated unknown input handling to set `data.RiskAggregations` to unknown when inputs are unknown.
- Updated documentation and examples:
  - Added `filter = "riskStatus:atRisk"` filter example, `risk_aggregations` output, and `risk_status` mapping in `examples/data-sources/doit_budgets/data-source.tf`.
  - Regenerated `docs/data-sources/budgets.md` via `make docs`.
- Added acceptance test coverage with drift checks:
  - Added `TestAccBudgetsDataSource_FilterByRiskStatus` with `ExpectEmptyPlan()` drift check.
  - Updated `TestAccBudgetsDataSource_MaxResultsOnly` to verify `budgets.0.risk_status` and `risk_aggregations.total`.
  - Updated `TestAccBudgetsDataSource_AutoPagination` to check `risk_aggregations` breakdown (`at_risk`, `on_track`, `total`, `unknown`).

## Test plan
- [x] `make test` — all unit tests pass
- [x] `make lint` (`./custom-gcl run`) — 0 issues
- [x] `make docs` / `make validate-examples` — all 88 examples validate cleanly
- [x] `make testacc-run TEST=TestAccBudgetsDataSource` — 6/6 acceptance tests pass