### PR TITLE
feat(report): support SchemaField id in report query and result data sources

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -11870,6 +11870,9 @@ components:
       type: object
       description: Schema of a report result column.
       properties:
+        id:
+          type: string
+          description: Stable allocation-group ID used to select the allocation dimension in report configurations. Omitted for other report columns.
         name:
           type: string
         type:

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -10611,6 +10611,9 @@ components:
       type: object
       description: Schema of a report result column.
       properties:
+        id:
+          type: string
+          description: Stable allocation-group ID used to select the allocation dimension in report configurations. Omitted for other report columns.
         name:
           type: string
         type:

--- a/docs/data-sources/report_query.md
+++ b/docs/data-sources/report_query.md
@@ -6,7 +6,8 @@ description: |-
   Runs an ad-hoc Cloud Analytics query without persisting a report.
   The query is executed with the provided config and results are returned as a JSON string in result_json. Use Terraform's jsondecode() to parse.
   ~> Note: Query results are dynamic — they change over time as new billing data is ingested. Every terraform plan will re-execute the query.
-  The result_json field contains the full result object, including the following keys: schema (column definitions, including name and type), rows (data rows, where each row is an array of values), forecastRows (forecast data rows, if applicable), secondaryRows (secondary time range rows, if applicable), and cacheHit (whether results were served from cache).
+  The result_json field contains the full result object including:
+  schema: Array of column metadata objects (name, type, and optional id for allocation dimensions)rows: Array of data rows, where each row is an array of cell values (string, number, or null)forecastRows: Array of forecast data rows (if applicable)secondaryRows: Array of secondary time range rows (if applicable)cacheHit: Whether results were served from cache
 ---
 
 # doit_report_query (Data Source)
@@ -17,7 +18,12 @@ The query is executed with the provided config and results are returned as a JSO
 
 ~> **Note:** Query results are dynamic — they change over time as new billing data is ingested. Every `terraform plan` will re-execute the query.
 
-The `result_json` field contains the full result object, including the following keys: `schema` (column definitions, including name and type), `rows` (data rows, where each row is an array of values), `forecastRows` (forecast data rows, if applicable), `secondaryRows` (secondary time range rows, if applicable), and `cacheHit` (whether results were served from cache).
+The `result_json` field contains the full result object including:
+- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)
+- `rows`: Array of data rows, where each row is an array of cell values (`string`, `number`, or `null`)
+- `forecastRows`: Array of forecast data rows (if applicable)
+- `secondaryRows`: Array of secondary time range rows (if applicable)
+- `cacheHit`: Whether results were served from cache
 
 ## Example Usage
 
@@ -62,7 +68,8 @@ data "doit_report_query" "cost_by_provider" {
 # Parse the JSON result
 locals {
   query_result = jsondecode(data.doit_report_query.cost_by_provider.result_json)
-  columns      = [for s in local.query_result.schema : s.name]
+  # Extract column names (each schema object has name, type, and optional allocation id)
+  columns = [for s in local.query_result.schema : s.name]
 }
 
 # Write results to a CSV file
@@ -93,7 +100,14 @@ output "row_count" {
 ### Read-Only
 
 - `cache_hit` (Boolean) If true, results were fetched from the cache.
-- `result_json` (String) The full query result as a JSON string. Contains `schema` (column definitions), `rows` (data), and metadata. Use `jsondecode()` to parse.
+- `result_json` (String) The full query result as a JSON string. Use `jsondecode()` to parse.
+
+Structure of the decoded JSON object:
+- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions).
+- `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns.
+- `forecastRows`: Array of forecast row arrays (if applicable).
+- `secondaryRows`: Array of secondary time range row arrays (if applicable).
+- `cacheHit`: Boolean indicating if the result was served from cache.
 - `row_count` (Number) The number of data rows in the result.
 
 <a id="nestedatt--config"></a>

--- a/docs/data-sources/report_result.md
+++ b/docs/data-sources/report_result.md
@@ -7,7 +7,7 @@ description: |-
   The report is executed and the results are returned as a JSON string in result_json. Use Terraform's jsondecode() to parse the results.
   ~> Note: Report results are dynamic — they change over time as new billing data is ingested. Every terraform plan will re-execute the report.
   The result_json field contains the full result object including:
-  schema: Column definitions (name and type)rows: Data rows (each row is an array of values)forecastRows: Forecast data rows (if applicable)secondaryRows: Secondary time range rows (if applicable)cacheHit: Whether results were served from cache
+  schema: Array of column metadata objects (name, type, and optional id for allocation dimensions)rows: Data rows (each row is an array of cell values: string, number, or null)forecastRows: Forecast data rows (if applicable)secondaryRows: Secondary time range rows (if applicable)cacheHit: Whether results were served from cache
 ---
 
 # doit_report_result (Data Source)
@@ -19,8 +19,8 @@ The report is executed and the results are returned as a JSON string in `result_
 ~> **Note:** Report results are dynamic — they change over time as new billing data is ingested. Every `terraform plan` will re-execute the report.
 
 The `result_json` field contains the full result object including:
-- `schema`: Column definitions (name and type)
-- `rows`: Data rows (each row is an array of values)
+- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)
+- `rows`: Data rows (each row is an array of cell values: string, number, or null)
 - `forecastRows`: Forecast data rows (if applicable)
 - `secondaryRows`: Secondary time range rows (if applicable)
 - `cacheHit`: Whether results were served from cache
@@ -36,6 +36,7 @@ data "doit_report_result" "example" {
 # Parse the JSON results
 locals {
   result  = jsondecode(data.doit_report_result.example.result_json)
+  # Extract column names (each schema object has name, type, and optional allocation id)
   columns = [for s in local.result.schema : s.name]
 }
 
@@ -80,7 +81,14 @@ data "doit_report_result" "last_week" {
 
 - `cache_hit` (Boolean) If true, results were fetched from the cache.
 - `report_name` (String) The name of the report.
-- `result_json` (String) The full report result as a JSON string. Contains `schema` (column definitions), `rows` (data), and metadata. Use `jsondecode()` to parse.
+- `result_json` (String) The full report result as a JSON string. Use `jsondecode()` to parse.
+
+Structure of the decoded JSON object:
+- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions).
+- `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns.
+- `forecastRows`: Array of forecast row arrays (if applicable).
+- `secondaryRows`: Array of secondary time range row arrays (if applicable).
+- `cacheHit`: Boolean indicating if the result was served from cache.
 - `row_count` (Number) The number of data rows in the result.
 
 <a id="nestedatt--timeouts"></a>

--- a/examples/data-sources/doit_report_query/data-source.tf
+++ b/examples/data-sources/doit_report_query/data-source.tf
@@ -38,7 +38,8 @@ data "doit_report_query" "cost_by_provider" {
 # Parse the JSON result
 locals {
   query_result = jsondecode(data.doit_report_query.cost_by_provider.result_json)
-  columns      = [for s in local.query_result.schema : s.name]
+  # Extract column names (each schema object has name, type, and optional allocation id)
+  columns = [for s in local.query_result.schema : s.name]
 }
 
 # Write results to a CSV file

--- a/examples/data-sources/doit_report_result/data-source.tf
+++ b/examples/data-sources/doit_report_result/data-source.tf
@@ -6,6 +6,7 @@ data "doit_report_result" "example" {
 # Parse the JSON results
 locals {
   result  = jsondecode(data.doit_report_result.example.result_json)
+  # Extract column names (each schema object has name, type, and optional allocation id)
   columns = [for s in local.result.schema : s.name]
 }
 

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -8438,6 +8438,8 @@ type RunReportResultResultMlFeatures string
 
 // SchemaField Schema of a report result column.
 type SchemaField struct {
+	// Id Stable allocation-group ID used to select the allocation dimension in report configurations. Omitted for other report columns.
+	Id   *string `json:"id,omitempty"`
 	Name *string `json:"name,omitempty"`
 	Type *string `json:"type,omitempty"`
 }

--- a/internal/provider/report_query_data_source.go
+++ b/internal/provider/report_query_data_source.go
@@ -91,19 +91,20 @@ func (d *reportQueryDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 			"\n\nNote: Query results are dynamic — they change over time as new billing" +
 			" data is ingested. Every terraform plan will re-execute the query." +
 			"\n\nThe result_json field contains the full result object, including the" +
-			" schema (column definitions), rows (data), forecastRows (forecast data)," +
-			" secondaryRows (secondary time range data), and cacheHit (whether results" +
-			" were served from cache).",
+			" schema (column definitions: name, type, and optional id), rows (data)," +
+			" forecastRows (forecast data), secondaryRows (secondary time range data)," +
+			" and cacheHit (whether results were served from cache).",
 		MarkdownDescription: "Runs an ad-hoc Cloud Analytics query without persisting a report." +
 			"\n\nThe query is executed with the provided config and results are returned" +
 			" as a JSON string in `result_json`. Use Terraform's `jsondecode()` to parse." +
 			"\n\n~> **Note:** Query results are dynamic — they change over time as new" +
 			" billing data is ingested. Every `terraform plan` will re-execute the query." +
-			"\n\nThe `result_json` field contains the full result object, including the following" +
-			" keys: `schema` (column definitions, including name and type), `rows` (data" +
-			" rows, where each row is an array of values), `forecastRows` (forecast data" +
-			" rows, if applicable), `secondaryRows` (secondary time range rows, if" +
-			" applicable), and `cacheHit` (whether results were served from cache).",
+			"\n\nThe `result_json` field contains the full result object including:" +
+			"\n- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)" +
+			"\n- `rows`: Array of data rows, where each row is an array of cell values (`string`, `number`, or `null`)" +
+			"\n- `forecastRows`: Array of forecast data rows (if applicable)" +
+			"\n- `secondaryRows`: Array of secondary time range rows (if applicable)" +
+			"\n- `cacheHit`: Whether results were served from cache",
 		Attributes: map[string]dsschema.Attribute{
 			// --- Input ---
 			"config": dsschema.SingleNestedAttribute{
@@ -117,11 +118,15 @@ func (d *reportQueryDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 			// --- Outputs ---
 			"result_json": dsschema.StringAttribute{
 				Description: "The full query result as a JSON string. " +
-					"Contains schema (column definitions), rows (data), and metadata. " +
+					"Contains schema (column definitions including name, type, and optional id), rows (data), and metadata. " +
 					"Use jsondecode() to parse.",
-				MarkdownDescription: "The full query result as a JSON string. " +
-					"Contains `schema` (column definitions), `rows` (data), and metadata. " +
-					"Use `jsondecode()` to parse.",
+				MarkdownDescription: "The full query result as a JSON string. Use `jsondecode()` to parse." +
+					"\n\nStructure of the decoded JSON object:" +
+					"\n- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions)." +
+					"\n- `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns." +
+					"\n- `forecastRows`: Array of forecast row arrays (if applicable)." +
+					"\n- `secondaryRows`: Array of secondary time range row arrays (if applicable)." +
+					"\n- `cacheHit`: Boolean indicating if the result was served from cache.",
 				Computed: true,
 			},
 			"cache_hit": dsschema.BoolAttribute{

--- a/internal/provider/report_query_data_source_test.go
+++ b/internal/provider/report_query_data_source_test.go
@@ -1,12 +1,15 @@
 package provider_test
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -718,4 +721,107 @@ data "doit_report_query" "test" {
     }
 }
 `
+}
+
+// TestAccReportQueryDataSource_AllocationSchemaFieldID verifies that when a query
+// is configured with an allocation dimension, the returned schema contains the
+// allocation's id.
+func TestAccReportQueryDataSource_AllocationSchemaFieldID(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tfacc-rq-alloc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportQueryDataSourceAllocationConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("doit_allocation.group", "id"),
+					resource.TestCheckOutput("schema_id_matches_allocation", "true"),
+					func(s *terraform.State) error {
+						allocRes, ok := s.RootModule().Resources["doit_allocation.group"]
+						if !ok {
+							return fmt.Errorf("resource doit_allocation.group not found")
+						}
+						schemaID := s.RootModule().Outputs["allocation_schema_id"].Value.(string)
+						if schemaID != allocRes.Primary.ID {
+							return fmt.Errorf("expected schema id %q, got %q", allocRes.Primary.ID, schemaID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccReportQueryDataSourceAllocationConfig(name string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "group" {
+    name              = "%[1]s-group"
+    description       = "test allocation group"
+    unallocated_costs = "%[1]s-other"
+    rules = [
+        {
+            action  = "create"
+            name    = "%[1]s-rule"
+            formula = "A"
+            components = [
+                {
+                    key    = "country"
+                    mode   = "is"
+                    type   = "fixed"
+                    values = ["US"]
+                }
+            ]
+        }
+    ]
+}
+
+data "doit_report_query" "test" {
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode            = "last"
+          amount          = 3
+          unit            = "month"
+          include_current = false
+        }
+        group = [
+          {
+            id   = doit_allocation.group.id
+            type = "allocation"
+          }
+        ]
+    }
+}
+
+locals {
+  query_result = jsondecode(data.doit_report_query.test.result_json)
+  allocation_fields = [
+    for field in local.query_result.schema : field
+    if lookup(field, "id", "") == doit_allocation.group.id
+  ]
+}
+
+output "allocation_schema_id" {
+  value = length(local.allocation_fields) > 0 ? lookup(local.allocation_fields[0], "id", "") : ""
+}
+
+output "schema_id_matches_allocation" {
+  value = tostring(length(local.allocation_fields) > 0 && lookup(local.allocation_fields[0], "id", "") == doit_allocation.group.id)
+}
+`, name)
 }

--- a/internal/provider/report_result_data_source.go
+++ b/internal/provider/report_result_data_source.go
@@ -70,9 +70,9 @@ func (d *reportResultDataSource) Schema(ctx context.Context, _ datasource.Schema
 			" billing data is ingested. Every terraform plan will re-execute the" +
 			" report." +
 			"\n\nThe result_json field contains the full result object, including the" +
-			" schema (column definitions), rows (data), forecastRows (forecast data)," +
-			" secondaryRows (secondary time range data), and cacheHit (whether results" +
-			" were served from cache).",
+			" schema (column definitions: name, type, and optional id), rows (data)," +
+			" forecastRows (forecast data), secondaryRows (secondary time range data)," +
+			" and cacheHit (whether results were served from cache).",
 		MarkdownDescription: "Fetches the results of an existing Cloud Analytics report." +
 			"\n\nThe report is executed and the results are returned as a JSON string in" +
 			" `result_json`. Use Terraform's `jsondecode()` to parse the results." +
@@ -80,8 +80,8 @@ func (d *reportResultDataSource) Schema(ctx context.Context, _ datasource.Schema
 			" billing data is ingested. Every `terraform plan` will re-execute the" +
 			" report." +
 			"\n\nThe `result_json` field contains the full result object including:" +
-			"\n- `schema`: Column definitions (name and type)" +
-			"\n- `rows`: Data rows (each row is an array of values)" +
+			"\n- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)" +
+			"\n- `rows`: Data rows (each row is an array of cell values: string, number, or null)" +
 			"\n- `forecastRows`: Forecast data rows (if applicable)" +
 			"\n- `secondaryRows`: Secondary time range rows (if applicable)" +
 			"\n- `cacheHit`: Whether results were served from cache",
@@ -135,11 +135,15 @@ func (d *reportResultDataSource) Schema(ctx context.Context, _ datasource.Schema
 			// --- Outputs ---
 			"result_json": schema.StringAttribute{
 				Description: "The full report result as a JSON string. " +
-					"Contains schema (column definitions), rows (data), and metadata. " +
+					"Contains schema (column definitions including name, type, and optional id), rows (data), and metadata. " +
 					"Use jsondecode() to parse.",
-				MarkdownDescription: "The full report result as a JSON string. " +
-					"Contains `schema` (column definitions), `rows` (data), and metadata. " +
-					"Use `jsondecode()` to parse.",
+				MarkdownDescription: "The full report result as a JSON string. Use `jsondecode()` to parse." +
+					"\n\nStructure of the decoded JSON object:" +
+					"\n- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions)." +
+					"\n- `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns." +
+					"\n- `forecastRows`: Array of forecast row arrays (if applicable)." +
+					"\n- `secondaryRows`: Array of secondary time range row arrays (if applicable)." +
+					"\n- `cacheHit`: Boolean indicating if the result was served from cache.",
 				Computed: true,
 			},
 			"report_name": schema.StringAttribute{

--- a/internal/provider/report_result_data_source_test.go
+++ b/internal/provider/report_result_data_source_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -249,4 +250,113 @@ data "doit_report_result" "test" {
     id = "non-existent-report-id"
 }
 `
+}
+
+// TestAccReportResultDataSource_AllocationSchemaFieldID verifies that when a saved
+// report is configured with an allocation dimension, reading its results via the
+// data source returns the allocation's id in the schema metadata.
+func TestAccReportResultDataSource_AllocationSchemaFieldID(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tfacc-rr-alloc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportResultDataSourceAllocationConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("doit_allocation.group", "id"),
+					resource.TestCheckOutput("schema_id_matches_allocation", "true"),
+					func(s *terraform.State) error {
+						allocRes, ok := s.RootModule().Resources["doit_allocation.group"]
+						if !ok {
+							return fmt.Errorf("resource doit_allocation.group not found")
+						}
+						schemaID := s.RootModule().Outputs["allocation_schema_id"].Value.(string)
+						if schemaID != allocRes.Primary.ID {
+							return fmt.Errorf("expected schema id %q, got %q", allocRes.Primary.ID, schemaID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccReportResultDataSourceAllocationConfig(name string) string {
+	return fmt.Sprintf(`
+resource "doit_allocation" "group" {
+    name              = "%[1]s-group"
+    description       = "test allocation group"
+    unallocated_costs = "%[1]s-other"
+    rules = [
+        {
+            action  = "create"
+            name    = "%[1]s-rule"
+            formula = "A"
+            components = [
+                {
+                    key    = "country"
+                    mode   = "is"
+                    type   = "fixed"
+                    values = ["US"]
+                }
+            ]
+        }
+    ]
+}
+
+resource "doit_report" "test" {
+    name        = "%[1]s-report"
+    description = "test report with allocation dimension read through report_result"
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode            = "last"
+          amount          = 3
+          unit            = "month"
+          include_current = false
+        }
+        group = [
+          {
+            id   = doit_allocation.group.id
+            type = "allocation"
+          }
+        ]
+    }
+}
+
+data "doit_report_result" "test" {
+    id = doit_report.test.id
+}
+
+locals {
+  result_payload = jsondecode(data.doit_report_result.test.result_json)
+  allocation_fields = [
+    for field in local.result_payload.schema : field
+    if lookup(field, "id", "") == doit_allocation.group.id
+  ]
+}
+
+output "allocation_schema_id" {
+  value = length(local.allocation_fields) > 0 ? lookup(local.allocation_fields[0], "id", "") : ""
+}
+
+output "schema_id_matches_allocation" {
+  value = tostring(length(local.allocation_fields) > 0 && lookup(local.allocation_fields[0], "id", "") == doit_allocation.group.id)
+}
+`, name)
 }


### PR DESCRIPTION
## Summary

Upstream Cloud Analytics API added an `id` field to `SchemaField` in report results and ad-hoc query responses, populated with the allocation ID when grouping by allocations.

This PR updates the provider to support this new field:
- Adds `Id *string` to `models.SchemaField` in the generated OpenAPI models.
- Updates documentation and schema `MarkdownDescription` for `doit_report_query` and `doit_report_result` to explain how column metadata in `result_json` can be decoded (including the `id` field on allocation dimensions).
- Updates HCL examples to show how to decode and inspect `schema` and `rows`.
- Adds acceptance tests `TestAccReportQueryDataSource_AllocationSchemaFieldID` and `TestAccReportResultDataSource_AllocationSchemaFieldID` to verify that `result_json` schema contains the expected `id` when configured with an allocation dimension.

## Changes
- `OpenAPI/openapi_spec_full.yml`, `OpenAPI/openapi_spec_processed.yml`: Updated OpenAPI spec with `id` on `SchemaField`.
- `internal/provider/models/models_gen.go`: Generated models updated with `Id *string `json:"id,omitempty"``.
- `internal/provider/report_query_data_source.go`, `internal/provider/report_result_data_source.go`: Updated docstrings for `result_json`.
- `examples/data-sources/doit_report_query/data-source.tf`, `examples/data-sources/doit_report_result/data-source.tf`: Added examples for decoding `result_json` and inspecting column metadata.
- `docs/data-sources/report_query.md`, `docs/data-sources/report_result.md`: Regenerated docs via `make docs`.
- `internal/provider/report_query_data_source_test.go`, `internal/provider/report_result_data_source_test.go`: Added acceptance tests asserting `id` presence in `schema` on allocation-configured queries/reports.

## Validation
- `make fmt`: Clean
- `make lint`: 0 issues
- `make test`: All unit tests passing
- `make testacc-run TEST=TestAccReportQueryDataSource_AllocationSchemaFieldID`: PASS
- `make testacc-run TEST=TestAccReportResultDataSource_AllocationSchemaFieldID`: PASS