### PR TITLE
feat(report): support SchemaField metadata in report query and result data sources

### DIFF
--- a/OpenAPI/openapi_spec_full.yml
+++ b/OpenAPI/openapi_spec_full.yml
@@ -12384,6 +12384,33 @@ components:
             cacheHit:
               type: boolean
               description: If true, results were fetched from the cache.
+      example:
+        id: rpt_dummy001abc
+        reportName: Monthly Cost by Service
+        owner: customer@example.com
+        type: custom
+        createTime: 1704067200000
+        updateTime: 1706745600000
+        urlUI: https://console.doit.com/customers/cust_dummy123/analyze/reports/rpt_dummy001abc
+        labels: []
+        result:
+          schema:
+            - name: service_description
+              type: string
+            - name: cost
+              type: float
+              unit: currency
+              currency: USD
+              aggregation: total
+            - name: usage
+              type: float
+              unit: number
+              aggregation: total
+          rows:
+            - ["Amazon Elastic Compute Cloud", 4821.37, 12450]
+            - ["Cloud Storage", 912.05, 893021]
+            - ["BigQuery", 356.88, 42]
+          cacheHit: true
     Report:
       type: object
       description: Report metadata and the console URL.
@@ -12477,6 +12504,21 @@ components:
             cacheHit:
               type: boolean
               description: If true, results were fetched from the cache.
+      example:
+        result:
+          schema:
+            - name: service_description
+              type: string
+            - name: cost
+              type: float
+              unit: currency
+              currency: USD
+              aggregation: total
+          rows:
+            - ["Amazon Elastic Compute Cloud", 4821.37]
+            - ["Cloud Storage", 912.05]
+            - ["BigQuery", 356.88]
+          cacheHit: false
     SchemaField:
       type: object
       description: Schema of a report result column.
@@ -12486,8 +12528,40 @@ components:
           description: Stable allocation-group ID used to select the allocation dimension in report configurations. Omitted for other report columns.
         name:
           type: string
+          description: Column name. Matches the corresponding value position in each row.
         type:
           type: string
+          description: >-
+            Wire-format type of the column values. Dimension columns use string;
+            metric columns use float (cost, usage, saving, custom, and extended
+            metrics) or integer (count aggregation). Time-series reports include
+            a timestamp column.
+          enum:
+            - string
+            - float
+            - integer
+            - timestamp
+        unit:
+          type: string
+          description: Semantic unit of the column values.
+          enum:
+            - currency
+            - number
+            - percent
+        currency:
+          type: string
+          description: Effective ISO 4217 currency code when unit is currency.
+          example: USD
+        aggregation:
+          type: string
+          description: Authoritative aggregation applied to this metric column.
+          enum:
+            - total
+            - percent_total
+            - percent_col
+            - percent_row
+            - total_over_total
+            - count
     SlackChannel:
       type: object
       description: >-

--- a/OpenAPI/openapi_spec_processed.yml
+++ b/OpenAPI/openapi_spec_processed.yml
@@ -9294,6 +9294,33 @@ components:
           description: List of labels associated with the report.
         result:
           $ref: '#/components/schemas/GetReportResponseResult'
+      example:
+        id: rpt_dummy001abc
+        reportName: Monthly Cost by Service
+        owner: customer@example.com
+        type: custom
+        createTime: 1704067200000
+        updateTime: 1706745600000
+        urlUI: https://console.doit.com/customers/cust_dummy123/analyze/reports/rpt_dummy001abc
+        labels: []
+        result:
+          schema:
+            - name: service_description
+              type: string
+            - name: cost
+              type: float
+              unit: currency
+              currency: USD
+              aggregation: total
+            - name: usage
+              type: float
+              unit: number
+              aggregation: total
+          rows:
+            - ["Amazon Elastic Compute Cloud", 4821.37, 12450]
+            - ["Cloud Storage", 912.05, 893021]
+            - ["BigQuery", 356.88, 42]
+          cacheHit: true
     GetReportResponseResult:
       type: object
       properties:
@@ -10574,6 +10601,21 @@ components:
       properties:
         result:
           $ref: '#/components/schemas/RunReportResultResult'
+      example:
+        result:
+          schema:
+            - name: service_description
+              type: string
+            - name: cost
+              type: float
+              unit: currency
+              currency: USD
+              aggregation: total
+          rows:
+            - ["Amazon Elastic Compute Cloud", 4821.37]
+            - ["Cloud Storage", 912.05]
+            - ["BigQuery", 356.88]
+          cacheHit: false
     RunReportResultResult:
       type: object
       properties:
@@ -10621,8 +10663,37 @@ components:
           description: Stable allocation-group ID used to select the allocation dimension in report configurations. Omitted for other report columns.
         name:
           type: string
+          description: Column name. Matches the corresponding value position in each row.
         type:
           type: string
+          description: >-
+            Wire-format type of the column values. Dimension columns use string; metric columns use float (cost, usage, saving, custom, and extended metrics) or integer (count aggregation). Time-series reports include a timestamp column.
+          enum:
+            - string
+            - float
+            - integer
+            - timestamp
+        unit:
+          type: string
+          description: Semantic unit of the column values.
+          enum:
+            - currency
+            - number
+            - percent
+        currency:
+          type: string
+          description: Effective ISO 4217 currency code when unit is currency.
+          example: USD
+        aggregation:
+          type: string
+          description: Authoritative aggregation applied to this metric column.
+          enum:
+            - total
+            - percent_total
+            - percent_col
+            - percent_row
+            - total_over_total
+            - count
     Seats:
       type: object
       description: Licensing seat counts for a subscription.

--- a/docs/data-sources/report_query.md
+++ b/docs/data-sources/report_query.md
@@ -69,7 +69,7 @@ data "doit_report_query" "cost_by_provider" {
 locals {
   query_result = jsondecode(data.doit_report_query.cost_by_provider.result_json)
   # Extract column names (schema objects contain name, type, and optional unit, currency, aggregation, id)
-  columns      = [for s in local.query_result.schema : s.name]
+  columns = [for s in local.query_result.schema : s.name]
 }
 
 # Write results to a CSV file

--- a/docs/data-sources/report_query.md
+++ b/docs/data-sources/report_query.md
@@ -7,7 +7,7 @@ description: |-
   The query is executed with the provided config and results are returned as a JSON string in result_json. Use Terraform's jsondecode() to parse.
   ~> Note: Query results are dynamic — they change over time as new billing data is ingested. Every terraform plan will re-execute the query.
   The result_json field contains the full result object including:
-  schema: Array of column metadata objects (name, type, and optional id for allocation dimensions)rows: Array of data rows, where each row is an array of cell values (string, number, or null)forecastRows: Array of forecast data rows (if applicable)secondaryRows: Array of secondary time range rows (if applicable)cacheHit: Whether results were served from cache
+  schema: Array of column metadata objects (name, type, and optional unit, currency, aggregation, and id for allocation dimensions)rows: Array of data rows, where each row is an array of cell values (string, number, or null)forecastRows: Array of forecast data rows (if applicable)secondaryRows: Array of secondary time range rows (if applicable)cacheHit: Whether results were served from cache
 ---
 
 # doit_report_query (Data Source)
@@ -19,7 +19,7 @@ The query is executed with the provided config and results are returned as a JSO
 ~> **Note:** Query results are dynamic — they change over time as new billing data is ingested. Every `terraform plan` will re-execute the query.
 
 The `result_json` field contains the full result object including:
-- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)
+- `schema`: Array of column metadata objects (`name`, `type`, and optional `unit`, `currency`, `aggregation`, and `id` for allocation dimensions)
 - `rows`: Array of data rows, where each row is an array of cell values (`string`, `number`, or `null`)
 - `forecastRows`: Array of forecast data rows (if applicable)
 - `secondaryRows`: Array of secondary time range rows (if applicable)
@@ -68,8 +68,8 @@ data "doit_report_query" "cost_by_provider" {
 # Parse the JSON result
 locals {
   query_result = jsondecode(data.doit_report_query.cost_by_provider.result_json)
-  # Extract column names (each schema object has name, type, and optional allocation id)
-  columns = [for s in local.query_result.schema : s.name]
+  # Extract column names (schema objects contain name, type, and optional unit, currency, aggregation, id)
+  columns      = [for s in local.query_result.schema : s.name]
 }
 
 # Write results to a CSV file
@@ -103,7 +103,7 @@ output "row_count" {
 - `result_json` (String) The full query result as a JSON string. Use `jsondecode()` to parse.
 
 Structure of the decoded JSON object:
-- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions).
+- `schema`: Array of column definitions: `name` (string), `type` (string: `string`, `float`, `integer`, `timestamp`), and optional fields `unit` (`currency`, `number`, `percent`), `currency` (ISO 4217 code), `aggregation` (`total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`), and `id` (present for allocation dimensions).
 - `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns.
 - `forecastRows`: Array of forecast row arrays (if applicable).
 - `secondaryRows`: Array of secondary time range row arrays (if applicable).

--- a/docs/data-sources/report_result.md
+++ b/docs/data-sources/report_result.md
@@ -7,7 +7,7 @@ description: |-
   The report is executed and the results are returned as a JSON string in result_json. Use Terraform's jsondecode() to parse the results.
   ~> Note: Report results are dynamic — they change over time as new billing data is ingested. Every terraform plan will re-execute the report.
   The result_json field contains the full result object including:
-  schema: Array of column metadata objects (name, type, and optional id for allocation dimensions)rows: Data rows (each row is an array of cell values: string, number, or null)forecastRows: Forecast data rows (if applicable)secondaryRows: Secondary time range rows (if applicable)cacheHit: Whether results were served from cache
+  schema: Array of column metadata objects (name, type, and optional unit, currency, aggregation, and id for allocation dimensions)rows: Data rows (each row is an array of cell values: string, number, or null)forecastRows: Forecast data rows (if applicable)secondaryRows: Secondary time range rows (if applicable)cacheHit: Whether results were served from cache
 ---
 
 # doit_report_result (Data Source)
@@ -19,7 +19,7 @@ The report is executed and the results are returned as a JSON string in `result_
 ~> **Note:** Report results are dynamic — they change over time as new billing data is ingested. Every `terraform plan` will re-execute the report.
 
 The `result_json` field contains the full result object including:
-- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)
+- `schema`: Array of column metadata objects (`name`, `type`, and optional `unit`, `currency`, `aggregation`, and `id` for allocation dimensions)
 - `rows`: Data rows (each row is an array of cell values: string, number, or null)
 - `forecastRows`: Forecast data rows (if applicable)
 - `secondaryRows`: Secondary time range rows (if applicable)
@@ -35,8 +35,8 @@ data "doit_report_result" "example" {
 
 # Parse the JSON results
 locals {
-  result  = jsondecode(data.doit_report_result.example.result_json)
-  # Extract column names (each schema object has name, type, and optional allocation id)
+  result = jsondecode(data.doit_report_result.example.result_json)
+  # Extract column names (schema objects contain name, type, and optional unit, currency, aggregation, id)
   columns = [for s in local.result.schema : s.name]
 }
 
@@ -84,7 +84,7 @@ data "doit_report_result" "last_week" {
 - `result_json` (String) The full report result as a JSON string. Use `jsondecode()` to parse.
 
 Structure of the decoded JSON object:
-- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions).
+- `schema`: Array of column definitions: `name` (string), `type` (string: `string`, `float`, `integer`, `timestamp`), and optional fields `unit` (`currency`, `number`, `percent`), `currency` (ISO 4217 code), `aggregation` (`total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`), and `id` (present for allocation dimensions).
 - `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns.
 - `forecastRows`: Array of forecast row arrays (if applicable).
 - `secondaryRows`: Array of secondary time range row arrays (if applicable).

--- a/examples/data-sources/doit_report_query/data-source.tf
+++ b/examples/data-sources/doit_report_query/data-source.tf
@@ -38,7 +38,7 @@ data "doit_report_query" "cost_by_provider" {
 # Parse the JSON result
 locals {
   query_result = jsondecode(data.doit_report_query.cost_by_provider.result_json)
-  # Extract column names (each schema object has name, type, and optional allocation id)
+  # Extract column names (schema objects contain name, type, and optional unit, currency, aggregation, id)
   columns = [for s in local.query_result.schema : s.name]
 }
 

--- a/examples/data-sources/doit_report_result/data-source.tf
+++ b/examples/data-sources/doit_report_result/data-source.tf
@@ -5,8 +5,8 @@ data "doit_report_result" "example" {
 
 # Parse the JSON results
 locals {
-  result  = jsondecode(data.doit_report_result.example.result_json)
-  # Extract column names (each schema object has name, type, and optional allocation id)
+  result = jsondecode(data.doit_report_result.example.result_json)
+  # Extract column names (schema objects contain name, type, and optional unit, currency, aggregation, id)
   columns = [for s in local.result.schema : s.name]
 }
 

--- a/internal/provider/allocation.go
+++ b/internal/provider/allocation.go
@@ -250,8 +250,8 @@ func (plan *allocationResourceModel) fillAllocationCommon(ctx context.Context, r
 					idVal := planRules[i].Id.ValueString()
 					if idVal != "" {
 						rule.Id = &idVal
-						if rule.Action == models.Create || rule.Action == "create" {
-							rule.Action = models.Update
+						if rule.Action == models.GroupAllocationRuleActionCreate || rule.Action == "create" {
+							rule.Action = models.GroupAllocationRuleActionUpdate
 						}
 					}
 				}

--- a/internal/provider/models/models.yml
+++ b/internal/provider/models/models.yml
@@ -4,6 +4,8 @@ output: models_gen.go
 generate:
   models: true
   client: true
+compatibility:
+  always-prefix-enum-values: true
 output-options:
   response-type-suffix: Resp
   nullable-type: true

--- a/internal/provider/models/models_gen.go
+++ b/internal/provider/models/models_gen.go
@@ -273,16 +273,16 @@ func (e BudgetAPIPublic) Valid() bool {
 
 // Defines values for BudgetCreateUpdateRequestMetric.
 const (
-	AmortizedCost BudgetCreateUpdateRequestMetric = "amortized_cost"
-	Cost          BudgetCreateUpdateRequestMetric = "cost"
+	BudgetCreateUpdateRequestMetricAmortizedCost BudgetCreateUpdateRequestMetric = "amortized_cost"
+	BudgetCreateUpdateRequestMetricCost          BudgetCreateUpdateRequestMetric = "cost"
 )
 
 // Valid indicates whether the value is a known member of the BudgetCreateUpdateRequestMetric enum.
 func (e BudgetCreateUpdateRequestMetric) Valid() bool {
 	switch e {
-	case AmortizedCost:
+	case BudgetCreateUpdateRequestMetricAmortizedCost:
 		return true
-	case Cost:
+	case BudgetCreateUpdateRequestMetricCost:
 		return true
 	default:
 		return false
@@ -1257,76 +1257,76 @@ func (e CreateLabelRequestColor) Valid() bool {
 
 // Defines values for Currency.
 const (
-	AED Currency = "AED"
-	AUD Currency = "AUD"
-	BRL Currency = "BRL"
-	CAD Currency = "CAD"
-	CHF Currency = "CHF"
-	COP Currency = "COP"
-	DKK Currency = "DKK"
-	EGP Currency = "EGP"
-	EUR Currency = "EUR"
-	GBP Currency = "GBP"
-	IDR Currency = "IDR"
-	ILS Currency = "ILS"
-	JPY Currency = "JPY"
-	MXN Currency = "MXN"
-	MYR Currency = "MYR"
-	NOK Currency = "NOK"
-	SEK Currency = "SEK"
-	SGD Currency = "SGD"
-	THB Currency = "THB"
-	TWD Currency = "TWD"
-	USD Currency = "USD"
-	ZAR Currency = "ZAR"
+	CurrencyAED Currency = "AED"
+	CurrencyAUD Currency = "AUD"
+	CurrencyBRL Currency = "BRL"
+	CurrencyCAD Currency = "CAD"
+	CurrencyCHF Currency = "CHF"
+	CurrencyCOP Currency = "COP"
+	CurrencyDKK Currency = "DKK"
+	CurrencyEGP Currency = "EGP"
+	CurrencyEUR Currency = "EUR"
+	CurrencyGBP Currency = "GBP"
+	CurrencyIDR Currency = "IDR"
+	CurrencyILS Currency = "ILS"
+	CurrencyJPY Currency = "JPY"
+	CurrencyMXN Currency = "MXN"
+	CurrencyMYR Currency = "MYR"
+	CurrencyNOK Currency = "NOK"
+	CurrencySEK Currency = "SEK"
+	CurrencySGD Currency = "SGD"
+	CurrencyTHB Currency = "THB"
+	CurrencyTWD Currency = "TWD"
+	CurrencyUSD Currency = "USD"
+	CurrencyZAR Currency = "ZAR"
 )
 
 // Valid indicates whether the value is a known member of the Currency enum.
 func (e Currency) Valid() bool {
 	switch e {
-	case AED:
+	case CurrencyAED:
 		return true
-	case AUD:
+	case CurrencyAUD:
 		return true
-	case BRL:
+	case CurrencyBRL:
 		return true
-	case CAD:
+	case CurrencyCAD:
 		return true
-	case CHF:
+	case CurrencyCHF:
 		return true
-	case COP:
+	case CurrencyCOP:
 		return true
-	case DKK:
+	case CurrencyDKK:
 		return true
-	case EGP:
+	case CurrencyEGP:
 		return true
-	case EUR:
+	case CurrencyEUR:
 		return true
-	case GBP:
+	case CurrencyGBP:
 		return true
-	case IDR:
+	case CurrencyIDR:
 		return true
-	case ILS:
+	case CurrencyILS:
 		return true
-	case JPY:
+	case CurrencyJPY:
 		return true
-	case MXN:
+	case CurrencyMXN:
 		return true
-	case MYR:
+	case CurrencyMYR:
 		return true
-	case NOK:
+	case CurrencyNOK:
 		return true
-	case SEK:
+	case CurrencySEK:
 		return true
-	case SGD:
+	case CurrencySGD:
 		return true
-	case THB:
+	case CurrencyTHB:
 		return true
-	case TWD:
+	case CurrencyTWD:
 		return true
-	case USD:
+	case CurrencyUSD:
 		return true
-	case ZAR:
+	case CurrencyZAR:
 		return true
 	default:
 		return false
@@ -1512,22 +1512,22 @@ func (e DimensionsTypes) Valid() bool {
 
 // Defines values for DismissalDetailsReason.
 const (
-	InaccurateOptimizationOpportunities DismissalDetailsReason = "inaccurate optimization opportunities"
-	NotEnoughInformation                DismissalDetailsReason = "not enough information"
-	NotRelevant                         DismissalDetailsReason = "not relevant"
-	NotWorthTheEffort                   DismissalDetailsReason = "not worth the effort"
+	DismissalDetailsReasonInaccurateOptimizationOpportunities DismissalDetailsReason = "inaccurate optimization opportunities"
+	DismissalDetailsReasonNotEnoughInformation                DismissalDetailsReason = "not enough information"
+	DismissalDetailsReasonNotRelevant                         DismissalDetailsReason = "not relevant"
+	DismissalDetailsReasonNotWorthTheEffort                   DismissalDetailsReason = "not worth the effort"
 )
 
 // Valid indicates whether the value is a known member of the DismissalDetailsReason enum.
 func (e DismissalDetailsReason) Valid() bool {
 	switch e {
-	case InaccurateOptimizationOpportunities:
+	case DismissalDetailsReasonInaccurateOptimizationOpportunities:
 		return true
-	case NotEnoughInformation:
+	case DismissalDetailsReasonNotEnoughInformation:
 		return true
-	case NotRelevant:
+	case DismissalDetailsReasonNotRelevant:
 		return true
-	case NotWorthTheEffort:
+	case DismissalDetailsReasonNotWorthTheEffort:
 		return true
 	default:
 		return false
@@ -1569,28 +1569,28 @@ func (e DisplayStatus) Valid() bool {
 
 // Defines values for ExternalConfigAggregation.
 const (
-	Count          ExternalConfigAggregation = "count"
-	PercentCol     ExternalConfigAggregation = "percent_col"
-	PercentRow     ExternalConfigAggregation = "percent_row"
-	PercentTotal   ExternalConfigAggregation = "percent_total"
-	Total          ExternalConfigAggregation = "total"
-	TotalOverTotal ExternalConfigAggregation = "total_over_total"
+	ExternalConfigAggregationCount          ExternalConfigAggregation = "count"
+	ExternalConfigAggregationPercentCol     ExternalConfigAggregation = "percent_col"
+	ExternalConfigAggregationPercentRow     ExternalConfigAggregation = "percent_row"
+	ExternalConfigAggregationPercentTotal   ExternalConfigAggregation = "percent_total"
+	ExternalConfigAggregationTotal          ExternalConfigAggregation = "total"
+	ExternalConfigAggregationTotalOverTotal ExternalConfigAggregation = "total_over_total"
 )
 
 // Valid indicates whether the value is a known member of the ExternalConfigAggregation enum.
 func (e ExternalConfigAggregation) Valid() bool {
 	switch e {
-	case Count:
+	case ExternalConfigAggregationCount:
 		return true
-	case PercentCol:
+	case ExternalConfigAggregationPercentCol:
 		return true
-	case PercentRow:
+	case ExternalConfigAggregationPercentRow:
 		return true
-	case PercentTotal:
+	case ExternalConfigAggregationPercentTotal:
 		return true
-	case Total:
+	case ExternalConfigAggregationTotal:
 		return true
-	case TotalOverTotal:
+	case ExternalConfigAggregationTotalOverTotal:
 		return true
 	default:
 		return false
@@ -1803,16 +1803,16 @@ func (e ExternalConfigFilterMode) Valid() bool {
 
 // Defines values for ExternalConfigMetricFilterOperand.
 const (
-	SeriesTotal ExternalConfigMetricFilterOperand = "series_total"
-	SingleValue ExternalConfigMetricFilterOperand = "single_value"
+	ExternalConfigMetricFilterOperandSeriesTotal ExternalConfigMetricFilterOperand = "series_total"
+	ExternalConfigMetricFilterOperandSingleValue ExternalConfigMetricFilterOperand = "single_value"
 )
 
 // Valid indicates whether the value is a known member of the ExternalConfigMetricFilterOperand enum.
 func (e ExternalConfigMetricFilterOperand) Valid() bool {
 	switch e {
-	case SeriesTotal:
+	case ExternalConfigMetricFilterOperandSeriesTotal:
 		return true
-	case SingleValue:
+	case ExternalConfigMetricFilterOperandSingleValue:
 		return true
 	default:
 		return false
@@ -1932,16 +1932,16 @@ func (e ExternalDisplaySettingsNumberScale) Valid() bool {
 
 // Defines values for ExternalForecastSettingsMode.
 const (
-	Grouping ExternalForecastSettingsMode = "grouping"
-	Totals   ExternalForecastSettingsMode = "totals"
+	ExternalForecastSettingsModeGrouping ExternalForecastSettingsMode = "grouping"
+	ExternalForecastSettingsModeTotals   ExternalForecastSettingsMode = "totals"
 )
 
 // Valid indicates whether the value is a known member of the ExternalForecastSettingsMode enum.
 func (e ExternalForecastSettingsMode) Valid() bool {
 	switch e {
-	case Grouping:
+	case ExternalForecastSettingsModeGrouping:
 		return true
-	case Totals:
+	case ExternalForecastSettingsModeTotals:
 		return true
 	default:
 		return false
@@ -1950,16 +1950,16 @@ func (e ExternalForecastSettingsMode) Valid() bool {
 
 // Defines values for ExternalLimitByChangeChangeType.
 const (
-	Absolute   ExternalLimitByChangeChangeType = "absolute"
-	Percentage ExternalLimitByChangeChangeType = "percentage"
+	ExternalLimitByChangeChangeTypeAbsolute   ExternalLimitByChangeChangeType = "absolute"
+	ExternalLimitByChangeChangeTypePercentage ExternalLimitByChangeChangeType = "percentage"
 )
 
 // Valid indicates whether the value is a known member of the ExternalLimitByChangeChangeType enum.
 func (e ExternalLimitByChangeChangeType) Valid() bool {
 	switch e {
-	case Absolute:
+	case ExternalLimitByChangeChangeTypeAbsolute:
 		return true
-	case Percentage:
+	case ExternalLimitByChangeChangeTypePercentage:
 		return true
 	default:
 		return false
@@ -1968,28 +1968,28 @@ func (e ExternalLimitByChangeChangeType) Valid() bool {
 
 // Defines values for ExternalLimitByChangeOperator.
 const (
-	Between          ExternalLimitByChangeOperator = "between"
-	GreaterThan      ExternalLimitByChangeOperator = ">"
-	GreaterThanEqual ExternalLimitByChangeOperator = ">="
-	LessThan         ExternalLimitByChangeOperator = "<"
-	LessThanEqual    ExternalLimitByChangeOperator = "<="
-	NotBetween       ExternalLimitByChangeOperator = "not_between"
+	ExternalLimitByChangeOperatorBetween          ExternalLimitByChangeOperator = "between"
+	ExternalLimitByChangeOperatorGreaterThan      ExternalLimitByChangeOperator = ">"
+	ExternalLimitByChangeOperatorGreaterThanEqual ExternalLimitByChangeOperator = ">="
+	ExternalLimitByChangeOperatorLessThan         ExternalLimitByChangeOperator = "<"
+	ExternalLimitByChangeOperatorLessThanEqual    ExternalLimitByChangeOperator = "<="
+	ExternalLimitByChangeOperatorNotBetween       ExternalLimitByChangeOperator = "not_between"
 )
 
 // Valid indicates whether the value is a known member of the ExternalLimitByChangeOperator enum.
 func (e ExternalLimitByChangeOperator) Valid() bool {
 	switch e {
-	case Between:
+	case ExternalLimitByChangeOperatorBetween:
 		return true
-	case GreaterThan:
+	case ExternalLimitByChangeOperatorGreaterThan:
 		return true
-	case GreaterThanEqual:
+	case ExternalLimitByChangeOperatorGreaterThanEqual:
 		return true
-	case LessThan:
+	case ExternalLimitByChangeOperatorLessThan:
 		return true
-	case LessThanEqual:
+	case ExternalLimitByChangeOperatorLessThanEqual:
 		return true
-	case NotBetween:
+	case ExternalLimitByChangeOperatorNotBetween:
 		return true
 	default:
 		return false
@@ -2067,58 +2067,58 @@ func (e ExternalOriginType) Valid() bool {
 
 // Defines values for ExternalRenderer.
 const (
-	AreaChart          ExternalRenderer = "area_chart"
-	AreaSplineChart    ExternalRenderer = "area_spline_chart"
-	BarChart           ExternalRenderer = "bar_chart"
-	ColumnChart        ExternalRenderer = "column_chart"
-	CsvExport          ExternalRenderer = "csv_export"
-	LineChart          ExternalRenderer = "line_chart"
-	SheetsExport       ExternalRenderer = "sheets_export"
-	SplineChart        ExternalRenderer = "spline_chart"
-	StackedAreaChart   ExternalRenderer = "stacked_area_chart"
-	StackedBarChart    ExternalRenderer = "stacked_bar_chart"
-	StackedColumnChart ExternalRenderer = "stacked_column_chart"
-	Table              ExternalRenderer = "table"
-	TableColHeatmap    ExternalRenderer = "table_col_heatmap"
-	TableHeatmap       ExternalRenderer = "table_heatmap"
-	TableRowHeatmap    ExternalRenderer = "table_row_heatmap"
-	TreemapChart       ExternalRenderer = "treemap_chart"
+	ExternalRendererAreaChart          ExternalRenderer = "area_chart"
+	ExternalRendererAreaSplineChart    ExternalRenderer = "area_spline_chart"
+	ExternalRendererBarChart           ExternalRenderer = "bar_chart"
+	ExternalRendererColumnChart        ExternalRenderer = "column_chart"
+	ExternalRendererCsvExport          ExternalRenderer = "csv_export"
+	ExternalRendererLineChart          ExternalRenderer = "line_chart"
+	ExternalRendererSheetsExport       ExternalRenderer = "sheets_export"
+	ExternalRendererSplineChart        ExternalRenderer = "spline_chart"
+	ExternalRendererStackedAreaChart   ExternalRenderer = "stacked_area_chart"
+	ExternalRendererStackedBarChart    ExternalRenderer = "stacked_bar_chart"
+	ExternalRendererStackedColumnChart ExternalRenderer = "stacked_column_chart"
+	ExternalRendererTable              ExternalRenderer = "table"
+	ExternalRendererTableColHeatmap    ExternalRenderer = "table_col_heatmap"
+	ExternalRendererTableHeatmap       ExternalRenderer = "table_heatmap"
+	ExternalRendererTableRowHeatmap    ExternalRenderer = "table_row_heatmap"
+	ExternalRendererTreemapChart       ExternalRenderer = "treemap_chart"
 )
 
 // Valid indicates whether the value is a known member of the ExternalRenderer enum.
 func (e ExternalRenderer) Valid() bool {
 	switch e {
-	case AreaChart:
+	case ExternalRendererAreaChart:
 		return true
-	case AreaSplineChart:
+	case ExternalRendererAreaSplineChart:
 		return true
-	case BarChart:
+	case ExternalRendererBarChart:
 		return true
-	case ColumnChart:
+	case ExternalRendererColumnChart:
 		return true
-	case CsvExport:
+	case ExternalRendererCsvExport:
 		return true
-	case LineChart:
+	case ExternalRendererLineChart:
 		return true
-	case SheetsExport:
+	case ExternalRendererSheetsExport:
 		return true
-	case SplineChart:
+	case ExternalRendererSplineChart:
 		return true
-	case StackedAreaChart:
+	case ExternalRendererStackedAreaChart:
 		return true
-	case StackedBarChart:
+	case ExternalRendererStackedBarChart:
 		return true
-	case StackedColumnChart:
+	case ExternalRendererStackedColumnChart:
 		return true
-	case Table:
+	case ExternalRendererTable:
 		return true
-	case TableColHeatmap:
+	case ExternalRendererTableColHeatmap:
 		return true
-	case TableHeatmap:
+	case ExternalRendererTableHeatmap:
 		return true
-	case TableRowHeatmap:
+	case ExternalRendererTableRowHeatmap:
 		return true
-	case TreemapChart:
+	case ExternalRendererTreemapChart:
 		return true
 	default:
 		return false
@@ -2397,19 +2397,19 @@ func (e GetReportResponseResultMlFeatures) Valid() bool {
 
 // Defines values for GroupAllocationRuleAction.
 const (
-	Create GroupAllocationRuleAction = "create"
-	Select GroupAllocationRuleAction = "select"
-	Update GroupAllocationRuleAction = "update"
+	GroupAllocationRuleActionCreate GroupAllocationRuleAction = "create"
+	GroupAllocationRuleActionSelect GroupAllocationRuleAction = "select"
+	GroupAllocationRuleActionUpdate GroupAllocationRuleAction = "update"
 )
 
 // Valid indicates whether the value is a known member of the GroupAllocationRuleAction enum.
 func (e GroupAllocationRuleAction) Valid() bool {
 	switch e {
-	case Create:
+	case GroupAllocationRuleActionCreate:
 		return true
-	case Select:
+	case GroupAllocationRuleActionSelect:
 		return true
-	case Update:
+	case GroupAllocationRuleActionUpdate:
 		return true
 	default:
 		return false
@@ -2661,19 +2661,19 @@ func (e MetricFilterText) Valid() bool {
 
 // Defines values for NotificationEventChannel.
 const (
-	Email   NotificationEventChannel = "email"
-	Msteams NotificationEventChannel = "msteams"
-	Slack   NotificationEventChannel = "slack"
+	NotificationEventChannelEmail   NotificationEventChannel = "email"
+	NotificationEventChannelMsteams NotificationEventChannel = "msteams"
+	NotificationEventChannelSlack   NotificationEventChannel = "slack"
 )
 
 // Valid indicates whether the value is a known member of the NotificationEventChannel enum.
 func (e NotificationEventChannel) Valid() bool {
 	switch e {
-	case Email:
+	case NotificationEventChannelEmail:
 		return true
-	case Msteams:
+	case NotificationEventChannelMsteams:
 		return true
-	case Slack:
+	case NotificationEventChannelSlack:
 		return true
 	default:
 		return false
@@ -2833,6 +2833,81 @@ func (e RunReportResultResultMlFeatures) Valid() bool {
 	}
 }
 
+// Defines values for SchemaFieldAggregation.
+const (
+	SchemaFieldAggregationCount          SchemaFieldAggregation = "count"
+	SchemaFieldAggregationPercentCol     SchemaFieldAggregation = "percent_col"
+	SchemaFieldAggregationPercentRow     SchemaFieldAggregation = "percent_row"
+	SchemaFieldAggregationPercentTotal   SchemaFieldAggregation = "percent_total"
+	SchemaFieldAggregationTotal          SchemaFieldAggregation = "total"
+	SchemaFieldAggregationTotalOverTotal SchemaFieldAggregation = "total_over_total"
+)
+
+// Valid indicates whether the value is a known member of the SchemaFieldAggregation enum.
+func (e SchemaFieldAggregation) Valid() bool {
+	switch e {
+	case SchemaFieldAggregationCount:
+		return true
+	case SchemaFieldAggregationPercentCol:
+		return true
+	case SchemaFieldAggregationPercentRow:
+		return true
+	case SchemaFieldAggregationPercentTotal:
+		return true
+	case SchemaFieldAggregationTotal:
+		return true
+	case SchemaFieldAggregationTotalOverTotal:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SchemaFieldType.
+const (
+	SchemaFieldTypeFloat     SchemaFieldType = "float"
+	SchemaFieldTypeInteger   SchemaFieldType = "integer"
+	SchemaFieldTypeString    SchemaFieldType = "string"
+	SchemaFieldTypeTimestamp SchemaFieldType = "timestamp"
+)
+
+// Valid indicates whether the value is a known member of the SchemaFieldType enum.
+func (e SchemaFieldType) Valid() bool {
+	switch e {
+	case SchemaFieldTypeFloat:
+		return true
+	case SchemaFieldTypeInteger:
+		return true
+	case SchemaFieldTypeString:
+		return true
+	case SchemaFieldTypeTimestamp:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SchemaFieldUnit.
+const (
+	SchemaFieldUnitCurrency SchemaFieldUnit = "currency"
+	SchemaFieldUnitNumber   SchemaFieldUnit = "number"
+	SchemaFieldUnitPercent  SchemaFieldUnit = "percent"
+)
+
+// Valid indicates whether the value is a known member of the SchemaFieldUnit enum.
+func (e SchemaFieldUnit) Valid() bool {
+	switch e {
+	case SchemaFieldUnitCurrency:
+		return true
+	case SchemaFieldUnitNumber:
+		return true
+	case SchemaFieldUnitPercent:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ServiceQuotaCloudProvider.
 const (
 	ServiceQuotaCloudProviderAws ServiceQuotaCloudProvider = "aws"
@@ -2853,19 +2928,19 @@ func (e ServiceQuotaCloudProvider) Valid() bool {
 
 // Defines values for ServiceQuotaStatus.
 const (
-	Exceeded ServiceQuotaStatus = "exceeded"
-	Ok       ServiceQuotaStatus = "ok"
-	Warning  ServiceQuotaStatus = "warning"
+	ServiceQuotaStatusExceeded ServiceQuotaStatus = "exceeded"
+	ServiceQuotaStatusOk       ServiceQuotaStatus = "ok"
+	ServiceQuotaStatusWarning  ServiceQuotaStatus = "warning"
 )
 
 // Valid indicates whether the value is a known member of the ServiceQuotaStatus enum.
 func (e ServiceQuotaStatus) Valid() bool {
 	switch e {
-	case Exceeded:
+	case ServiceQuotaStatusExceeded:
 		return true
-	case Ok:
+	case ServiceQuotaStatusOk:
 		return true
-	case Warning:
+	case ServiceQuotaStatusWarning:
 		return true
 	default:
 		return false
@@ -3630,19 +3705,19 @@ func (e ListLabelsParamsSortOrder) Valid() bool {
 
 // Defines values for ListAnomaliesParamsSortBy.
 const (
-	CostOfAnomaly ListAnomaliesParamsSortBy = "costOfAnomaly"
-	SeverityLevel ListAnomaliesParamsSortBy = "severityLevel"
-	StartTime     ListAnomaliesParamsSortBy = "startTime"
+	ListAnomaliesParamsSortByCostOfAnomaly ListAnomaliesParamsSortBy = "costOfAnomaly"
+	ListAnomaliesParamsSortBySeverityLevel ListAnomaliesParamsSortBy = "severityLevel"
+	ListAnomaliesParamsSortByStartTime     ListAnomaliesParamsSortBy = "startTime"
 )
 
 // Valid indicates whether the value is a known member of the ListAnomaliesParamsSortBy enum.
 func (e ListAnomaliesParamsSortBy) Valid() bool {
 	switch e {
-	case CostOfAnomaly:
+	case ListAnomaliesParamsSortByCostOfAnomaly:
 		return true
-	case SeverityLevel:
+	case ListAnomaliesParamsSortBySeverityLevel:
 		return true
-	case StartTime:
+	case ListAnomaliesParamsSortByStartTime:
 		return true
 	default:
 		return false
@@ -7357,6 +7432,8 @@ type GetKnownIssue200ResponsePlatform string
 type GetKnownIssue200ResponseStatus string
 
 // GetReportResponse Results returned when running a report; includes schema and rows.
+//
+// Example: {"createTime":1704067200000,"id":"rpt_dummy001abc","labels":[],"owner":"customer@example.com","reportName":"Monthly Cost by Service","result":{"cacheHit":true,"rows":[["Amazon Elastic Compute Cloud",4821.37,12450],["Cloud Storage",912.05,893021],["BigQuery",356.88,42]],"schema":[{"name":"service_description","type":"string"},{"aggregation":"total","currency":"USD","name":"cost","type":"float","unit":"currency"},{"aggregation":"total","name":"usage","type":"float","unit":"number"}]},"type":"custom","updateTime":1706745600000,"urlUI":"https://console.doit.com/customers/cust_dummy123/analyze/reports/rpt_dummy001abc"}
 type GetReportResponse struct {
 	// CreateTime The creation time of the report, in milliseconds since the epoch.
 	CreateTime *int64 `json:"createTime,omitempty"`
@@ -8392,6 +8469,8 @@ type Role struct {
 }
 
 // RunReportResult Results returned when running a report; includes schema and rows.
+//
+// Example: {"result":{"cacheHit":false,"rows":[["Amazon Elastic Compute Cloud",4821.37],["Cloud Storage",912.05],["BigQuery",356.88]],"schema":[{"name":"service_description","type":"string"},{"aggregation":"total","currency":"USD","name":"cost","type":"float","unit":"currency"}]}}
 type RunReportResult struct {
 	Result *RunReportResultResult `json:"result,omitempty"`
 }
@@ -8414,11 +8493,35 @@ type RunReportResultResultMlFeatures string
 
 // SchemaField Schema of a report result column.
 type SchemaField struct {
+	// Aggregation Authoritative aggregation applied to this metric column.
+	Aggregation *SchemaFieldAggregation `json:"aggregation,omitempty"`
+
+	// Currency Effective ISO 4217 currency code when unit is currency.
+	//
+	// Example: USD
+	Currency *string `json:"currency,omitempty"`
+
 	// Id Stable allocation-group ID used to select the allocation dimension in report configurations. Omitted for other report columns.
-	Id   *string `json:"id,omitempty"`
+	Id *string `json:"id,omitempty"`
+
+	// Name Column name. Matches the corresponding value position in each row.
 	Name *string `json:"name,omitempty"`
-	Type *string `json:"type,omitempty"`
+
+	// Type Wire-format type of the column values. Dimension columns use string; metric columns use float (cost, usage, saving, custom, and extended metrics) or integer (count aggregation). Time-series reports include a timestamp column.
+	Type *SchemaFieldType `json:"type,omitempty"`
+
+	// Unit Semantic unit of the column values.
+	Unit *SchemaFieldUnit `json:"unit,omitempty"`
 }
+
+// SchemaFieldAggregation Authoritative aggregation applied to this metric column.
+type SchemaFieldAggregation string
+
+// SchemaFieldType Wire-format type of the column values. Dimension columns use string; metric columns use float (cost, usage, saving, custom, and extended metrics) or integer (count aggregation). Time-series reports include a timestamp column.
+type SchemaFieldType string
+
+// SchemaFieldUnit Semantic unit of the column values.
+type SchemaFieldUnit string
 
 // Seats Licensing seat counts for a subscription.
 type Seats struct {

--- a/internal/provider/report.go
+++ b/internal/provider/report.go
@@ -1801,7 +1801,7 @@ func mapReportToModel(ctx context.Context, resp *models.ExternalReport, state *r
 			fs.HistoricalTimeIntervals != nil ||
 			fs.FutureCustomDateRange != nil ||
 			fs.HistoricalCustomDateRange != nil ||
-			(fs.Mode != nil && *fs.Mode == models.Grouping)) {
+			(fs.Mode != nil && *fs.Mode == models.ExternalForecastSettingsModeGrouping)) {
 		fsMap := map[string]attr.Value{
 			"future_custom_date_range":     resource_report.NewFutureCustomDateRangeValueNull(),
 			"future_time_intervals":        types.Int64Null(),

--- a/internal/provider/report_query_data_source.go
+++ b/internal/provider/report_query_data_source.go
@@ -91,8 +91,8 @@ func (d *reportQueryDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 			"\n\nNote: Query results are dynamic — they change over time as new billing" +
 			" data is ingested. Every terraform plan will re-execute the query." +
 			"\n\nThe result_json field contains the full result object, including the" +
-			" schema (column definitions: name, type, and optional id), rows (data)," +
-			" forecastRows (forecast data), secondaryRows (secondary time range data)," +
+			" schema (column definitions: name, type, and optional unit, currency, aggregation, and id)," +
+			" rows (data), forecastRows (forecast data), secondaryRows (secondary time range data)," +
 			" and cacheHit (whether results were served from cache).",
 		MarkdownDescription: "Runs an ad-hoc Cloud Analytics query without persisting a report." +
 			"\n\nThe query is executed with the provided config and results are returned" +
@@ -100,7 +100,7 @@ func (d *reportQueryDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 			"\n\n~> **Note:** Query results are dynamic — they change over time as new" +
 			" billing data is ingested. Every `terraform plan` will re-execute the query." +
 			"\n\nThe `result_json` field contains the full result object including:" +
-			"\n- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)" +
+			"\n- `schema`: Array of column metadata objects (`name`, `type`, and optional `unit`, `currency`, `aggregation`, and `id` for allocation dimensions)" +
 			"\n- `rows`: Array of data rows, where each row is an array of cell values (`string`, `number`, or `null`)" +
 			"\n- `forecastRows`: Array of forecast data rows (if applicable)" +
 			"\n- `secondaryRows`: Array of secondary time range rows (if applicable)" +
@@ -118,11 +118,11 @@ func (d *reportQueryDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 			// --- Outputs ---
 			"result_json": dsschema.StringAttribute{
 				Description: "The full query result as a JSON string. " +
-					"Contains schema (column definitions including name, type, and optional id), rows (data), and metadata. " +
+					"Contains schema (column definitions including name, type, and optional unit, currency, aggregation, and id), rows (data), and metadata. " +
 					"Use jsondecode() to parse.",
 				MarkdownDescription: "The full query result as a JSON string. Use `jsondecode()` to parse." +
 					"\n\nStructure of the decoded JSON object:" +
-					"\n- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions)." +
+					"\n- `schema`: Array of column definitions: `name` (string), `type` (string: `string`, `float`, `integer`, `timestamp`), and optional fields `unit` (`currency`, `number`, `percent`), `currency` (ISO 4217 code), `aggregation` (`total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`), and `id` (present for allocation dimensions)." +
 					"\n- `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns." +
 					"\n- `forecastRows`: Array of forecast row arrays (if applicable)." +
 					"\n- `secondaryRows`: Array of secondary time range row arrays (if applicable)." +

--- a/internal/provider/report_query_data_source_test.go
+++ b/internal/provider/report_query_data_source_test.go
@@ -825,3 +825,81 @@ output "schema_id_matches_allocation" {
 }
 `, name)
 }
+
+// TestAccReportQueryDataSource_SchemaFieldMetadata verifies that executing a query
+// returns column metadata (name, type, unit, currency, aggregation) in result_json.schema.
+func TestAccReportQueryDataSource_SchemaFieldMetadata(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportQueryDataSourceSchemaFieldMetadataConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("cost_field_name", "cost"),
+					resource.TestCheckOutput("cost_field_type", "float"),
+					resource.TestCheckOutput("cost_field_unit", "currency"),
+					resource.TestCheckOutput("cost_field_currency", "USD"),
+					resource.TestCheckOutput("cost_field_aggregation", "total"),
+				),
+			},
+		},
+	})
+}
+
+func testAccReportQueryDataSourceSchemaFieldMetadataConfig() string {
+	return `
+data "doit_report_query" "test" {
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode            = "last"
+          amount          = 1
+          unit            = "month"
+          include_current = false
+        }
+    }
+}
+
+locals {
+  query_result = jsondecode(data.doit_report_query.test.result_json)
+  cost_fields = [
+    for field in local.query_result.schema : field
+    if lookup(field, "name", "") == "cost"
+  ]
+  cost_field = length(local.cost_fields) > 0 ? local.cost_fields[0] : {}
+}
+
+output "cost_field_name" {
+  value = lookup(local.cost_field, "name", "")
+}
+
+output "cost_field_type" {
+  value = lookup(local.cost_field, "type", "")
+}
+
+output "cost_field_unit" {
+  value = lookup(local.cost_field, "unit", "")
+}
+
+output "cost_field_currency" {
+  value = lookup(local.cost_field, "currency", "")
+}
+
+output "cost_field_aggregation" {
+  value = lookup(local.cost_field, "aggregation", "")
+}
+`
+}

--- a/internal/provider/report_result_data_source.go
+++ b/internal/provider/report_result_data_source.go
@@ -70,8 +70,8 @@ func (d *reportResultDataSource) Schema(ctx context.Context, _ datasource.Schema
 			" billing data is ingested. Every terraform plan will re-execute the" +
 			" report." +
 			"\n\nThe result_json field contains the full result object, including the" +
-			" schema (column definitions: name, type, and optional id), rows (data)," +
-			" forecastRows (forecast data), secondaryRows (secondary time range data)," +
+			" schema (column definitions: name, type, and optional unit, currency, aggregation, and id)," +
+			" rows (data), forecastRows (forecast data), secondaryRows (secondary time range data)," +
 			" and cacheHit (whether results were served from cache).",
 		MarkdownDescription: "Fetches the results of an existing Cloud Analytics report." +
 			"\n\nThe report is executed and the results are returned as a JSON string in" +
@@ -80,7 +80,7 @@ func (d *reportResultDataSource) Schema(ctx context.Context, _ datasource.Schema
 			" billing data is ingested. Every `terraform plan` will re-execute the" +
 			" report." +
 			"\n\nThe `result_json` field contains the full result object including:" +
-			"\n- `schema`: Array of column metadata objects (`name`, `type`, and optional `id` for allocation dimensions)" +
+			"\n- `schema`: Array of column metadata objects (`name`, `type`, and optional `unit`, `currency`, `aggregation`, and `id` for allocation dimensions)" +
 			"\n- `rows`: Data rows (each row is an array of cell values: string, number, or null)" +
 			"\n- `forecastRows`: Forecast data rows (if applicable)" +
 			"\n- `secondaryRows`: Secondary time range rows (if applicable)" +
@@ -135,11 +135,11 @@ func (d *reportResultDataSource) Schema(ctx context.Context, _ datasource.Schema
 			// --- Outputs ---
 			"result_json": schema.StringAttribute{
 				Description: "The full report result as a JSON string. " +
-					"Contains schema (column definitions including name, type, and optional id), rows (data), and metadata. " +
+					"Contains schema (column definitions including name, type, and optional unit, currency, aggregation, and id), rows (data), and metadata. " +
 					"Use jsondecode() to parse.",
 				MarkdownDescription: "The full report result as a JSON string. Use `jsondecode()` to parse." +
 					"\n\nStructure of the decoded JSON object:" +
-					"\n- `schema`: Array of column definitions: `name` (string), `type` (string), and `id` (optional string, present for allocation dimensions)." +
+					"\n- `schema`: Array of column definitions: `name` (string), `type` (string: `string`, `float`, `integer`, `timestamp`), and optional fields `unit` (`currency`, `number`, `percent`), `currency` (ISO 4217 code), `aggregation` (`total`, `percent_total`, `percent_col`, `percent_row`, `total_over_total`, `count`), and `id` (present for allocation dimensions)." +
 					"\n- `rows`: Array of row arrays `[][string | number | null]` corresponding to the schema columns." +
 					"\n- `forecastRows`: Array of forecast row arrays (if applicable)." +
 					"\n- `secondaryRows`: Array of secondary time range row arrays (if applicable)." +

--- a/internal/provider/report_result_data_source_test.go
+++ b/internal/provider/report_result_data_source_test.go
@@ -360,3 +360,89 @@ output "schema_id_matches_allocation" {
 }
 `, name)
 }
+
+// TestAccReportResultDataSource_SchemaFieldMetadata verifies that reading a report's
+// results returns column metadata (name, type, unit, currency, aggregation) in result_json.schema.
+func TestAccReportResultDataSource_SchemaFieldMetadata(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tfacc-rr-meta")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProvidersProtoV6Factories,
+		PreCheck:                 testAccPreCheckFunc(t),
+		TerraformVersionChecks:   testAccTFVersionChecks,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReportResultDataSourceSchemaFieldMetadataConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("cost_field_name", "cost"),
+					resource.TestCheckOutput("cost_field_type", "float"),
+					resource.TestCheckOutput("cost_field_unit", "currency"),
+					resource.TestCheckOutput("cost_field_currency", "USD"),
+					resource.TestCheckOutput("cost_field_aggregation", "total"),
+				),
+			},
+		},
+	})
+}
+
+func testAccReportResultDataSourceSchemaFieldMetadataConfig(name string) string {
+	return fmt.Sprintf(`
+resource "doit_report" "test" {
+    name        = "%[1]s-report"
+    description = "test report schema field metadata"
+    config = {
+        metrics = [
+          {
+            type  = "basic"
+            value = "cost"
+          }
+        ]
+        aggregation    = "total"
+        time_interval  = "month"
+        data_source    = "billing"
+        display_values = "actuals_only"
+        currency       = "USD"
+        layout         = "table"
+        time_range = {
+          mode            = "last"
+          amount          = 1
+          unit            = "month"
+          include_current = false
+        }
+    }
+}
+
+data "doit_report_result" "test" {
+    id = doit_report.test.id
+}
+
+locals {
+  result_payload = jsondecode(data.doit_report_result.test.result_json)
+  cost_fields = [
+    for field in local.result_payload.schema : field
+    if lookup(field, "name", "") == "cost"
+  ]
+  cost_field = length(local.cost_fields) > 0 ? local.cost_fields[0] : {}
+}
+
+output "cost_field_name" {
+  value = lookup(local.cost_field, "name", "")
+}
+
+output "cost_field_type" {
+  value = lookup(local.cost_field, "type", "")
+}
+
+output "cost_field_unit" {
+  value = lookup(local.cost_field, "unit", "")
+}
+
+output "cost_field_currency" {
+  value = lookup(local.cost_field, "currency", "")
+}
+
+output "cost_field_aggregation" {
+  value = lookup(local.cost_field, "aggregation", "")
+}
+`, name)
+}


### PR DESCRIPTION
## Summary

Upstream Cloud Analytics API updated `SchemaField` in report results and ad-hoc query responses to include `unit`, `currency`, and `aggregation` metadata, as well as an explicit enum for column `type` (`string`, `float`, `integer`, `timestamp`).

This PR:
- Enables `always-prefix-enum-values: true` in `internal/provider/models/models.yml` to prevent Go identifier collisions between the newly introduced `unit: currency` enum constant and `type Currency string`.
- Regenerates OpenAPI models and updates existing call sites in `internal/provider/allocation.go` and `internal/provider/report.go` to use the prefixed enum constants.
- Documents the new `SchemaField` metadata fields (`unit`, `currency`, `aggregation`, and explicit `type` values) in schema descriptions and examples for `doit_report_result` and `doit_report_query`.
- Regenerates documentation via `make docs`.
- Adds acceptance tests verifying `SchemaField` column metadata deserialization from `result_json`.

## Changes
- `OpenAPI/openapi_spec_full.yml`, `OpenAPI/openapi_spec_processed.yml`: Updated OpenAPI spec with `unit`, `currency`, `aggregation`, and `type` enum on `SchemaField`.
- `internal/provider/models/models.yml`: Added `compatibility.always-prefix-enum-values: true`.
- `internal/provider/models/models_gen.go`: Regenerated models with prefixed enum constants.
- `internal/provider/allocation.go`, `internal/provider/report.go`: Updated enum references to prefixed versions.
- `internal/provider/report_result_data_source.go`, `internal/provider/report_query_data_source.go`: Updated schema descriptions and docstrings for `result_json`.
- `examples/data-sources/doit_report_result/data-source.tf`, `examples/data-sources/doit_report_query/data-source.tf`: Updated examples documenting metadata schema fields.
- `docs/data-sources/report_result.md`, `docs/data-sources/report_query.md`: Regenerated documentation.
- `internal/provider/report_result_data_source_test.go`, `internal/provider/report_query_data_source_test.go`: Added acceptance tests asserting `name`, `type`, `unit`, `currency`, and `aggregation` in `result_json.schema`.

## Validation
- `make default`: Clean (fmt, custom linter, golangci-lint, go build)
- `make test`: All unit tests passing
- `make testacc-run TEST=TestAccReportResultDataSource_SchemaFieldMetadata`: PASS
- `make testacc-run TEST=TestAccReportQueryDataSource_SchemaFieldMetadata`: PASS