### PR TITLE
ci: add path filtering for acceptance tests and integrate tooling tests

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -52,6 +52,7 @@ go mod tidy
 ```
 
 Verify the build compiles successfully:
+
 ```bash
 go build ./...
 ```
@@ -60,14 +61,14 @@ go build ./...
 
 For each **direct** dependency in `go.mod` (the first `require` block), check the release notes for breaking changes:
 
-| Dependency | Check for |
-|---|---|
-| `hashicorp/terraform-plugin-framework` | [Changelog](https://github.com/hashicorp/terraform-plugin-framework/blob/main/CHANGELOG.md) — breaking API changes, deprecations |
-| `hashicorp/terraform-plugin-testing` | [Changelog](https://github.com/hashicorp/terraform-plugin-testing/blob/main/CHANGELOG.md) — new test helper patterns |
-| `hashicorp/terraform-plugin-go` | [Changelog](https://github.com/hashicorp/terraform-plugin-go/blob/main/CHANGELOG.md) — protocol changes |
-| `hashicorp/terraform-plugin-framework-validators` | [Changelog](https://github.com/hashicorp/terraform-plugin-framework-validators/blob/main/CHANGELOG.md) — new validators |
-| `oapi-codegen/runtime` | [Releases](https://github.com/oapi-codegen/runtime/releases) — request/response handling changes |
-| `cenkalti/backoff/v5` | [Releases](https://github.com/cenkalti/backoff/releases) — retry behaviour changes |
+| Dependency                                        | Check for                                                                                                                        |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `hashicorp/terraform-plugin-framework`            | [Changelog](https://github.com/hashicorp/terraform-plugin-framework/blob/main/CHANGELOG.md) — breaking API changes, deprecations |
+| `hashicorp/terraform-plugin-testing`              | [Changelog](https://github.com/hashicorp/terraform-plugin-testing/blob/main/CHANGELOG.md) — new test helper patterns             |
+| `hashicorp/terraform-plugin-go`                   | [Changelog](https://github.com/hashicorp/terraform-plugin-go/blob/main/CHANGELOG.md) — protocol changes                          |
+| `hashicorp/terraform-plugin-framework-validators` | [Changelog](https://github.com/hashicorp/terraform-plugin-framework-validators/blob/main/CHANGELOG.md) — new validators          |
+| `oapi-codegen/runtime`                            | [Releases](https://github.com/oapi-codegen/runtime/releases) — request/response handling changes                                 |
+| `cenkalti/backoff/v5`                             | [Releases](https://github.com/cenkalti/backoff/releases) — retry behaviour changes                                               |
 
 Report any relevant findings to the user before proceeding.
 
@@ -87,6 +88,7 @@ go mod tidy
 ```
 
 Verify code generation still works:
+
 ```bash
 make generate
 make docs
@@ -107,17 +109,19 @@ Check the [latest release](https://github.com/gotestyourself/gotestsum/releases)
 
 Check for newer versions of all GitHub Actions used in `.github/workflows/`:
 
-| Action | Current | Check |
-|---|---|---|
-| `actions/checkout` | Check current pinned hash | [Releases](https://github.com/actions/checkout/releases) |
-| `actions/setup-go` | Check current pinned hash | [Releases](https://github.com/actions/setup-go/releases) |
-| `hashicorp/setup-terraform` | Check current pinned hash | [Releases](https://github.com/hashicorp/setup-terraform/releases) |
-| `goreleaser/goreleaser-action` | Check current pinned hash | [Releases](https://github.com/goreleaser/goreleaser-action/releases) |
+| Action                          | Current                   | Check                                                                 |
+| ------------------------------- | ------------------------- | --------------------------------------------------------------------- |
+| `actions/checkout`              | Check current pinned hash | [Releases](https://github.com/actions/checkout/releases)              |
+| `actions/setup-go`              | Check current pinned hash | [Releases](https://github.com/actions/setup-go/releases)              |
+| `hashicorp/setup-terraform`     | Check current pinned hash | [Releases](https://github.com/hashicorp/setup-terraform/releases)     |
+| `goreleaser/goreleaser-action`  | Check current pinned hash | [Releases](https://github.com/goreleaser/goreleaser-action/releases)  |
 | `crazy-max/ghaction-import-gpg` | Check current pinned hash | [Releases](https://github.com/crazy-max/ghaction-import-gpg/releases) |
 | `golangci/golangci-lint-action` | Check current pinned hash | [Releases](https://github.com/golangci/golangci-lint-action/releases) |
-| `mikepenz/action-junit-report` | Check current pinned hash | [Releases](https://github.com/mikepenz/action-junit-report/releases) |
+| `mikepenz/action-junit-report`  | Check current pinned hash | [Releases](https://github.com/mikepenz/action-junit-report/releases)  |
+| `dorny/paths-filter`            | Check current pinned hash | [Releases](https://github.com/dorny/paths-filter/releases)            |
 
 ### Update procedure for each action:
+
 1. Find the latest release tag (e.g., `v6.1.0`).
 2. Get the full commit SHA for that tag:
    ```bash
@@ -140,12 +144,13 @@ Check for newer versions of all GitHub Actions used in `.github/workflows/`:
 
 Check for newer versions of pre-commit hook repos in `.pre-commit-config.yaml`:
 
-| Hook repo | Check |
-|---|---|
-| `golangci/golangci-lint` | [Releases](https://github.com/golangci/golangci-lint/releases) — update `rev:` |
+| Hook repo                     | Check                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| `golangci/golangci-lint`      | [Releases](https://github.com/golangci/golangci-lint/releases) — update `rev:`      |
 | `pre-commit/pre-commit-hooks` | [Releases](https://github.com/pre-commit/pre-commit-hooks/releases) — update `rev:` |
 
 **Important:** If `golangci-lint` is updated, also update:
+
 - `.pre-commit-config.yaml` — the `rev:` field
 - `.github/workflows/golangci-lint.yml` — the `version:` field in the golangci-lint-action step
 - `flake.nix` — the comment referencing the version (and nixpkgs pin if needed)
@@ -159,6 +164,7 @@ Compare the local `.goreleaser.yml` against the upstream HashiCorp scaffolding f
 **Reference:** https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml
 
 Fetch the latest reference and diff:
+
 ```bash
 curl -sL https://raw.githubusercontent.com/hashicorp/terraform-provider-scaffolding-framework/main/.goreleaser.yml > /tmp/goreleaser-upstream.yml
 diff .goreleaser.yml /tmp/goreleaser-upstream.yml
@@ -171,20 +177,25 @@ If there are meaningful differences (not just whitespace), update `.goreleaser.y
 ## Step 7: Verify Documentation is Up to Date
 
 ### README.md
+
 Check and update:
+
 - [ ] Go version requirement matches `go.mod`
 - [ ] Nix flake tool versions match `flake.nix` (Go, Terraform, golangci-lint versions)
 - [ ] The `# Requirements` section matches current tool versions
 - [ ] The environment variables tables match `.envrc.example`
 
 ### .envrc.example
+
 Check and update:
+
 - [ ] All required env vars from `README.md` are present
 - [ ] All optional env vars from `README.md` are present
 - [ ] Any new env vars added since the last release are included
 - [ ] Compare against the actual `.envrc.local` (but do NOT commit `.envrc.local`)
 
 ### Cross-check environment variables
+
 - [ ] The environment variables in `.envrc.example` match what `README.md` documents
 
 ### DCI API Status Document
@@ -192,6 +203,7 @@ Check and update:
 Update `.test/Current Status of DCI API.md`:
 
 1. **Check open Jira tickets:** For each ticket listed in the "Open API Issues" section that is NOT in the "Resolved Issues" table, fetch the current status from Jira using the Atlassian MCP:
+
    ```
    getJiraIssue(cloudId: "doitintl.atlassian.net", issueIdOrKey: "CMP-XXXXX", fields: ["summary", "status"])
    ```
@@ -234,27 +246,34 @@ Write a new changelog entry at the top of `CHANGELOG.md` following the existing 
 ## v<VERSION> (<YYYY-MM-DD>)
 
 ### BREAKING CHANGES
+
 (only if applicable)
 
 ### FEATURES
+
 - **resource/doit_xxx**: Description ([#PR](url))
 
 ### ENHANCEMENTS
+
 - Description ([#PR](url))
 
 ### BUG FIXES
+
 - Description ([#PR](url))
 
 ### DOCUMENTATION
+
 - Description
 
 ### INTERNAL
+
 - Upgraded Go to X.XX
 - Upgraded dependencies: list key upgrades
 - Upgraded CI workflow actions (list versions)
 ```
 
 **Categories to use** (omit empty ones):
+
 - `BREAKING CHANGES` — only for user-facing breaking changes
 - `FEATURES` — new resources or data sources
 - `ENHANCEMENTS` — additions to existing resources
@@ -289,6 +308,7 @@ make test
 
 If acceptance tests are desired (this makes real API calls against the live
 tenant — see the `testing` skill for interpreting flaky reruns and output):
+
 ```bash
 make testacc
 ```
@@ -314,6 +334,7 @@ chore: prepare release v<VERSION>
 ```
 
 Create a PR. After merge, tag the release:
+
 ```bash
 git tag v<VERSION>
 git push origin v<VERSION>

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,10 +8,35 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    outputs:
+      lint: ${{ steps.filter.outputs.lint }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            lint:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'tools/**'
+              - '.golangci.yml'
+              - '.custom-gcl.yml'
+              - 'GNUmakefile'
+              - '.github/workflows/golangci-lint.yml'
+
   golangci:
     name: lint
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: changes
+    if: |
+      github.event.pull_request.draft == false &&
+      needs.changes.outputs.lint == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -27,6 +52,20 @@ jobs:
         with:
           version: v2.12.2
           install-only: true
+
+      # Lint the linter source code itself with stock golangci-lint.
+      - name: Lint custom linters
+        run: make lint-tools
+
+      # Run unit tests for custom analyzers.
+      - name: Test custom linters
+        run: |
+          cd tools/linters
+          go test -v ./...
+
+      # Run unit tests for schema extraction tools.
+      - name: Test schema tools
+        run: go test -v ./tools/extract-inline-schemas/...
 
       # Build custom binary and run linting (same as local `make lint`)
       - name: golangci-lint (custom)

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changes:
@@ -16,7 +17,7 @@ jobs:
       lint: ${{ steps.filter.outputs.lint }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changes:
@@ -24,7 +25,7 @@ jobs:
       examples: ${{ steps.filter.outputs.examples }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           filters: |
             code:
-              - '**/*.go'
-              - '!tools/linters/**'
+              - 'internal/**'
+              - 'main.go'
               - 'go.mod'
               - 'go.sum'
               - 'GNUmakefile'
@@ -80,6 +80,7 @@ jobs:
       (github.event_name == 'schedule' ||
        github.event_name == 'push' ||
        needs.changes.outputs.docs == 'true' ||
+       needs.changes.outputs.examples == 'true' ||
        needs.changes.outputs.code == 'true')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,22 +10,51 @@ on:
     # Run daily at 5am UTC
     - cron: "0 5 * * *"
 
-# Acceptance tests mutate shared remote resources, so only one run of this
-# workflow may execute at a time. A single fixed group key serializes runs
-# across all branches/PRs. cancel-in-progress: false queues new runs behind
-# the in-progress one instead of cancelling it.
-concurrency:
-  group: acceptance-tests
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+      examples: ${{ steps.filter.outputs.examples }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - '!tools/linters/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'GNUmakefile'
+              - '.github/workflows/tests.yml'
+            docs:
+              - 'docs/**'
+              - 'templates/**'
+              - '**/*.md'
+              - '.github/workflows/tests.yml'
+            examples:
+              - 'examples/**'
+              - 'scripts/validate_examples.sh'
+              - '.github/workflows/tests.yml'
+
   validate-examples:
     name: Validate Examples
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: changes
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'push' ||
+       needs.changes.outputs.examples == 'true' ||
+       needs.changes.outputs.code == 'true')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -44,7 +73,13 @@ jobs:
   validate-docs:
     name: Validate Docs
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: changes
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'push' ||
+       needs.changes.outputs.docs == 'true' ||
+       needs.changes.outputs.code == 'true')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -63,7 +98,17 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: changes
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'push' ||
+       needs.changes.outputs.code == 'true')
+    # Acceptance tests mutate shared remote resources, so only one test run
+    # may execute at a time across all branches and PRs.
+    concurrency:
+      group: acceptance-tests
+      cancel-in-progress: false
     permissions:
       contents: read
       checks: write # allow the JUnit reporter to publish a check run

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,9 +18,9 @@ custom-gcl: .custom-gcl.yml .golangci.yml go.sum tools/linters/go.mod tools/lint
 
 lint-build: custom-gcl
 
-# Lint the linter source code itself with stock golangci-lint.
-lint-tools:
-	cd tools/linters && golangci-lint run
+# Lint the linter source code itself with stock linters via custom-gcl.
+lint-tools: lint-build
+	cd tools/linters && $(CURDIR)/custom-gcl run
 
 # Generate OpenAPI models and Terraform resource schemas
 # Must be run in order: extract-inline-schemas -> openapi -> framework -> models


### PR DESCRIPTION
## Summary

Optimizes CI workflows by adding path filtering so that heavy acceptance tests and validations only run when relevant code changes, moves acceptance-test serialization concurrency to the job level to avoid blocking the queue, and adds automated unit tests for custom linters and tooling.

## Key Changes

- **Path Filtering in Acceptance Tests (`.github/workflows/tests.yml`)**:
  - Adds `dorny/paths-filter` to detect changes across `code`, `docs`, and `examples`.
  - Excludes `OpenAPI/**` (upstream spec syncs) and linter internals from triggering acceptance tests.
  - `validate-docs` and `validate-examples` only run when documentation or examples/code change.
  - Acceptance tests only run on schedule (5am UTC), pushes to `main`, or PRs modifying provider Go code.
- **Job-Level Concurrency (`.github/workflows/tests.yml`)**:
  - Moved `concurrency: group: acceptance-tests` from the workflow level to the `test` job level.
  - Guarantees serialized execution of acceptance tests against shared live cloud resources without blocking non-test PRs in the concurrency queue.
- **Tooling & Linter Tests (`.github/workflows/golangci-lint.yml`)**:
  - Added change detection to skip linting on doc-only PRs.
  - Runs `make lint-tools` to lint custom analyzer source code with stock golangci-lint.
  - Runs `cd tools/linters && go test -v ./...` to execute all 23 custom analyzer unit tests.
  - Runs `go test -v ./tools/extract-inline-schemas/...` to test schema extraction tools.
  - Runs `make lint` to compile `custom-gcl` and lint the provider.
- **Skills Update (`.agents/skills/prepare-release/SKILL.md`)**:
  - Added `dorny/paths-filter` to the GitHub Actions version tracking table in Step 4.

## Verification

- `make lint-tools`: 0 issues
- `cd tools/linters && go test ./...`: All 23 analyzer tests passed
- `go test ./tools/extract-inline-schemas/...`: Passed
- `make lint`: 0 issues
- Pre-commit hooks passed cleanly on all modified files